### PR TITLE
Always pack full elements, never partial

### DIFF
--- a/test/iov/iov.c
+++ b/test/iov/iov.c
@@ -261,6 +261,22 @@ int main(int argc, char **argv)
             }
         }
 
+        /* update the segment starts and lengths, so a basic type is
+         * not split across multiple segments */
+        uintptr_t basic_iov_len;
+        rc = yaksa_iov_len(1, dtp.DTP_base_type, &basic_iov_len);
+        assert(rc == YAKSA_SUCCESS);
+
+        for (int m = 0; m < segments; m++) {
+            while (segment_starts[m] % basic_iov_len) {
+                segment_starts[m]--;
+                segment_lengths[m]++;
+            }
+            while (segment_lengths[m] % basic_iov_len) {
+                segment_lengths[m]++;
+            }
+        }
+
         /* create the sobj iov and fill it with the segments */
         struct iovec *sobj_iov = (struct iovec *) malloc(sobj_iov_len * sizeof(struct iovec));
         struct iovec *sobj_tmp_iov = (struct iovec *) malloc(sobj_iov_len * sizeof(struct iovec));


### PR DESCRIPTION
## Pull Request Description

For pack/unpack, we always respected the basic type boundaries, so we never packed partial basic types.  But we were not doing the same for IOVs.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
