### PR TITLE
CUDA fat binaries

### DIFF
--- a/src/backend/cuda/Makefile.mk
+++ b/src/backend/cuda/Makefile.mk
@@ -12,11 +12,10 @@ else
 include $(top_srcdir)/src/backend/cuda/stub/Makefile.mk
 endif !BUILD_CUDA_BACKEND
 
-GENCODE_FLAGS = -gencode arch=compute_$(CUDA_SM),code=sm_$(CUDA_SM)
 .cu.lo:
 	@if $(AM_V_P) ; then \
-		$(top_srcdir)/cudalt.sh --verbose $@ $(NVCC) $(AM_CPPFLAGS) $(GENCODE_FLAGS) -c $< ; \
+		$(top_srcdir)/cudalt.sh --verbose $@ $(NVCC) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
 	else \
 		echo "  NVCC     $@" ; \
-		$(top_srcdir)/cudalt.sh $@ $(NVCC) $(AM_CPPFLAGS) $(GENCODE_FLAGS) -c $< ; \
+		$(top_srcdir)/cudalt.sh $@ $(NVCC) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
 	fi

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -3,13 +3,57 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+
+##########################################################################
+##### capture user arguments
+##########################################################################
+
 # --with-cuda-sm
-AC_ARG_WITH([cuda-sm],AS_HELP_STRING([--with-cuda-sm=<numeric>],[builds CUDA support for that architecture]),,
-            [with_cuda_sm=none])
-if test "${with_cuda_sm}" != "none" ; then
-    CUDA_SM="${with_cuda_sm}"
-    AC_SUBST(CUDA_SM)
-fi
+AC_ARG_WITH([cuda-sm],
+            [
+  --with-cuda-sm=<options> (https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/)
+          Comma-separated list of below options:
+                all - build compatibility for all GPUs supported by the CUDA version (can increase compilation time)
+
+                # Kepler architecture
+                kepler - build compatibility for all Kepler GPUs
+                30     - generic kepler architecture (generic - Tesla K40/K80, GeForce 700, GT-730)
+                35     - specific Tesla K40 (adds support for dynamic parallelism)
+                37     - specific Tesla K80 (adds more registers)
+
+                # Maxwell architecture
+                maxwell - build compatibility for all Maxwell GPUs
+                50      - Tesla/Quadro M series
+                52      - Quadro M6000, GeForce 900, GTX-970, GTX-980, GTX Titan X
+                53      - Tegra (Jetson) TX1 / Tegra X1, Drive CX, Drive PX, Jetson Nano
+
+                # Pascal architecture
+                pascal - build compatibility for all Pascal GPUs
+                60     - Quadro GP100, Tesla P100, DGX-1 (Generic Pascal)
+                61     - GTX 1080, GTX 1070, GTX 1060, GTX 1050, GTX 1030, Titan Xp,
+                         Tesla P40, Tesla P4, Discrete GPU on the NVIDIA Drive PX2
+                62     - Integrated GPU on the NVIDIA Drive PX2, Tegra (Jetson) TX2
+
+                # Volta architecture
+                volta - build compatibility for all Volta GPUs
+                70    - DGX-1 with Volta, Tesla V100, GTX 1180 (GV104), Titan V, Quadro GV100
+                72    - Jetson AGX Xavier, Drive AGX Pegasus, Xavier NX
+
+                # Turing architecture
+                turing - build compatibility for all Turing GPUs
+                75     - GTX/RTX Turing - GTX 1660 Ti, RTX 2060, RTX 2070, RTX 2080, Titan RTX,
+                         Quadro RTX 4000, Quadro RTX 5000, Quadro RTX 6000, Quadro RTX 8000,
+                         Quadro T1000/T2000, Tesla T4
+
+                # Ampere architecture
+                ampere - build compatibility for all Ampere GPUs
+                80     - RTX Ampere - RTX 3080
+
+                # Other
+                <numeric> - specific SM numeric to use
+            ],,
+            [with_cuda_sm=all])
+
 
 # --with=cuda
 PAC_SET_HEADER_LIB_PATH([cuda])
@@ -18,18 +62,10 @@ if test "${have_cuda}" = "yes" ; then
     AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
     AS_IF([test -n "${with_cuda}"],[NVCC=${with_cuda}/bin/nvcc],[NVCC=nvcc])
     AC_SUBST(NVCC)
-
-    if test -z "${CUDA_SM}" ; then
-        AC_MSG_ERROR([--with-cuda-sm not specified; either specify it or disable cuda support])
-    fi
-
-    supported_backend="${supported_backends},cuda"
-    backend_info="${backend_info}
-CUDA backend specific options:
-      CUDA SM: ${with_cuda_sm}"
 fi
 AM_CONDITIONAL([BUILD_CUDA_BACKEND], [test x${have_cuda} = xyes])
 AM_CONDITIONAL([BUILD_CUDA_TESTS], [test x${have_cuda} = xyes])
+
 
 # --with-cuda-p2p
 AC_ARG_ENABLE([cuda-p2p],AS_HELP_STRING([--enable-cuda-p2p={yes|no|cliques}],[controls CUDA P2P capability]),,
@@ -40,4 +76,122 @@ elif test "${enable_cuda_p2p}" = "cliques" ; then
     AC_DEFINE([CUDA_P2P],[CUDA_P2P_CLIQUES],[Define if CUDA P2P is enabled in clique mode])
 else
     AC_DEFINE([CUDA_P2P],[CUDA_P2P_DISABLED],[Define if CUDA P2P is disabled])
+fi
+
+
+##########################################################################
+##### analyze the user arguments and setup internal infrastructure
+##########################################################################
+
+if test ${have_cuda} = "yes" ; then
+    for maj_version in 11 10 9 8 7 6 5 ; do
+        version=$((maj_version * 1000))
+        AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+                              #include <cuda.h>
+                              int x[[CUDA_VERSION - $version]];
+                          ],)],[cuda_version=${maj_version}],[])
+        if test ! -z ${cuda_version} ; then break ; fi
+    done
+    PAC_PUSH_FLAG([IFS])
+    IFS=","
+    CUDA_SM=
+    for sm in ${with_cuda_sm} ; do
+        case "$sm" in
+            all)
+                if test ${cuda_version} -ge 11 ; then
+                    # ampere
+                    PAC_APPEND_FLAG([80],[CUDA_SM])
+                fi
+
+                if test ${cuda_version} -ge 10 ; then
+                    # turing
+                    PAC_APPEND_FLAG([75],[CUDA_SM])
+                fi
+
+                if test ${cuda_version} -ge 9 ; then
+                    # volta
+                    PAC_APPEND_FLAG([70],[CUDA_SM])
+                    PAC_APPEND_FLAG([72],[CUDA_SM])
+                fi
+
+                if test ${cuda_version} -ge 8 ; then
+                    # pascal
+                    PAC_APPEND_FLAG([60],[CUDA_SM])
+                    PAC_APPEND_FLAG([61],[CUDA_SM])
+                    PAC_APPEND_FLAG([62],[CUDA_SM])
+                fi
+
+                if test ${cuda_version} -ge 6 ; then
+                    # maxwell
+                    PAC_APPEND_FLAG([50],[CUDA_SM])
+                    PAC_APPEND_FLAG([52],[CUDA_SM])
+                    PAC_APPEND_FLAG([53],[CUDA_SM])
+                fi
+
+                if test ${cuda_version} -ge 5 ; then
+                    # kepler
+                    PAC_APPEND_FLAG([30],[CUDA_SM])
+                    PAC_APPEND_FLAG([35],[CUDA_SM])
+                    PAC_APPEND_FLAG([37],[CUDA_SM])
+                fi
+                ;;
+
+            kepler)
+                PAC_APPEND_FLAG([30],[CUDA_SM])
+                PAC_APPEND_FLAG([35],[CUDA_SM])
+                PAC_APPEND_FLAG([37],[CUDA_SM])
+                ;;
+
+            maxwell)
+                PAC_APPEND_FLAG([50],[CUDA_SM])
+                PAC_APPEND_FLAG([52],[CUDA_SM])
+                PAC_APPEND_FLAG([53],[CUDA_SM])
+                ;;
+
+            pascal)
+                PAC_APPEND_FLAG([60],[CUDA_SM])
+                PAC_APPEND_FLAG([61],[CUDA_SM])
+                PAC_APPEND_FLAG([62],[CUDA_SM])
+                ;;
+
+            volta)
+                PAC_APPEND_FLAG([70],[CUDA_SM])
+                PAC_APPEND_FLAG([72],[CUDA_SM])
+                ;;
+
+            turing)
+                PAC_APPEND_FLAG([75],[CUDA_SM])
+                ;;
+
+            ampere)
+                PAC_APPEND_FLAG([80],[CUDA_SM])
+                ;;
+
+            none)
+                ;;
+
+            *)
+                PAC_APPEND_FLAG([$sm],[CUDA_SM])
+                ;;
+          esac
+    done
+    PAC_POP_FLAG([IFS])
+
+    for sm in ${CUDA_SM} ; do
+        if test -z "${CUDA_GENCODE}" ; then
+            CUDA_GENCODE="-gencode=arch=compute_${sm},code=sm_${sm}"
+        else
+            CUDA_GENCODE="${CUDA_GENCODE} -gencode=arch=compute_${sm},code=sm_${sm}"
+        fi
+    done
+    AC_SUBST(CUDA_GENCODE)
+
+    if test -z "${CUDA_GENCODE}" ; then
+        AC_MSG_ERROR([--with-cuda-sm not specified; either specify it or disable cuda support])
+    fi
+
+    supported_backends="${supported_backends},cuda"
+    backend_info="${backend_info}
+CUDA backend specific options:
+      CUDA GENCODE: ${with_cuda_sm} (${CUDA_GENCODE})"
 fi


### PR DESCRIPTION
## Pull Request Description

Allow the CUDA backend to build executables for multiple architectures, including all supported architectures depending on the CUDA version.  Users still have the option to specialize builds for specific architectures, but are not required to do so.

## Expected Impact

Adds convenience for the user so they do not have to figure out the exact GPU architecture they are building for.  Also helps binary distributors where the binary code needs to work on multiple architectures.

On the negative side, this significantly increases the build time.  In my experiments, the default (parallel) build goes up from 35 seconds to 315 seconds.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
