### PR TITLE
Treat Fortran complex types as pairtypes

### DIFF
--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -33,9 +33,6 @@ builtin_maps = {
     "YAKSA_TYPE__UINT16_T": "int16_t",
     "YAKSA_TYPE__UINT32_T": "int32_t",
     "YAKSA_TYPE__UINT64_T": "int64_t",
-    "YAKSA_TYPE__C_COMPLEX": "float",
-    "YAKSA_TYPE__C_DOUBLE_COMPLEX": "double",
-    "YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX": "double",
     "YAKSA_TYPE__BYTE": "int8_t"
 }
 

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -32,9 +32,6 @@ builtin_maps = {
     "YAKSA_TYPE__UINT16_T": "int16_t",
     "YAKSA_TYPE__UINT32_T": "int32_t",
     "YAKSA_TYPE__UINT64_T": "int64_t",
-    "YAKSA_TYPE__C_COMPLEX": "float",
-    "YAKSA_TYPE__C_DOUBLE_COMPLEX": "double",
-    "YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX": "long_double",
     "YAKSA_TYPE__BYTE": "int8_t"
 }
 

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -154,6 +154,21 @@ typedef struct {
     int y;
 } yaksi_long_double_int_s;
 
+typedef struct {
+    float x;
+    float y;
+} yaksi_c_complex_s;
+
+typedef struct {
+    double x;
+    double y;
+} yaksi_c_double_complex_s;
+
+typedef struct {
+    long double x;
+    long double y;
+} yaksi_c_long_double_complex_s;
+
 
 /* post headers come after the type declarations */
 #include "yaksur_post.h"

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -160,9 +160,6 @@ int yaksa_init(yaksa_init_attr_t attr)
     INIT_BUILTIN(float, FLOAT, rc, fn_fail);
     INIT_BUILTIN(double, DOUBLE, rc, fn_fail);
     INIT_BUILTIN(long double, LONG_DOUBLE, rc, fn_fail);
-    INIT_BUILTIN(float, C_COMPLEX, rc, fn_fail);
-    INIT_BUILTIN(double, C_DOUBLE_COMPLEX, rc, fn_fail);
-    INIT_BUILTIN(long double, C_LONG_DOUBLE_COMPLEX, rc, fn_fail);
 
     INIT_BUILTIN_PAIRTYPE(float, int, yaksi_float_int_s, FLOAT_INT, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(double, int, yaksi_double_int_s, DOUBLE_INT, rc, fn_fail);
@@ -172,6 +169,10 @@ int yaksa_init(yaksa_init_attr_t attr)
     /* *INDENT-ON* */
     INIT_BUILTIN_PAIRTYPE(short, int, yaksi_short_int_s, SHORT_INT, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(long double, int, yaksi_long_double_int_s, LONG_DOUBLE_INT, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE(float, float, yaksi_c_complex_s, C_COMPLEX, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE(double, double, yaksi_c_double_complex_s, C_DOUBLE_COMPLEX, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE(long double, long double, yaksi_c_long_double_complex_s,
+                          C_LONG_DOUBLE_COMPLEX, rc, fn_fail);
 
     INIT_BUILTIN(uint8_t, BYTE, rc, fn_fail);
 


### PR DESCRIPTION
## Pull Request Description

These are contiguous, but cannot necessarily be represented as a
single C type.  They'd need to be represented by two C types in most
cases.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
