### PR TITLE
Optimizations for flattening of datatypes

### DIFF
--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -13,6 +13,27 @@ int yaksi_create_hindexed_block(int count, int blocklength, const intptr_t * arr
 {
     int rc = YAKSA_SUCCESS;
 
+    /* shortcut for vector types */
+    bool is_hvector = true;
+    if (array_of_displs[0])
+        is_hvector = false;
+    for (int i = 2; i < count; i++) {
+        if (array_of_displs[i] - array_of_displs[i - 1] != array_of_displs[1] - array_of_displs[0])
+            is_hvector = false;
+    }
+    if (is_hvector) {
+        if (count > 1) {
+            rc = yaksi_create_hvector(count, blocklength, array_of_displs[1] - array_of_displs[0],
+                                      intype, newtype);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = yaksi_create_hvector(count, blocklength, 0, intype, newtype);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        goto fn_exit;
+    }
+
+    /* regular hindexed type */
     yaksi_type_s *outtype;
     rc = yaksi_type_alloc(&outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -14,6 +14,20 @@ int yaksi_create_hindexed(int count, const int *array_of_blocklengths,
 {
     int rc = YAKSA_SUCCESS;
 
+    /* shortcut for hindexed_block types */
+    bool is_hindexed_block = true;
+    for (int i = 1; i < count; i++) {
+        if (array_of_blocklengths[i] != array_of_blocklengths[i - 1])
+            is_hindexed_block = false;
+    }
+    if (is_hindexed_block) {
+        rc = yaksi_create_hindexed_block(count, array_of_blocklengths[0], array_of_displs, intype,
+                                         newtype);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+        goto fn_exit;
+    }
+
+    /* regular hindexed type */
     yaksi_type_s *outtype;
     rc = yaksi_type_alloc(&outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -14,6 +14,20 @@ int yaksi_create_struct(int count, const int *array_of_blocklengths,
 {
     int rc = YAKSA_SUCCESS;
 
+    /* shortcut for hindexed types */
+    bool is_hindexed = true;
+    for (int i = 1; i < count; i++) {
+        if (array_of_intypes[i]->id != array_of_intypes[i - 1]->id)
+            is_hindexed = false;
+    }
+    if (is_hindexed) {
+        rc = yaksi_create_hindexed(count, array_of_blocklengths, array_of_displs,
+                                   array_of_intypes[0], newtype);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+        goto fn_exit;
+    }
+
+    /* regular struct type */
     yaksi_type_s *outtype;
     rc = yaksi_type_alloc(&outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);


### PR DESCRIPTION
## Pull Request Description

Flattening/unflattening of datatypes can be expensive when there are many child datatypes involved.  This is particularly true for structs, where the number of child datatypes can be arbitrarily large.  This PR optimizes flattening/unflattening in some cases.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
