### PR TITLE
Cleanup the buffer type checking function in the CUDA backend

### DIFF
--- a/src/backend/cuda/include/yaksuri_cuda.h
+++ b/src/backend/cuda/include/yaksuri_cuda.h
@@ -7,39 +7,11 @@
 #define YAKSURI_CUDA_H_INCLUDED
 
 #include "yaksi.h"
-#include <cuda.h>
-#include <cuda_runtime_api.h>
 
 int yaksuri_cuda_init_hook(void);
 int yaksuri_cuda_finalize_hook(void);
 int yaksuri_cuda_type_create_hook(yaksi_type_s * type);
 int yaksuri_cuda_type_free_hook(yaksi_type_s * type);
-
-static int yaksuri_cuda_is_gpu_memory(const void *buf, int *flag)
-{
-    int rc = YAKSA_SUCCESS;
-
-    struct cudaPointerAttributes attr;
-    cudaError_t cerr = cudaPointerGetAttributes(&attr, buf);
-    if (cerr == cudaSuccess) {
-        if (attr.type == cudaMemoryTypeUnregistered || attr.type == cudaMemoryTypeHost) {
-            *flag = 0;
-        } else {
-            *flag = 1;
-        }
-    } else if (cerr == cudaErrorInvalidValue) {
-        *flag = 0;
-    } else if (cerr != cudaSuccess) {
-        fprintf(stderr, "CUDA Error (%s:%s,%d): %s\n", __func__, __FILE__, __LINE__,
-                cudaGetErrorString(cerr));
-        rc = YAKSA_ERR__INTERNAL;
-        goto fn_fail;
-    }
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
+int yaksuri_cuda_is_gpu_memory(const void *buf, int *flag);
 
 #endif /* YAKSURI_CUDA_H_INCLUDED */

--- a/src/backend/cuda/pup/Makefile.mk
+++ b/src/backend/cuda/pup/Makefile.mk
@@ -6,6 +6,7 @@
 AM_CPPFLAGS += -I$(top_srcdir)/src/backend/cuda/pup
 
 libyaksa_la_SOURCES += \
+	src/backend/cuda/pup/yaksuri_cuda_buftype.c \
 	src/backend/cuda/pup/yaksuri_cudai_pup_char.cu \
 	src/backend/cuda/pup/yaksuri_cudai_pup_double.cu \
 	src/backend/cuda/pup/yaksuri_cudai_pup_float.cu \

--- a/src/backend/cuda/pup/yaksuri_cuda_buftype.c
+++ b/src/backend/cuda/pup/yaksuri_cuda_buftype.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksi.h"
+#include "yaksu.h"
+#include "yaksur.h"
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+int yaksuri_cuda_is_gpu_memory(const void *buf, int *flag)
+{
+    int rc = YAKSA_SUCCESS;
+
+    struct cudaPointerAttributes attr;
+    cudaError_t cerr = cudaPointerGetAttributes(&attr, buf);
+    if (cerr == cudaSuccess) {
+        if (attr.type == cudaMemoryTypeUnregistered || attr.type == cudaMemoryTypeHost) {
+            *flag = 0;
+        } else {
+            *flag = 1;
+        }
+    } else if (cerr == cudaErrorInvalidValue) {
+        *flag = 0;
+    } else if (cerr != cudaSuccess) {
+        fprintf(stderr, "CUDA Error (%s:%s,%d): %s\n", __func__, __FILE__, __LINE__,
+                cudaGetErrorString(cerr));
+        rc = YAKSA_ERR__INTERNAL;
+        goto fn_fail;
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}


### PR DESCRIPTION
## Pull Request Description

The buffer type checking function was defined as a static inside the device exposed header file.  This was causing it to be included in files that didn't use the function at all and was throwing warnings.  We could have silenced it with an attribute, but it is cleaner to simply move the function into a `.c` file.

## Expected Impact

Fixes warnings.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
