### PR TITLE
Add init attributes to yaksa_init

### DIFF
--- a/examples/contig.c
+++ b/examples/contig.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t contig;
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/fuf.c
+++ b/examples/fuf.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hindexed.c
+++ b/examples/hindexed.c
@@ -23,8 +23,8 @@ int main()
         36 * sizeof(int), 44 * sizeof(int), 52 * sizeof(int), 60 * sizeof(int)
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hindexed_block.c
+++ b/examples/hindexed_block.c
@@ -27,8 +27,8 @@ int main()
         32 * sizeof(int), 40 * sizeof(int), 48 * sizeof(int), 56 * sizeof(int)
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hvector.c
+++ b/examples/hvector.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t hvector;
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/indexed.c
+++ b/examples/indexed.c
@@ -23,8 +23,8 @@ int main()
         36, 44, 52, 60
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/indexed_block.c
+++ b/examples/indexed_block.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/iov.c
+++ b/examples/iov.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/resized.c
+++ b/examples/resized.c
@@ -17,7 +17,7 @@ int main()
     yaksa_type_t vector_resized;
     yaksa_type_t transpose;
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/subarray.c
+++ b/examples/subarray.c
@@ -21,8 +21,8 @@ int main()
     int array_of_starts[2] = { 4, 4 };
     yaksa_subarray_order_e order = YAKSA_SUBARRAY_ORDER__C;
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/vector.c
+++ b/examples/vector.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t vector;
 
-    yaksa_init();       /* before any yaksa API is called the library
-                         * must be initialized */
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
+                                                 * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -138,6 +138,22 @@ typedef enum {
 /*! @} */
 
 
+/*! \addtogroup yaksa-init-attr Yaksa initialization attributes
+ * @{
+ */
+
+/**
+ * \brief yaksa initialization attributes
+ */
+/* currently there are no init attributes */
+typedef struct {
+    int __reserved_for_future_use;
+} yaksa_init_attr_t;
+extern yaksa_init_attr_t YAKSA_INIT_ATTR__DEFAULT;
+
+/*! @} */
+
+
 /*! \addtogroup yaksa-funcs Yaksa public functions
  * @{
  */
@@ -148,7 +164,7 @@ typedef enum {
 /*!
  * \brief initializes the yaksa library
  */
-int yaksa_init(void);
+int yaksa_init(yaksa_init_attr_t attr);
 
 /*!
  * \brief finalizes the yaksa library

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -70,10 +70,11 @@
     } while (0)
 
 yaksi_global_s yaksi_global = { 0 };
+yaksa_init_attr_t YAKSA_INIT_ATTR__DEFAULT = { 0 };
 
 #define CHUNK_SIZE (1024)
 
-int yaksa_init(void)
+int yaksa_init(yaksa_init_attr_t attr)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/test/flatten/flatten.c
+++ b/test/flatten/flatten.c
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
 
     rc = DTP_pool_create(typestr, basecount, seed, &dtp);
     assert(rc == DTP_SUCCESS);

--- a/test/iov/iov.c
+++ b/test/iov/iov.c
@@ -129,7 +129,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
 
     rc = DTP_pool_create(typestr, basecount, seed, &dtp);
     assert(rc == DTP_SUCCESS);

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -259,7 +259,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
     init_devices();
 
     rc = DTP_pool_create(typestr, basecount, seed, &dtp);

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -58,7 +58,9 @@ typedef enum {
     MEM_TYPE__DEVICE,
 } mem_type_e;
 
+#ifdef HAVE_CUDA
 static int ndevices = -1;
+#endif
 static int device_id = 0;
 static int device_stride = 0;
 

--- a/test/simple/simple_test.c
+++ b/test/simple/simple_test.c
@@ -17,7 +17,7 @@ int main()
     yaksa_type_t vector, vector_vector;
     uintptr_t actual;
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
 
     rc = yaksa_create_vector(3, 2, 3, YAKSA_TYPE__INT, &vector);
     assert(rc == YAKSA_SUCCESS);

--- a/test/simple/threaded_test.c
+++ b/test/simple/threaded_test.c
@@ -87,7 +87,7 @@ int main()
 {
     pthread_t thread[MAX_THREADS];
 
-    yaksa_init();
+    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
 
     inbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));
     outbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));


### PR DESCRIPTION
## Pull Request Description

Allow for attributes to be passed to yaksa during initialization.  Though we do not have any attributes right now, this will help future-proof the API somewhat.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
