### PR TITLE
Abstract GPU related code

### DIFF
--- a/src/backend/cuda/hooks/Makefile.mk
+++ b/src/backend/cuda/hooks/Makefile.mk
@@ -7,4 +7,4 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/backend/cuda/hooks
 
 libyaksa_la_SOURCES += \
 	src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c \
-	src/backend/cuda/hooks/yaksuri_cuda_type_hooks.c
+	src/backend/cuda/hooks/yaksuri_cudai_type_hooks.c

--- a/src/backend/cuda/hooks/yaksuri_cudai_type_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cudai_type_hooks.c
@@ -46,8 +46,8 @@ static uintptr_t get_num_elements(yaksi_type_s * type)
     }
 }
 
-int yaksuri_cuda_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
-                                  yaksur_gpudev_pup_fn * unpack)
+int yaksuri_cudai_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
+                                   yaksur_gpudev_pup_fn * unpack)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -67,7 +67,7 @@ int yaksuri_cuda_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pa
     goto fn_exit;
 }
 
-int yaksuri_cuda_type_free_hook(yaksi_type_s * type)
+int yaksuri_cudai_type_free_hook(yaksi_type_s * type)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_cudai_type_s *cuda = (yaksuri_cudai_type_s *) type->backend.cuda.priv;

--- a/src/backend/cuda/include/yaksuri_cuda_post.h
+++ b/src/backend/cuda/include/yaksuri_cuda_post.h
@@ -6,18 +6,6 @@
 #ifndef YAKSURI_CUDA_POST_H_INCLUDED
 #define YAKSURI_CUDA_POST_H_INCLUDED
 
-int yaksuri_cuda_init_hook(yaksu_malloc_fn * host_malloc_fn, yaksu_free_fn * host_free_fn,
-                           yaksu_malloc_fn * device_malloc_fn, yaksu_free_fn * device_free_fn);
-int yaksuri_cuda_finalize_hook(void);
-int yaksuri_cuda_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
-                                  yaksur_gpudev_pup_fn * unpack);
-int yaksuri_cuda_type_free_hook(yaksi_type_s * type);
-
-int yaksuri_cuda_event_create(void **event);
-int yaksuri_cuda_event_destroy(void *event);
-int yaksuri_cuda_event_query(void *event, int *completed);
-int yaksuri_cuda_event_synchronize(void *event);
-
-int yaksuri_cuda_get_memory_type(const void *buf, yaksur_memory_type_e * memtype);
+int yaksuri_cuda_init_hook(yaksur_gpudev_info_s ** info);
 
 #endif /* YAKSURI_CUDA_H_INCLUDED */

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -83,6 +83,18 @@ typedef struct yaksuri_cudai_type_s {
     uintptr_t num_elements;
 } yaksuri_cudai_type_s;
 
+int yaksuri_cudai_finalize_hook(void);
+int yaksuri_cudai_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
+                                   yaksur_gpudev_pup_fn * unpack);
+int yaksuri_cudai_type_free_hook(yaksi_type_s * type);
+
+int yaksuri_cudai_event_create(void **event);
+int yaksuri_cudai_event_destroy(void *event);
+int yaksuri_cudai_event_query(void *event, int *completed);
+int yaksuri_cudai_event_synchronize(void *event);
+
+int yaksuri_cudai_get_memory_type(const void *buf, yaksur_memory_type_e * memtype);
+
 int yaksuri_cudai_md_alloc(yaksi_type_s * type);
 int yaksuri_cudai_populate_pupfns(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
                                   yaksur_gpudev_pup_fn * unpack);

--- a/src/backend/cuda/pup/Makefile.mk
+++ b/src/backend/cuda/pup/Makefile.mk
@@ -6,8 +6,8 @@
 AM_CPPFLAGS += -I$(top_srcdir)/src/backend/cuda/pup
 
 libyaksa_la_SOURCES += \
-	src/backend/cuda/pup/yaksuri_cuda_event.c \
-	src/backend/cuda/pup/yaksuri_cuda_get_memory_type.c \
+	src/backend/cuda/pup/yaksuri_cudai_event.c \
+	src/backend/cuda/pup/yaksuri_cudai_get_memory_type.c \
 	src/backend/cuda/pup/yaksuri_cudai_pup_char.cu \
 	src/backend/cuda/pup/yaksuri_cudai_pup_double.cu \
 	src/backend/cuda/pup/yaksuri_cudai_pup_float.cu \

--- a/src/backend/cuda/pup/yaksuri_cudai_event.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_event.c
@@ -10,7 +10,7 @@
 #include "yaksu.h"
 #include "yaksuri_cudai.h"
 
-int yaksuri_cuda_event_create(void **event)
+int yaksuri_cudai_event_create(void **event)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -23,7 +23,7 @@ int yaksuri_cuda_event_create(void **event)
     goto fn_exit;
 }
 
-int yaksuri_cuda_event_destroy(void *event)
+int yaksuri_cudai_event_destroy(void *event)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -36,7 +36,7 @@ int yaksuri_cuda_event_destroy(void *event)
     goto fn_exit;
 }
 
-int yaksuri_cuda_event_query(void *event, int *completed)
+int yaksuri_cudai_event_query(void *event, int *completed)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -55,7 +55,7 @@ int yaksuri_cuda_event_query(void *event, int *completed)
     goto fn_exit;
 }
 
-int yaksuri_cuda_event_synchronize(void *event)
+int yaksuri_cudai_event_synchronize(void *event)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/backend/cuda/pup/yaksuri_cudai_get_memory_type.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_get_memory_type.c
@@ -8,7 +8,7 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 
-int yaksuri_cuda_get_memory_type(const void *buf, yaksur_memory_type_e * memtype)
+int yaksuri_cudai_get_memory_type(const void *buf, yaksur_memory_type_e * memtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/backend/cuda/stub/yaksuri_cuda_post.h
+++ b/src/backend/cuda/stub/yaksuri_cuda_post.h
@@ -6,70 +6,63 @@
 #ifndef YAKSURI_CUDA_POST_H_INCLUDED
 #define YAKSURI_CUDA_POST_H_INCLUDED
 
-static int yaksuri_cuda_init_hook(yaksu_malloc_fn * host_malloc_fn, yaksu_free_fn * host_free_fn,
-                                  yaksu_malloc_fn * device_malloc_fn,
-                                  yaksu_free_fn * device_free_fn);
-static int yaksuri_cuda_init_hook(yaksu_malloc_fn * host_malloc_fn, yaksu_free_fn * host_free_fn,
-                                  yaksu_malloc_fn * device_malloc_fn,
-                                  yaksu_free_fn * device_free_fn)
+static int yaksuri_cuda_init_hook(yaksur_gpudev_info_s ** info) ATTRIBUTE((unused));
+static int yaksuri_cuda_init_hook(yaksur_gpudev_info_s ** info)
 {
-    *host_malloc_fn = NULL;
-    *host_free_fn = NULL;
-    *device_malloc_fn = NULL;
-    *device_free_fn = NULL;
+    *info = NULL;
 
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_finalize_hook(void) ATTRIBUTE((unused));
-static int yaksuri_cuda_finalize_hook(void)
+static int yaksuri_cudai_finalize_hook(void) ATTRIBUTE((unused));
+static int yaksuri_cudai_finalize_hook(void)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
-                                         yaksur_gpudev_pup_fn * unpack) ATTRIBUTE((unused));
-static int yaksuri_cuda_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
-                                         yaksur_gpudev_pup_fn * unpack)
+static int yaksuri_cudai_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
+                                          yaksur_gpudev_pup_fn * unpack) ATTRIBUTE((unused));
+static int yaksuri_cudai_type_create_hook(yaksi_type_s * type, yaksur_gpudev_pup_fn * pack,
+                                          yaksur_gpudev_pup_fn * unpack)
 {
     *pack = NULL;
     *unpack = NULL;
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_type_free_hook(yaksi_type_s * type) ATTRIBUTE((unused));
-static int yaksuri_cuda_type_free_hook(yaksi_type_s * type)
+static int yaksuri_cudai_type_free_hook(yaksi_type_s * type) ATTRIBUTE((unused));
+static int yaksuri_cudai_type_free_hook(yaksi_type_s * type)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_event_create(void **event) ATTRIBUTE((unused));
-static int yaksuri_cuda_event_create(void **event)
+static int yaksuri_cudai_event_create(void **event) ATTRIBUTE((unused));
+static int yaksuri_cudai_event_create(void **event)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_event_destroy(void *event) ATTRIBUTE((unused));
-static int yaksuri_cuda_event_destroy(void *event)
+static int yaksuri_cudai_event_destroy(void *event) ATTRIBUTE((unused));
+static int yaksuri_cudai_event_destroy(void *event)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_event_query(void *event, int *completed) ATTRIBUTE((unused));
-static int yaksuri_cuda_event_query(void *event, int *completed)
+static int yaksuri_cudai_event_query(void *event, int *completed) ATTRIBUTE((unused));
+static int yaksuri_cudai_event_query(void *event, int *completed)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_event_synchronize(void *event) ATTRIBUTE((unused));
-static int yaksuri_cuda_event_synchronize(void *event)
+static int yaksuri_cudai_event_synchronize(void *event) ATTRIBUTE((unused));
+static int yaksuri_cudai_event_synchronize(void *event)
 {
     return YAKSA_SUCCESS;
 }
 
-static int yaksuri_cuda_get_memory_type(const void *buf,
-                                        yaksur_memory_type_e * memtype) ATTRIBUTE((unused));
-static int yaksuri_cuda_get_memory_type(const void *buf, yaksur_memory_type_e * memtype)
+static int yaksuri_cudai_get_memory_type(const void *buf,
+                                         yaksur_memory_type_e * memtype) ATTRIBUTE((unused));
+static int yaksuri_cudai_get_memory_type(const void *buf, yaksur_memory_type_e * memtype)
 {
     *memtype = YAKSUR_MEMORY_TYPE__UNREGISTERED_HOST;
 

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -4,6 +4,7 @@
  */
 
 #include <stdlib.h>
+#include <assert.h>
 #include "yaksa.h"
 #include "yaksi.h"
 #include "yaksu.h"
@@ -14,13 +15,15 @@ yaksuri_global_s yaksuri_global;
 int yaksur_init_hook(void)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_gpudev_id_e id;
 
     rc = yaksuri_seq_init_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = yaksuri_cuda_init_hook(&yaksuri_global.cuda.host.malloc, &yaksuri_global.cuda.host.free,
-                                &yaksuri_global.cuda.device.malloc,
-                                &yaksuri_global.cuda.device.free);
+    /* CUDA hooks */
+    id = YAKSURI_GPUDEV_ID__CUDA;
+    yaksuri_global.gpudev[id].info = NULL;
+    rc = yaksuri_cuda_init_hook(&yaksuri_global.gpudev[id].info);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -36,15 +39,20 @@ int yaksur_finalize_hook(void)
     rc = yaksuri_seq_finalize_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    if (yaksuri_global.cuda.host.slab) {
-        yaksuri_global.cuda.host.free(yaksuri_global.cuda.host.slab);
-    }
-    if (yaksuri_global.cuda.device.slab) {
-        yaksuri_global.cuda.device.free(yaksuri_global.cuda.device.slab);
-    }
+    for (yaksuri_gpudev_id_e id = YAKSURI_GPUDEV_ID__UNSET + 1; id < YAKSURI_GPUDEV_ID__LAST; id++) {
+        if (yaksuri_global.gpudev[id].host.slab) {
+            yaksuri_global.gpudev[id].info->host_free(yaksuri_global.gpudev[id].host.slab);
+        }
+        if (yaksuri_global.gpudev[id].device.slab) {
+            yaksuri_global.gpudev[id].info->device_free(yaksuri_global.gpudev[id].device.slab);
+        }
 
-    rc = yaksuri_cuda_finalize_hook();
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        if (yaksuri_global.gpudev[id].info) {
+            rc = yaksuri_global.gpudev[id].info->finalize();
+            YAKSU_ERR_CHECK(rc, fn_fail);
+            free(yaksuri_global.gpudev[id].info);
+        }
+    }
 
   fn_exit:
     return rc;
@@ -62,8 +70,13 @@ int yaksur_type_create_hook(yaksi_type_s * type)
     rc = yaksuri_seq_type_create_hook(type, &backend->seq.pack, &backend->seq.unpack);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = yaksuri_cuda_type_create_hook(type, &backend->cuda.pack, &backend->cuda.unpack);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    for (yaksuri_gpudev_id_e id = YAKSURI_GPUDEV_ID__UNSET + 1; id < YAKSURI_GPUDEV_ID__LAST; id++) {
+        if (yaksuri_global.gpudev[id].info) {
+            rc = yaksuri_global.gpudev[id].info->type_create(type, &backend->gpudev[id].pack,
+                                                             &backend->gpudev[id].unpack);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+    }
 
   fn_exit:
     return rc;
@@ -78,8 +91,12 @@ int yaksur_type_free_hook(yaksi_type_s * type)
     rc = yaksuri_seq_type_free_hook(type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = yaksuri_cuda_type_free_hook(type);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    for (yaksuri_gpudev_id_e id = YAKSURI_GPUDEV_ID__UNSET + 1; id < YAKSURI_GPUDEV_ID__LAST; id++) {
+        if (yaksuri_global.gpudev[id].info) {
+            rc = yaksuri_global.gpudev[id].info->type_free(type);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+    }
 
     free(type->backend.priv);
 
@@ -96,8 +113,7 @@ int yaksur_request_create_hook(yaksi_request_s * request)
     request->backend.priv = malloc(sizeof(yaksuri_request_s));
     yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
 
-    rc = yaksuri_cuda_event_create(&backend->event);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    backend->event = NULL;
 
   fn_exit:
     return rc;
@@ -109,9 +125,13 @@ int yaksur_request_free_hook(yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
+    yaksuri_gpudev_id_e id = backend->gpudev_id;
 
-    rc = yaksuri_cuda_event_destroy(backend->event);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (backend->event) {
+        assert(yaksuri_global.gpudev[id].info);
+        rc = yaksuri_global.gpudev[id].info->event_destroy(backend->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     free(backend);
 

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -36,4 +36,29 @@ typedef struct {
     void *priv;
 } yaksur_request_s;
 
+typedef int (*yaksur_event_create_fn) (void **);
+typedef int (*yaksur_event_destroy_fn) (void *);
+typedef int (*yaksur_event_query_fn) (void *, int *);
+typedef int (*yaksur_event_synchronize_fn) (void *);
+typedef int (*yaksur_finalize_fn) (void);
+typedef int (*yaksur_type_create_fn) (struct yaksi_type_s *, yaksur_gpudev_pup_fn *,
+                                      yaksur_gpudev_pup_fn *);
+typedef int (*yaksur_type_free_fn) (struct yaksi_type_s *);
+typedef int (*yaksur_get_memory_type) (const void *, yaksur_memory_type_e *);
+
+typedef struct yaksur_gpudev_info_s {
+    yaksu_malloc_fn host_malloc;
+    yaksu_free_fn host_free;
+    yaksu_malloc_fn device_malloc;
+    yaksu_free_fn device_free;
+    yaksur_event_create_fn event_create;
+    yaksur_event_destroy_fn event_destroy;
+    yaksur_event_query_fn event_query;
+    yaksur_event_synchronize_fn event_synchronize;
+    yaksur_type_create_fn type_create;
+    yaksur_type_free_fn type_free;
+    yaksur_get_memory_type get_memory_type;
+    yaksur_finalize_fn finalize;
+} yaksur_gpudev_info_s;
+
 #endif /* YAKSUR_PRE_H_INCLUDED */

--- a/src/backend/src/yaksur_request.c
+++ b/src/backend/src/yaksur_request.c
@@ -13,10 +13,11 @@ int yaksur_request_test(yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
+    yaksuri_gpudev_id_e id = backend->gpudev_id;
 
     if (backend->kind == YAKSURI_REQUEST_KIND__DEVICE_NATIVE) {
         int completed;
-        rc = yaksuri_cuda_event_query(backend->event, &completed);
+        rc = yaksuri_global.gpudev[id].info->event_query(backend->event, &completed);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         if (completed) {
@@ -37,9 +38,10 @@ int yaksur_request_wait(yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
+    yaksuri_gpudev_id_e id = backend->gpudev_id;
 
     if (backend->kind == YAKSURI_REQUEST_KIND__DEVICE_NATIVE) {
-        rc = yaksuri_cuda_event_synchronize(backend->event);
+        rc = yaksuri_global.gpudev[id].info->event_synchronize(backend->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         yaksu_atomic_decr(&request->cc);

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -8,17 +8,21 @@
 
 #include "yaksi.h"
 
+typedef enum yaksuri_gpudev_id_e {
+    YAKSURI_GPUDEV_ID__UNSET = -1,
+    YAKSURI_GPUDEV_ID__CUDA = 0,
+    YAKSURI_GPUDEV_ID__LAST,
+} yaksuri_gpudev_id_e;
+
 typedef struct {
     struct {
         struct {
             void *slab;
             uintptr_t slab_head_offset;
             uintptr_t slab_tail_offset;
-
-            yaksu_malloc_fn malloc;
-            yaksu_free_fn free;
         } device, host;
-    } cuda;
+        yaksur_gpudev_info_s *info;
+    } gpudev[YAKSURI_GPUDEV_ID__LAST];
 } yaksuri_global_s;
 extern yaksuri_global_s yaksuri_global;
 
@@ -31,10 +35,11 @@ typedef struct yaksuri_type_s {
     struct {
         yaksur_gpudev_pup_fn pack;
         yaksur_gpudev_pup_fn unpack;
-    } cuda;
+    } gpudev[YAKSURI_GPUDEV_ID__LAST];
 } yaksuri_type_s;
 
 typedef struct {
+    yaksuri_gpudev_id_e gpudev_id;
     void *event;
 
     enum {

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -92,7 +92,7 @@ typedef enum {
  * \brief yaksa predefined requests
  */
 typedef enum {
-    YAKSA_REQUEST__NULL = 0,
+    YAKSA_REQUEST__NULL = -1,
 
     /* terminal */
     YAKSI_REQUEST__LAST,

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -94,23 +94,15 @@ int yaksa_init(void)
         assert(type->id == i);
     }
 
-
     /* initialize the request pool */
     rc = yaksu_pool_alloc(sizeof(yaksi_request_s), CHUNK_SIZE, UINTPTR_MAX, malloc, free,
                           &yaksi_global.request_pool);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    /* these are the first set of allocations for our builtin
-     * requests, so the indices should match that of the request
-     * themselves */
-    for (int i = 0; i < YAKSI_REQUEST__LAST; i++) {
-        struct yaksi_request_s *request;
 
-        rc = yaksi_request_create(&request);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        assert(request->id == i);
-    }
+    /* initialize the backend */
+    rc = yaksur_init_hook();
+    YAKSU_ERR_CHECK(rc, fn_fail);
 
 
     /* setup builtin datatypes */
@@ -152,11 +144,6 @@ int yaksa_init(void)
     INIT_BUILTIN_PAIRTYPE(long double, int, yaksi_long_double_int_s, LONG_DOUBLE_INT, rc, fn_fail);
 
     INIT_BUILTIN(uint8_t, BYTE, rc, fn_fail);
-
-
-    /* initialize the backend */
-    rc = yaksur_init_hook();
-    YAKSU_ERR_CHECK(rc, fn_fail);
 
 
     /* done */

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -65,17 +65,18 @@ static void alloc_mem(size_t size, mem_type_e type, void **hostbuf, void **devic
         if (hostbuf)
             *hostbuf = *devicebuf;
 #ifdef HAVE_CUDA
-    } else {
-        if (type == MEM_TYPE__REGISTERED_HOST) {
-            cudaMallocHost(devicebuf, size);
-            if (hostbuf)
-                *hostbuf = *devicebuf;
-        } else if (type == MEM_TYPE__DEVICE) {
-            cudaMalloc(devicebuf, size);
-            if (hostbuf)
-                cudaMallocHost(hostbuf, size);
-        }
+    } else if (type == MEM_TYPE__REGISTERED_HOST) {
+        cudaMallocHost(devicebuf, size);
+        if (hostbuf)
+            *hostbuf = *devicebuf;
+    } else if (type == MEM_TYPE__DEVICE) {
+        cudaMalloc(devicebuf, size);
+        if (hostbuf)
+            cudaMallocHost(hostbuf, size);
 #endif
+    } else {
+        fprintf(stderr, "ERROR: unsupported memory type\n");
+        exit(1);
     }
 }
 
@@ -256,7 +257,7 @@ int main(int argc, char **argv)
         rc = DTP_obj_create(dtp, &sobj, maxbufsize);
         assert(rc == DTP_SUCCESS);
 
-        char *sbuf_h, *sbuf_d;
+        char *sbuf_h = NULL, *sbuf_d = NULL;
         alloc_mem(sobj.DTP_bufsize, sbuf_memtype, (void **) &sbuf_h, (void **) &sbuf_d);
         assert(sbuf_h);
         assert(sbuf_d);


### PR DESCRIPTION
## Pull Request Description

The backend glue layer includes a large amount of GPU management code.  But most of this code is not specific to a GPU type.  This PR abstracts the GPU type from the code, so as to reduce the footprint of "cuda" in the code.  Specifically, the algorithm logic that is independent of CUDA does not directly reference any CUDA-specific content.

This PR is in preparation for supporting other GPU types (e.g., AMD and Intel GPUs).

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Passes whitespace checkers
* [ ] Passes all tests
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
