### PR TITLE
test: free description string

### DIFF
--- a/test/flatten/flatten.c
+++ b/test/flatten/flatten.c
@@ -72,8 +72,6 @@ int main(int argc, char **argv)
     assert(rc == DTP_SUCCESS);
 
     for (int i = 0; i < iters; i++) {
-        char *desc;
-
         dprintf("==== iter %d ====\n", i);
 
         /* create the source object */
@@ -84,9 +82,11 @@ int main(int argc, char **argv)
         assert(sbuf);
 
         if (verbose) {
+            char *desc;
             rc = DTP_obj_get_description(sobj, &desc);
             assert(rc == DTP_SUCCESS);
             dprintf("==> sbuf %p, sobj (count: %zu):\n%s\n", sbuf, sobj.DTP_type_count, desc);
+            free(desc);
         }
 
         rc = DTP_obj_buf_init(sobj, sbuf, 0, 1, basecount);

--- a/test/iov/iov.c
+++ b/test/iov/iov.c
@@ -138,8 +138,6 @@ int main(int argc, char **argv)
     uintptr_t *segment_lengths = (uintptr_t *) malloc(segments * sizeof(uintptr_t));
 
     for (int i = 0; i < iters; i++) {
-        char *desc;
-
         dprintf("==== iter %d ====\n", i);
 
         /* create the source object */
@@ -150,10 +148,12 @@ int main(int argc, char **argv)
         assert(sbuf);
 
         if (verbose) {
+            char *desc;
             rc = DTP_obj_get_description(sobj, &desc);
             assert(rc == DTP_SUCCESS);
             dprintf("==> sbuf %p (with offset) %p, sobj (count: %zu):\n%s\n",
                     sbuf, sbuf + sobj.DTP_buf_offset, sobj.DTP_type_count, desc);
+            free(desc);
         }
 
         rc = DTP_obj_buf_init(sobj, sbuf, 0, 1, basecount);
@@ -172,10 +172,12 @@ int main(int argc, char **argv)
         assert(dbuf);
 
         if (verbose) {
+            char *desc;
             rc = DTP_obj_get_description(dobj, &desc);
             assert(rc == DTP_SUCCESS);
             dprintf("==> dbuf %p (with offset) %p, dobj (count: %zu):\n%s\n",
                     dbuf, dbuf + dobj.DTP_buf_offset, dobj.DTP_type_count, desc);
+            free(desc);
         }
 
         rc = DTP_obj_buf_init(dobj, dbuf, -1, -1, basecount);

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -249,8 +249,6 @@ int main(int argc, char **argv)
     uintptr_t *segment_lengths = (uintptr_t *) malloc(segments * sizeof(uintptr_t));
 
     for (int i = 0; i < iters; i++) {
-        char *desc;
-
         dprintf("==== iter %d ====\n", i);
 
         /* create the source object */
@@ -263,10 +261,12 @@ int main(int argc, char **argv)
         assert(sbuf_d);
 
         if (verbose) {
+            char *desc;
             rc = DTP_obj_get_description(sobj, &desc);
             assert(rc == DTP_SUCCESS);
             dprintf("==> sbuf_h %p, sbuf_d %p, sobj (count: %zu):\n%s\n", sbuf_h, sbuf_d,
                     sobj.DTP_type_count, desc);
+            free(desc);
         }
 
         rc = DTP_obj_buf_init(sobj, sbuf_h, 0, 1, basecount);
@@ -287,10 +287,12 @@ int main(int argc, char **argv)
         assert(dbuf_d);
 
         if (verbose) {
+            char *desc;
             rc = DTP_obj_get_description(dobj, &desc);
             assert(rc == DTP_SUCCESS);
             dprintf("==> dbuf_h %p, dbuf_d %p, dobj (count: %zu):\n%s\n", dbuf_h, dbuf_d,
                     dobj.DTP_type_count, desc);
+            free(desc);
         }
 
         rc = DTP_obj_buf_init(dobj, dbuf_h, -1, -1, basecount);


### PR DESCRIPTION
## Pull Request Description

dtpools no longer manages the description string. This is now generated
on demand by tests for single cases in which debugging info is needed.
The description string is thus handled by the test and should be freed
afterwards.

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
