### PR TITLE
cuda: make stream fully asynchronous

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -39,7 +39,8 @@ int yaksuri_cuda_init_hook(void)
                           &yaksuri_cudai_global.pup_buf_pool);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    cudaError_t cerr = cudaStreamCreate(&yaksuri_cudai_global.stream);
+    cudaError_t cerr =
+        cudaStreamCreateWithFlags(&yaksuri_cudai_global.stream, cudaStreamNonBlocking);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description
`cudaStreamCreate` creates a stream that implicitly synchronizes with the
default stream (stream 0). Thus, if work on the created stream is
interleaved with work on the default stream the two will be serialized.
This behavior can be fixed by replacing `cudaStreamCreate` with
`cudaStreamCreateWithFlags` and using the `cudaStreamNonBlocking` flag for
the new stream.

Fixes issue https://github.com/pmodels/yaksa/issues/31

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes all tests
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
