### PR TITLE
build: create NUMVERSION only for released copies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,34 +33,34 @@ AC_SUBST([libyaksa_so_version])
 #
 # Numeric version will have 1 digit for MAJ, 2 digits for MIN,
 # 2 digits for REV, 1 digit for EXT and 2 digits for EXT_NUMBER.
-changequote(<<,>>)
-V1=`expr $YAKSA_VERSION : '\([0-9]*\)\.[0-9]*\.*[0-9]*[a-zA-Z]*[0-9]*'`
-V2=`expr $YAKSA_VERSION : '[0-9]*\.\([0-9]*\)\.*[0-9]*[a-zA-Z]*[0-9]*'`
-V3=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*\([0-9]*\)[a-zA-Z]*[0-9]*'`
-V4=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*[0-9]*\([a-zA-Z]*\)[0-9]*'`
-V5=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*[0-9]*[a-zA-Z]*\([0-9]*\)'`
-changequote([,])
-
-if test "$V2" -le 9 ; then V2="0$V2" ; fi
-if test "$V3" = "" ; then V3="0"; fi
-if test "$V3" -le 9 ; then V3="0$V3" ; fi
-if test "$V4" = "a" ; then
-    V4=0
-elif test "$V4" = "b" ; then
-    V4=1
-elif test "$V4" = "rc" ; then
-    V4=2
-elif test "$V4" = "" ; then
-    V4=3
-    V5=0
-elif test "$V4" = "p" ; then
-    V4=3
-fi
-if test "$V5" -le 9 ; then V5="0$V5" ; fi
-
 if test "${YAKSA_VERSION}" = "unreleased" ; then
     YAKSA_NUMVERSION=0
 else
+    changequote(<<,>>)
+    V1=`expr $YAKSA_VERSION : '\([0-9]*\)\.[0-9]*\.*[0-9]*[a-zA-Z]*[0-9]*'`
+    V2=`expr $YAKSA_VERSION : '[0-9]*\.\([0-9]*\)\.*[0-9]*[a-zA-Z]*[0-9]*'`
+    V3=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*\([0-9]*\)[a-zA-Z]*[0-9]*'`
+    V4=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*[0-9]*\([a-zA-Z]*\)[0-9]*'`
+    V5=`expr $YAKSA_VERSION : '[0-9]*\.[0-9]*\.*[0-9]*[a-zA-Z]*\([0-9]*\)'`
+    changequote([,])
+
+    if test "$V2" -le 9 ; then V2="0$V2" ; fi
+    if test "$V3" = "" ; then V3="0"; fi
+    if test "$V3" -le 9 ; then V3="0$V3" ; fi
+    if test "$V4" = "a" ; then
+	V4=0
+    elif test "$V4" = "b" ; then
+	V4=1
+    elif test "$V4" = "rc" ; then
+	V4=2
+    elif test "$V4" = "" ; then
+	V4=3
+	V5=0
+    elif test "$V4" = "p" ; then
+	V4=3
+    fi
+    if test "$V5" -le 9 ; then V5="0$V5" ; fi
+
     YAKSA_NUMVERSION=`expr $V1$V2$V3$V4$V5 + 0`
 fi
 AC_SUBST(YAKSA_NUMVERSION)


### PR DESCRIPTION
Signed-off-by: Pavan Balaji <balaji@anl.gov>

## Pull Request Description

In [9bc91a821367], the calculation `YAKSA_NUMVERSION` was protected, so it would only be calculated in a release version.  However, the remaining variables were still being always calculated.  This was throwing warnings in the direct git-based source build.

## Expected Impact

Fixes warnings.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
