### PR TITLE
Add --enable-g as an alias for --enable-debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -109,8 +109,9 @@ AC_ARG_ENABLE([embedded],AS_HELP_STRING([--enable-embedded],[enables embedded bu
 AM_CONDITIONAL([EMBEDDED_BUILD], [test x${enable_embedded} = xyes])
 
 # --enable-debug
-AC_ARG_ENABLE([debug],AS_HELP_STRING([--enable-debug],[adds -g to CFLAGS]),,[enable_debug=no])
-if test "${enable_debug}" = "yes" ; then
+AC_ARG_ENABLE([g],AS_HELP_STRING([--enable-g],[alias for --enable-debug]),,[enable_g=no])
+AC_ARG_ENABLE([debug],AS_HELP_STRING([--enable-debug],[adds -g to CFLAGS]),,[enable_debug=${enable_g}])
+if test "${enable_debug}" != "no" ; then
     PAC_APPEND_FLAG([-g],[CFLAGS])
 fi
 


### PR DESCRIPTION
## Pull Request Description

When we are embedded in mpich, the debugging option might get passed
in as --enable-g instead of --enable-debug.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
