### PR TITLE
Better detect zero-byte types

### DIFF
--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -176,6 +176,30 @@ int yaksa_init(yaksa_init_attr_t attr)
     INIT_BUILTIN(uint8_t, BYTE, rc, fn_fail);
 
 
+    /* special initialzation for the NULL type */
+    INIT_BUILTIN(uint8_t, NULL, rc, fn_fail);
+
+    yaksi_type_s *null_type;
+    rc = yaksi_type_get(YAKSA_TYPE__NULL, &null_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    null_type->kind = YAKSI_TYPE_KIND__BUILTIN;
+    null_type->tree_depth = 0;
+
+    null_type->size = 0;
+    null_type->alignment = 1;
+    null_type->extent = 0;
+    null_type->lb = 0;
+    null_type->ub = 0;
+    null_type->true_lb = 0;
+    null_type->true_ub = 0;
+
+    null_type->is_contig = true;
+    null_type->num_contig = 0;
+
+    yaksur_type_create_hook(null_type);
+
+
     /* done */
     yaksi_global.is_initialized = 1;
 

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -85,14 +85,14 @@ int yaksa_create_hindexed_block(int count, int blocklength, const intptr_t * arr
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (count * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_hindexed_block(count, blocklength, array_of_displs, intype, &outtype);
@@ -114,17 +114,17 @@ int yaksa_create_indexed_block(int count, int blocklength, const int *array_of_d
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
+    yaksi_type_s *intype;
+    rc = yaksi_type_get(oldtype, &intype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (count * intype->size == 0) {
         *newtype = YAKSA_TYPE__NULL;
         goto fn_exit;
     }
     assert(count > 0);
 
     real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
-
-    yaksi_type_s *intype;
-    rc = yaksi_type_get(oldtype, &intype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
 
     for (int i = 0; i < count; i++)
         real_array_of_displs[i] = array_of_displs[i] * intype->extent;

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -56,14 +56,14 @@ int yaksa_create_contig(int count, yaksa_type_t oldtype, yaksa_type_t * newtype)
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (count * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_contig(count, intype, &outtype);

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -112,14 +112,18 @@ int yaksa_create_hindexed(int count, const int *array_of_blocklengths,
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    uintptr_t total_size = 0;
+    for (int i = 0; i < count; i++) {
+        total_size += intype->size * array_of_blocklengths[i];
+    }
+    if (total_size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_hindexed(count, array_of_blocklengths, array_of_displs, intype, &outtype);
@@ -141,15 +145,18 @@ int yaksa_create_indexed(int count, const int *array_of_blocklengths, const int 
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-    assert(count > 0);
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    uintptr_t total_size = 0;
+    for (int i = 0; i < count; i++) {
+        total_size += intype->size * array_of_blocklengths[i];
+    }
+    if (total_size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     for (int i = 0; i < count; i++)
         real_array_of_displs[i] = array_of_displs[i] * intype->extent;

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -123,7 +123,15 @@ int yaksa_create_struct(int count, const int *array_of_blocklengths,
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
+    uintptr_t total_size = 0;
+    for (int i = 0; i < count; i++) {
+        yaksi_type_s *type;
+        rc = yaksi_type_get(array_of_types[i], &type);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        total_size += type->size * array_of_blocklengths[i];
+    }
+    if (total_size == 0) {
         *newtype = YAKSA_TYPE__NULL;
         goto fn_exit;
     }

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -141,14 +141,14 @@ int yaksa_create_subarray(int ndims, const int *array_of_sizes, const int *array
 
     assert(yaksi_global.is_initialized);
 
-    if (ndims == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (ndims * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_subarray(ndims, array_of_sizes, array_of_subsizes, array_of_starts, order,

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -76,14 +76,14 @@ int yaksa_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (count * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_hvector(count, blocklength, stride, intype, &outtype);
@@ -104,14 +104,14 @@ int yaksa_create_vector(int count, int blocklength, int stride, yaksa_type_t old
 
     assert(yaksi_global.is_initialized);
 
-    if (count == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (count * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
 
     yaksi_type_s *outtype;
     rc = yaksi_create_hvector(count, blocklength, (intptr_t) stride * intype->extent, intype,


### PR DESCRIPTION
Look at the count, the blocklengths and the sizes of each of the child
types to decide whether a new type is a zero-byte type.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
