### PR TITLE
build: ignore unrecognized options to --enable-fast

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,10 +117,10 @@ fi
 
 # --enable-fast
 AC_ARG_ENABLE([fast],AS_HELP_STRING([--enable-fast=O<opt>],[adds -O<opt> to CFLAGS]),,[enable_fast=yes])
-if test "${enable_fast}" = "yes" ; then
-    PAC_APPEND_FLAG([-O2],[CFLAGS])
-elif test "${enable_fast}" != "no" ; then
+if test "`echo ${enable_fast} | cut -c1`" = "O" ; then
     PAC_APPEND_FLAG([-${enable_fast}],[CFLAGS])
+elif test "${enable_fast}" != "no" ; then
+    PAC_APPEND_FLAG([-O2],[CFLAGS])
 fi
 
 


### PR DESCRIPTION
## Pull Request Description

In embedded builds, the user might provide extra options to `--enable-fast`.  Ignore them.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
