### PR TITLE
build: remove -Wcast-qual checking

### DIFF
--- a/m4/aclocal_cc.m4
+++ b/m4/aclocal_cc.m4
@@ -587,7 +587,6 @@ if test "$enable_strict_done" != "yes" ; then
 		;;
              extra)
                 pac_common_strict_flags="$pac_common_strict_flags
-                    -Wcast-qual
                     -Wredundant-decls
                     -Waggregate-return
                     -Wfloat-equal


### PR DESCRIPTION
## Pull Request Description

This compiler argument throws several warnings in genuine cases that are hard to fix.
Disable this check for now.

## Expected Impact

Fewer unnecessary warnings.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [x] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
