### PR TITLE
Allow users to control the maximum number of nesting levels generated for the pup functions

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -4,6 +4,10 @@
 ##     See COPYRIGHT in top-level directory
 ##
 
+########################################################################
+## Utility functions
+########################################################################
+
 echo_n() {
     # "echo -n" isn't portable, must portably implement with printf
     printf "%s" "$*"
@@ -14,6 +18,10 @@ error() {
 }
 
 
+########################################################################
+## Autotools
+########################################################################
+
 # generate configure files
 echo
 echo "=== generating configure files in main directory ==="
@@ -21,6 +29,10 @@ autoreconf -vif
 echo "=== done === "
 echo
 
+
+########################################################################
+## Generating required files
+########################################################################
 
 # backend pup functions
 for x in seq cuda ; do

--- a/autogen.sh
+++ b/autogen.sh
@@ -15,7 +15,26 @@ echo_n() {
 
 error() {
     echo "===> ERROR:   $@"
+    exit
 }
+
+
+########################################################################
+## Parse user arguments
+########################################################################
+
+genpup_args=
+for arg in "$@" ; do
+    case $arg in
+        -pup-max-nesting=*|--pup-max-nesting=*)
+            genpup_args="$genpup_args $arg"
+            ;;
+
+        *)
+            error "unknown argument $arg"
+            ;;
+    esac
+done
 
 
 ########################################################################
@@ -37,7 +56,7 @@ echo
 # backend pup functions
 for x in seq cuda ; do
     echo_n "generating backend pup functions for ${x}... "
-    ./src/backend/${x}/genpup.py
+    ./src/backend/${x}/genpup.py ${genpup_args}
     echo "done"
 done
 

--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -5,6 +5,7 @@
 ##
 
 import sys
+import argparse
 sys.path.append('maint/')
 import yutils
 
@@ -320,9 +321,19 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
+    ##### parse user arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pup-max-nesting', type=int, default=3, help='maximum nesting levels to generate')
+    args = parser.parse_args()
+    if (args.pup_max_nesting < 0):
+        parser.print_help()
+        print
+        print("===> ERROR: pup-max-nesting must be positive")
+        sys.exit(1)
+
     ##### generate the list of derived datatype arrays
     darraylist = [ ]
-    yutils.generate_darrays(derived_types, darraylist, 3)
+    yutils.generate_darrays(derived_types, darraylist, args.pup_max_nesting)
 
     ##### generate the core pack/unpack kernels
     for b in builtin_types:
@@ -376,7 +387,7 @@ if __name__ == '__main__':
     indentation += 1
     pupstr = "pack"
     typelist = [ ]
-    switcher(typelist, pupstr, 4)
+    switcher(typelist, pupstr, args.pup_max_nesting + 1)
     OUTFILE.write("\n")
     display("return rc;\n")
     indentation -= 1

--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -320,6 +320,10 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
+    ##### generate the list of derived datatype arrays
+    darraylist = [ ]
+    yutils.generate_darrays(derived_types, darraylist, 3)
+
     ##### generate the core pack/unpack kernels
     for b in builtin_types:
         filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s.cu" % b.replace(" ","_")
@@ -335,8 +339,6 @@ if __name__ == '__main__':
         OUTFILE.write("#include \"yaksuri_cudai_populate_pupfns.h\"\n")
         OUTFILE.write("\n")
 
-        darraylist = [ ]
-        yutils.generate_darrays(derived_types, darraylist, 3)
         for darray in darraylist:
             generate_kernels(b, darray)
 
@@ -401,8 +403,6 @@ if __name__ == '__main__':
     OUTFILE.write("\n")
 
     for b in builtin_types:
-        darraylist = [ ]
-        yutils.generate_darrays(derived_types, darraylist, 3)
         for darray in darraylist:
             for func in "pack","unpack":
                 ##### figure out the function name to use

--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -320,7 +320,7 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
-    #### generate the core pack/unpack kernels
+    ##### generate the core pack/unpack kernels
     for b in builtin_types:
         filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s.cu" % b.replace(" ","_")
         yutils.copyright(filename)

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -340,6 +340,10 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
+    ##### generate the list of derived datatype arrays
+    darraylist = [ ]
+    yutils.generate_darrays(derived_types, darraylist, 3)
+
     ##### generate the core pack/unpack kernels
     for b in builtin_types:
         filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s.c" % b.replace(" ","_")
@@ -351,8 +355,6 @@ if __name__ == '__main__':
         OUTFILE.write("#include \"yaksuri_seqi_populate_pupfns.h\"\n")
         OUTFILE.write("\n")
 
-        darraylist = [ ]
-        yutils.generate_darrays(derived_types, darraylist, 3)
         for darray in darraylist:
             for blklen in blklens:
                 generate_kernels(b, darray, blklen)
@@ -412,9 +414,6 @@ if __name__ == '__main__':
     OUTFILE.write("\n")
 
     for b in builtin_types:
-        darraylist = [ ]
-        yutils.generate_darrays(derived_types, darraylist, 3)
-
         for darray in darraylist:
             for blklen in blklens:
                 # individual blocklength optimization is only for

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -340,7 +340,7 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
-    #### generate the core pack/unpack kernels
+    ##### generate the core pack/unpack kernels
     for b in builtin_types:
         filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s.c" % b.replace(" ","_")
         yutils.copyright(filename)

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -5,6 +5,7 @@
 ##
 
 import sys
+import argparse
 sys.path.append('maint/')
 import yutils
 
@@ -340,9 +341,19 @@ def switcher(typelist, pupstr, nests):
 ##### main function
 ########################################################################################
 if __name__ == '__main__':
+    ##### parse user arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pup-max-nesting', type=int, default=3, help='maximum nesting levels to generate')
+    args = parser.parse_args()
+    if (args.pup_max_nesting < 0):
+        parser.print_help()
+        print
+        print("===> ERROR: pup-max-nesting must be positive")
+        sys.exit(1)
+
     ##### generate the list of derived datatype arrays
     darraylist = [ ]
-    yutils.generate_darrays(derived_types, darraylist, 3)
+    yutils.generate_darrays(derived_types, darraylist, args.pup_max_nesting)
 
     ##### generate the core pack/unpack kernels
     for b in builtin_types:
@@ -393,7 +404,7 @@ if __name__ == '__main__':
     indentation += 1
     pupstr = "pack"
     typelist = [ ]
-    switcher(typelist, pupstr, 4)
+    switcher(typelist, pupstr, args.pup_max_nesting + 1)
     OUTFILE.write("\n")
     display("return rc;\n")
     indentation -= 1


### PR DESCRIPTION
## Pull Request Description

Allow for users to generate different levels of nesting, thus trading off performance with the library size and build time.  The default is set to 3 levels of nesting, as before.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
