### PR TITLE
Unpack: return the actual number of unpacked bytes

### DIFF
--- a/examples/contig.c
+++ b/examples/contig.c
@@ -35,7 +35,9 @@ int main()
     assert(rc == YAKSA_SUCCESS);
 
     /* unpack */
-    rc = yaksa_iunpack(pack_buf, SIZE * sizeof(int), unpack_buf, 1, contig, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, SIZE * sizeof(int), unpack_buf, 1, contig, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/fuf.c
+++ b/examples/fuf.c
@@ -55,7 +55,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, size, unpack_buf, 1, unflatten_type, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, size, unpack_buf, 1, unflatten_type, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/hindexed.c
+++ b/examples/hindexed.c
@@ -42,7 +42,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, 21 * sizeof(int), unpack_buf, 1, hindexed, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, 21 * sizeof(int), unpack_buf, 1, hindexed, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/hindexed_block.c
+++ b/examples/hindexed_block.c
@@ -46,8 +46,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
+    uintptr_t actual_unpack_bytes;
     rc = yaksa_iunpack(pack_buf, ROWS * BLKLEN * sizeof(int), unpack_buf, 1, hindexed_block, 0,
-                       &request);
+                       &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/hvector.c
+++ b/examples/hvector.c
@@ -34,7 +34,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf, 1, hvector, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf, 1, hvector, 0,
+                       &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
@@ -51,7 +53,8 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf + 1, 1, hvector, 0, &request);
+    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf + 1, 1, hvector, 0,
+                       &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
@@ -76,7 +79,7 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, 256, unpack_buf, 1, hvector, 0, &request);
+    rc = yaksa_iunpack(pack_buf, 256, unpack_buf, 1, hvector, 0, &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/indexed.c
+++ b/examples/indexed.c
@@ -42,7 +42,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, 21 * sizeof(int), unpack_buf, 1, indexed, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, 21 * sizeof(int), unpack_buf, 1, indexed, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/indexed_block.c
+++ b/examples/indexed_block.c
@@ -41,8 +41,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
+    uintptr_t actual_unpack_bytes;
     rc = yaksa_iunpack(pack_buf, ROWS * BLKLEN * sizeof(int), unpack_buf, 1, indexed_block, 0,
-                       &request);
+                       &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/resized.c
+++ b/examples/resized.c
@@ -37,7 +37,8 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, 256, unpack_buf, 1, transpose, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, 256, unpack_buf, 1, transpose, 0, &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/subarray.c
+++ b/examples/subarray.c
@@ -40,7 +40,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, 16 * sizeof(int), unpack_buf, 1, subarray, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, 16 * sizeof(int), unpack_buf, 1, subarray, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/examples/vector.c
+++ b/examples/vector.c
@@ -34,7 +34,9 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf, 1, vector, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf, 1, vector, 0, &actual_unpack_bytes,
+                       &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
@@ -51,7 +53,8 @@ int main()
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf + 1, 1, vector, 0, &request);
+    rc = yaksa_iunpack(pack_buf, ROWS * sizeof(int), unpack_buf + 1, 1, vector, 0,
+                       &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
     rc = yaksa_request_wait(request);
     assert(rc == YAKSA_SUCCESS);

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -365,7 +365,7 @@ int yaksa_free(yaksa_type_t type);
  *                               (incount, type) tuple
  * \param[out] outbuf            Output buffer into which data is being packed
  * \param[in]  max_pack_bytes    Maximum number of bytes that can be packed in the output buffer
- * \param[out] actual_pack_bytes Actual number of bytes that were packed in the output buffer
+ * \param[out] actual_pack_bytes Actual number of bytes that were packed into the output buffer
  * \param[out] request           Request handle associated with the operation
  *                               (YAKSA_REQUEST__NULL if the request already completed)
  */
@@ -383,11 +383,13 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
  * \param[in]  type              Datatype representing the layout
  * \param[in]  outoffset         Number of bytes to skip from the layout represented by the
  *                               (incount, type) tuple
+ * \param[out] actual_unpack_bytes Actual number of bytes that were unpacked into the output buffer
  * \param[out] request           Request handle associated with the operation
  *                               (YAKSA_REQUEST__NULL if the request already completed)
  */
 int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                  yaksa_type_t type, uintptr_t outoffset, yaksa_request_t * request);
+                  yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                  yaksa_request_t * request);
 
 /*!
  * \brief tests to see if a request has completed

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -204,11 +204,13 @@ int yaksi_ipack_element(const void *inbuf, yaksi_type_s * type, uintptr_t inoffs
                         yaksi_request_s * request);
 
 int yaksi_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                  yaksi_type_s * type, uintptr_t outoffset, yaksi_request_s * request);
+                  yaksi_type_s * type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                  yaksi_request_s * request);
 int yaksi_iunpack_backend(const void *inbuf, void *outbuf, uintptr_t outcount, yaksi_type_s * type,
                           yaksi_request_s * request);
 int yaksi_iunpack_element(const void *inbuf, uintptr_t insize, void *outbuf, yaksi_type_s * type,
-                          uintptr_t outoffset, yaksi_request_s * request);
+                          uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                          yaksi_request_s * request);
 
 int yaksi_iov_len(uintptr_t count, yaksi_type_s * type, uintptr_t * iov_len);
 

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -10,7 +10,8 @@
 #include <assert.h>
 
 int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                  yaksa_type_t type, uintptr_t outoffset, yaksa_request_t * request)
+                  yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                  yaksa_request_t * request)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -34,7 +35,8 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
     rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = yaksi_iunpack(inbuf, insize, outbuf, outcount, yaksi_type, outoffset, yaksi_request);
+    rc = yaksi_iunpack(inbuf, insize, outbuf, outcount, yaksi_type, outoffset, actual_unpack_bytes,
+                       yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     int cc = yaksu_atomic_load(&yaksi_request->cc);

--- a/test/flatten/flatten.c
+++ b/test/flatten/flatten.c
@@ -133,8 +133,9 @@ int main(int argc, char **argv)
         rc = DTP_obj_buf_init(sobj, sbuf, -1, -1, basecount);
         assert(rc == DTP_SUCCESS);
 
+        uintptr_t actual_unpack_bytes;
         rc = yaksa_iunpack(tbuf, actual_pack_bytes, sbuf + sobj.DTP_buf_offset,
-                           sobj.DTP_type_count, newtype, 0, &request);
+                           sobj.DTP_type_count, newtype, 0, &actual_unpack_bytes, &request);
         assert(rc == YAKSA_SUCCESS);
 
         if (request != YAKSA_REQUEST__NULL) {

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -410,9 +410,12 @@ int main(int argc, char **argv)
             rc = yaksa_request_wait(request);
             assert(rc == YAKSA_SUCCESS);
 
+            uintptr_t actual_unpack_bytes;
             rc = yaksa_iunpack(tbuf, actual_pack_bytes, dbuf_d + dobj.DTP_buf_offset,
-                               dobj.DTP_type_count, dobj.DTP_datatype, segment_starts[j], &request);
+                               dobj.DTP_type_count, dobj.DTP_datatype, segment_starts[j],
+                               &actual_unpack_bytes, &request);
             assert(rc == YAKSA_SUCCESS);
+            assert(actual_pack_bytes == actual_unpack_bytes);
 
             rc = yaksa_request_wait(request);
             assert(rc == YAKSA_SUCCESS);

--- a/test/simple/simple_test.c
+++ b/test/simple/simple_test.c
@@ -55,7 +55,8 @@ int main()
         val += 71;
     }
 
-    rc = yaksa_iunpack(outbuf, actual, inbuf, 1, vector_vector, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(outbuf, actual, inbuf, 1, vector_vector, 0, &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
 
     rc = yaksa_request_wait(request);

--- a/test/simple/threaded_test.c
+++ b/test/simple/threaded_test.c
@@ -59,7 +59,8 @@ void *thread_fn(void *arg)
         val += 71;
     }
 
-    rc = yaksa_iunpack(outbuf, actual, inbuf, 1, vector_vector, 0, &request);
+    uintptr_t actual_unpack_bytes;
+    rc = yaksa_iunpack(outbuf, actual, inbuf, 1, vector_vector, 0, &actual_unpack_bytes, &request);
     assert(rc == YAKSA_SUCCESS);
 
     rc = yaksa_request_wait(request);


### PR DESCRIPTION
## Pull Request Description

When the user receives data in a pipelined fashion, it is possible
that the number of bytes received might not be able to fully fit a
basic datatype element.  In such cases, yaksa needs to tell the user
how much data was actually unpacked, so the user can keep track of the
remaining bytes.

Fixes pmodels/yaksa#67

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
