### PR TITLE
Allow users to pass zero-byte datatypes to pack/unpack

### DIFF
--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -15,9 +15,21 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
 
     assert(yaksi_global.is_initialized);
 
+    if (incount == 0) {
+        *actual_pack_bytes = 0;
+        *request = YAKSA_REQUEST__NULL;
+        goto fn_exit;
+    }
+
     yaksi_type_s *yaksi_type;
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *actual_pack_bytes = 0;
+        *request = YAKSA_REQUEST__NULL;
+        goto fn_exit;
+    }
 
     yaksi_request_s *yaksi_request;
     rc = yaksi_request_create(&yaksi_request);

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -16,9 +16,19 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
 
     assert(yaksi_global.is_initialized);
 
+    if (outcount == 0) {
+        *request = YAKSA_REQUEST__NULL;
+        goto fn_exit;
+    }
+
     yaksi_type_s *yaksi_type;
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *request = YAKSA_REQUEST__NULL;
+        goto fn_exit;
+    }
 
     yaksi_request_s *yaksi_request = NULL;
     rc = yaksi_request_create(&yaksi_request);


### PR DESCRIPTION
This is useful when the caller of yaksa is a library itself and does not know what kind of datatype got passed down to it.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
