### PR TITLE
unflatten: reset refcount for newly unflattened types

### DIFF
--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -26,6 +26,7 @@ static int unflatten(yaksi_type_s ** type, const void *flattened_type)
     flatbuf += sizeof(yaksi_type_s);
     orig_id = newtype->id;
     newtype->id = local_id;
+    yaksu_atomic_store(&newtype->refcount, 1);
 
     switch (newtype->kind) {
         case YAKSI_TYPE_KIND__BUILTIN:


### PR DESCRIPTION
When we flatten a datatype, we include the refcount for that type.
However, when we unflatten, we are essentially creating a new type.
So we need to reset the refcount back to 1.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
