### PR TITLE
build: avoid installing yaksa for embedded builds

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,12 +19,17 @@ noinst_PROGRAMS =
 nodist_noinst_SCRIPTS =
 dist_noinst_SCRIPTS = autogen.sh
 
+if EMBEDDED_BUILD
+noinst_LTLIBRARIES = libyaksa.la
+else
 lib_LTLIBRARIES = libyaksa.la
+endif !EMBEDDED_BUILD
+
 libyaksa_la_SOURCES =
 AM_CPPFLAGS =
 
 if EMBEDDED_BUILD
-libyaksa_la_LDFLAGS =
+libyaksa_la_LDFLAGS = -avoid-version
 else
 libyaksa_la_LDFLAGS = -version-info @libyaksa_so_version@
 endif !EMBEDDED_BUILD

--- a/src/frontend/include/Makefile.mk
+++ b/src/frontend/include/Makefile.mk
@@ -5,8 +5,13 @@
 
 AM_CPPFLAGS += -I$(top_srcdir)/src/frontend/include -I$(top_builddir)/src/frontend/include
 
+if EMBEDDED_BUILD
+noinst_HEADERS += \
+	src/frontend/include/yaksa.h
+else
 include_HEADERS += \
 	src/frontend/include/yaksa.h
+endif !EMBEDDED_BUILD
 
 noinst_HEADERS += \
 	src/frontend/include/yaksi.h


### PR DESCRIPTION
## Pull Request Description

This is needed on systems where installing the library disables embedding the library.  See pmodels/mpich#4496.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
