### PR TITLE
Allow pack/unpack to switch to iov-based packing

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cudai_info_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cudai_info_hooks.c
@@ -5,10 +5,22 @@
 
 #include "yaksi.h"
 #include "yaksuri_cudai.h"
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
 
 int yaksuri_cudai_info_create_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_info_s *cuda;
+
+    cuda = (yaksuri_cudai_info_s *) malloc(sizeof(yaksuri_cudai_info_s));
+
+    /* set default values for info keys */
+    cuda->iov_pack_threshold = YAKSURI_CUDAI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+    cuda->iov_unpack_threshold = YAKSURI_CUDAI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+
+    info->backend.cuda.priv = (void *) cuda;
 
   fn_exit:
     return rc;
@@ -20,6 +32,8 @@ int yaksuri_cudai_info_free_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
 
+    free(info->backend.cuda.priv);
+
   fn_exit:
     return rc;
   fn_fail:
@@ -30,6 +44,15 @@ int yaksuri_cudai_info_keyval_append(yaksi_info_s * info, const char *key, const
                                      unsigned int vallen)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_info_s *cuda = (yaksuri_cudai_info_s *) info->backend.cuda.priv;
+
+    if (!strncmp(key, "yaksa_cuda_iov_pack_threshold", YAKSA_INFO_MAX_KEYLEN)) {
+        assert(vallen == sizeof(uintptr_t));
+        cuda->iov_pack_threshold = (uintptr_t) val;
+    } else if (!strncmp(key, "yaksa_cuda_iov_unpack_threshold", YAKSA_INFO_MAX_KEYLEN)) {
+        assert(vallen == sizeof(uintptr_t));
+        cuda->iov_unpack_threshold = (uintptr_t) val;
+    }
 
   fn_exit:
     return rc;

--- a/src/backend/cuda/include/yaksuri_cuda_pre.h
+++ b/src/backend/cuda/include/yaksuri_cuda_pre.h
@@ -14,6 +14,8 @@ typedef struct {
     void *priv;
 } yaksuri_cuda_type_s;
 
-typedef int yaksuri_cuda_info_s;
+typedef struct {
+    void *priv;
+} yaksuri_cuda_info_s;
 
 #endif /* YAKSURI_CUDA_PRE_H_INCLUDED */

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -91,6 +91,13 @@ typedef struct yaksuri_cudai_type_s {
     uintptr_t num_elements;
 } yaksuri_cudai_type_s;
 
+#define YAKSURI_CUDAI_INFO__DEFAULT_IOV_PUP_THRESHOLD   (16384)
+
+typedef struct {
+    uintptr_t iov_pack_threshold;
+    uintptr_t iov_unpack_threshold;
+} yaksuri_cudai_info_s;
+
 int yaksuri_cudai_finalize_hook(void);
 int yaksuri_cudai_type_create_hook(yaksi_type_s * type);
 int yaksuri_cudai_type_free_hook(yaksi_type_s * type);

--- a/src/backend/seq/hooks/yaksuri_seq_hooks.c
+++ b/src/backend/seq/hooks/yaksuri_seq_hooks.c
@@ -7,6 +7,8 @@
 #include "yaksu.h"
 #include "yaksuri_seqi.h"
 #include <stdlib.h>
+#include <assert.h>
+#include <string.h>
 
 int yaksuri_seq_init_hook(void)
 {
@@ -44,16 +46,51 @@ int yaksuri_seq_type_free_hook(yaksi_type_s * type)
 
 int yaksuri_seq_info_create_hook(yaksi_info_s * info)
 {
-    return YAKSA_SUCCESS;
+    int rc = YAKSA_SUCCESS;
+    yaksuri_seqi_info_s *seq;
+
+    seq = (yaksuri_seqi_info_s *) malloc(sizeof(yaksuri_seqi_info_s));
+
+    /* set default values for info keys */
+    seq->iov_pack_threshold = YAKSURI_SEQI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+    seq->iov_unpack_threshold = YAKSURI_SEQI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+
+    info->backend.seq.priv = (void *) seq;
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
 }
 
 int yaksuri_seq_info_free_hook(yaksi_info_s * info)
 {
-    return YAKSA_SUCCESS;
+    int rc = YAKSA_SUCCESS;
+
+    free(info->backend.seq.priv);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
 }
 
 int yaksuri_seq_info_keyval_append(yaksi_info_s * info, const char *key, const void *val,
                                    unsigned int vallen)
 {
-    return YAKSA_SUCCESS;
+    int rc = YAKSA_SUCCESS;
+    yaksuri_seqi_info_s *seq = (yaksuri_seqi_info_s *) info->backend.seq.priv;
+
+    if (!strncmp(key, "yaksa_seq_iov_pack_threshold", YAKSA_INFO_MAX_KEYLEN)) {
+        assert(vallen == sizeof(uintptr_t));
+        seq->iov_pack_threshold = (uintptr_t) val;
+    } else if (!strncmp(key, "yaksa_seq_iov_unpack_threshold", YAKSA_INFO_MAX_KEYLEN)) {
+        assert(vallen == sizeof(uintptr_t));
+        seq->iov_unpack_threshold = (uintptr_t) val;
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
 }

--- a/src/backend/seq/include/yaksuri_seq_pre.h
+++ b/src/backend/seq/include/yaksuri_seq_pre.h
@@ -14,6 +14,8 @@ typedef struct {
     void *priv;
 } yaksuri_seq_type_s;
 
-typedef int yaksuri_seq_info_s;
+typedef struct {
+    void *priv;
+} yaksuri_seq_info_s;
 
 #endif /* YAKSURI_SEQ_PRE_H_INCLUDED */

--- a/src/backend/seq/include/yaksuri_seqi.h
+++ b/src/backend/seq/include/yaksuri_seqi.h
@@ -13,6 +13,13 @@ typedef struct yaksuri_seqi_type_s {
     int (*unpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s *);
 } yaksuri_seqi_type_s;
 
+#define YAKSURI_SEQI_INFO__DEFAULT_IOV_PUP_THRESHOLD   (16384)
+
+typedef struct {
+    uintptr_t iov_pack_threshold;
+    uintptr_t iov_unpack_threshold;
+} yaksuri_seqi_info_s;
+
 int yaksuri_seqi_populate_pupfns(yaksi_type_s * type);
 
 #endif /* YAKSURI_SEQI_H_INCLUDED */

--- a/src/backend/seq/pup/yaksuri_seq_pup.c
+++ b/src/backend/seq/pup/yaksuri_seq_pup.c
@@ -6,6 +6,9 @@
 #include <string.h>
 #include "yaksi.h"
 #include "yaksuri_seqi.h"
+#include <assert.h>
+
+#define MAX_IOV_LENGTH (16384)
 
 int yaksuri_seq_pup_is_supported(yaksi_type_s * type, bool * is_supported)
 {
@@ -26,8 +29,47 @@ int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_in
     int rc = YAKSA_SUCCESS;
     yaksuri_seqi_type_s *seq_type = (yaksuri_seqi_type_s *) type->backend.seq.priv;
 
+    uintptr_t iov_pack_threshold = YAKSURI_SEQI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+    if (info) {
+        yaksuri_seqi_info_s *seq_info = (yaksuri_seqi_info_s *) info->backend.seq.priv;
+        iov_pack_threshold = seq_info->iov_pack_threshold;
+    }
+
     if (type->is_contig) {
         memcpy(outbuf, (const char *) inbuf + type->true_lb, type->size * count);
+    } else if (type->size / type->num_contig >= iov_pack_threshold) {
+        struct iovec iov[MAX_IOV_LENGTH];
+        uintptr_t actual_iov_len;
+
+        if (type->num_contig * count <= MAX_IOV_LENGTH) {
+            rc = yaksi_iov(inbuf, count, type, 0, iov, MAX_IOV_LENGTH, &actual_iov_len);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+            assert(actual_iov_len == type->num_contig * count);
+
+            char *dbuf = (char *) outbuf;
+            for (uintptr_t i = 0; i < actual_iov_len; i++) {
+                memcpy(dbuf, iov[i].iov_base, iov[i].iov_len);
+                dbuf += iov[i].iov_len;
+            }
+        } else if (type->num_contig <= MAX_IOV_LENGTH) {
+            uintptr_t iov_offset = 0;
+            char *dbuf = (char *) outbuf;
+            const char *sbuf = (const char *) inbuf;
+            for (uintptr_t i = 0; i < count; i++) {
+                rc = yaksi_iov(sbuf, 1, type, iov_offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+                assert(actual_iov_len == type->num_contig);
+
+                for (uintptr_t j = 0; j < actual_iov_len; j++) {
+                    memcpy(dbuf, iov[j].iov_base, iov[j].iov_len);
+                    dbuf += iov[j].iov_len;
+                }
+
+                sbuf += type->extent;
+            }
+        } else {
+            rc = YAKSA_ERR__NOT_SUPPORTED;
+        }
     } else if (seq_type->pack) {
         rc = seq_type->pack(inbuf, outbuf, count, type);
         YAKSU_ERR_CHECK(rc, fn_fail);
@@ -47,8 +89,47 @@ int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     int rc = YAKSA_SUCCESS;
     yaksuri_seqi_type_s *seq_type = (yaksuri_seqi_type_s *) type->backend.seq.priv;
 
+    uintptr_t iov_unpack_threshold = YAKSURI_SEQI_INFO__DEFAULT_IOV_PUP_THRESHOLD;
+    if (info) {
+        yaksuri_seqi_info_s *seq_info = (yaksuri_seqi_info_s *) info->backend.seq.priv;
+        iov_unpack_threshold = seq_info->iov_unpack_threshold;
+    }
+
     if (type->is_contig) {
         memcpy((char *) outbuf + type->true_lb, inbuf, type->size * count);
+    } else if (type->size / type->num_contig >= iov_unpack_threshold) {
+        struct iovec iov[MAX_IOV_LENGTH];
+        uintptr_t actual_iov_len;
+
+        if (type->num_contig * count <= MAX_IOV_LENGTH) {
+            rc = yaksi_iov(outbuf, count, type, 0, iov, MAX_IOV_LENGTH, &actual_iov_len);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+            assert(actual_iov_len == type->num_contig * count);
+
+            const char *sbuf = (const char *) inbuf;
+            for (uintptr_t i = 0; i < actual_iov_len; i++) {
+                memcpy(iov[i].iov_base, sbuf, iov[i].iov_len);
+                sbuf += iov[i].iov_len;
+            }
+        } else if (type->num_contig <= MAX_IOV_LENGTH) {
+            uintptr_t iov_offset = 0;
+            char *dbuf = (char *) outbuf;
+            const char *sbuf = (const char *) inbuf;
+            for (uintptr_t i = 0; i < count; i++) {
+                rc = yaksi_iov(dbuf, 1, type, iov_offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+                assert(actual_iov_len == type->num_contig);
+
+                for (uintptr_t j = 0; j < actual_iov_len; j++) {
+                    memcpy(iov[j].iov_base, sbuf, iov[j].iov_len);
+                    sbuf += iov[j].iov_len;
+                }
+
+                dbuf += type->extent;
+            }
+        } else {
+            rc = YAKSA_ERR__NOT_SUPPORTED;
+        }
     } else if (seq_type->unpack) {
         rc = seq_type->unpack(inbuf, outbuf, count, type);
         YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -218,6 +218,8 @@ int yaksi_iunpack_element(const void *inbuf, uintptr_t insize, void *outbuf, yak
                           yaksi_info_s * info, yaksi_request_s * request);
 
 int yaksi_iov_len(uintptr_t count, yaksi_type_s * type, uintptr_t * iov_len);
+int yaksi_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t iov_offset,
+              struct iovec *iov, uintptr_t max_iov_len, uintptr_t * actual_iov_len);
 
 int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size);
 

--- a/src/frontend/iov/yaksa_iov.c
+++ b/src/frontend/iov/yaksa_iov.c
@@ -45,8 +45,8 @@
         }                                                               \
     } while (0)
 
-static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t iov_offset,
-                  struct iovec *iov, uintptr_t max_iov_len, uintptr_t * actual_iov_len)
+int yaksi_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t iov_offset,
+              struct iovec *iov, uintptr_t max_iov_len, uintptr_t * actual_iov_len)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -130,8 +130,9 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                         } else {
                             uintptr_t tmp_iov_len;
 
-                            rc = to_iov(rem_buf, type->u.hvector.blocklength, type->u.hvector.child,
-                                        rem_iov_offset, rem_iov, rem_iov_len, &tmp_iov_len);
+                            rc = yaksi_iov(rem_buf, type->u.hvector.blocklength,
+                                           type->u.hvector.child, rem_iov_offset, rem_iov,
+                                           rem_iov_len, &tmp_iov_len);
                             YAKSU_ERR_CHECK(rc, fn_fail);
 
                             rem_iov_len -= tmp_iov_len;
@@ -173,9 +174,9 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                                 type->u.blkhindx.array_of_displs[j];
                             uintptr_t tmp_iov_len;
 
-                            rc = to_iov(rem_buf, type->u.blkhindx.blocklength,
-                                        type->u.blkhindx.child, rem_iov_offset, rem_iov,
-                                        rem_iov_len, &tmp_iov_len);
+                            rc = yaksi_iov(rem_buf, type->u.blkhindx.blocklength,
+                                           type->u.blkhindx.child, rem_iov_offset, rem_iov,
+                                           rem_iov_len, &tmp_iov_len);
                             YAKSU_ERR_CHECK(rc, fn_fail);
 
                             rem_iov_len -= tmp_iov_len;
@@ -215,9 +216,9 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                                 type->u.hindexed.array_of_displs[j];
                             uintptr_t tmp_iov_len;
 
-                            rc = to_iov(rem_buf, type->u.hindexed.array_of_blocklengths[j],
-                                        type->u.hindexed.child, rem_iov_offset, rem_iov,
-                                        rem_iov_len, &tmp_iov_len);
+                            rc = yaksi_iov(rem_buf, type->u.hindexed.array_of_blocklengths[j],
+                                           type->u.hindexed.child, rem_iov_offset, rem_iov,
+                                           rem_iov_len, &tmp_iov_len);
                             YAKSU_ERR_CHECK(rc, fn_fail);
 
                             rem_iov_len -= tmp_iov_len;
@@ -257,9 +258,9 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                                 type->u.str.array_of_displs[j];
                             uintptr_t tmp_iov_len;
 
-                            rc = to_iov(rem_buf, type->u.str.array_of_blocklengths[j],
-                                        type->u.str.array_of_types[j], rem_iov_offset, rem_iov,
-                                        rem_iov_len, &tmp_iov_len);
+                            rc = yaksi_iov(rem_buf, type->u.str.array_of_blocklengths[j],
+                                           type->u.str.array_of_types[j], rem_iov_offset, rem_iov,
+                                           rem_iov_len, &tmp_iov_len);
                             YAKSU_ERR_CHECK(rc, fn_fail);
 
                             rem_iov_len -= tmp_iov_len;
@@ -292,8 +293,8 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                     } else {
                         uintptr_t tmp_iov_len;
 
-                        rc = to_iov(rem_buf, 1, type->u.resized.child, rem_iov_offset, rem_iov,
-                                    rem_iov_len, &tmp_iov_len);
+                        rc = yaksi_iov(rem_buf, 1, type->u.resized.child, rem_iov_offset, rem_iov,
+                                       rem_iov_len, &tmp_iov_len);
                         YAKSU_ERR_CHECK(rc, fn_fail);
 
                         rem_iov_len -= tmp_iov_len;
@@ -312,8 +313,8 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
 
         case YAKSI_TYPE_KIND__CONTIG:
             {
-                rc = to_iov(buf, count * type->u.contig.count, type->u.contig.child,
-                            iov_offset, iov, max_iov_len, actual_iov_len);
+                rc = yaksi_iov(buf, count * type->u.contig.count, type->u.contig.child,
+                               iov_offset, iov, max_iov_len, actual_iov_len);
                 YAKSU_ERR_CHECK(rc, fn_fail);
             }
             break;
@@ -336,8 +337,8 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
                     } else {
                         uintptr_t tmp_iov_len;
 
-                        rc = to_iov(rem_buf, 1, primary, rem_iov_offset, rem_iov, rem_iov_len,
-                                    &tmp_iov_len);
+                        rc = yaksi_iov(rem_buf, 1, primary, rem_iov_offset, rem_iov, rem_iov_len,
+                                       &tmp_iov_len);
                         YAKSU_ERR_CHECK(rc, fn_fail);
 
                         rem_iov_len -= tmp_iov_len;
@@ -352,8 +353,8 @@ static int to_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr
             break;
 
         case YAKSI_TYPE_KIND__DUP:
-            rc = to_iov(buf, count, type->u.dup.child, iov_offset, iov, max_iov_len,
-                        actual_iov_len);
+            rc = yaksi_iov(buf, count, type->u.dup.child, iov_offset, iov, max_iov_len,
+                           actual_iov_len);
             YAKSU_ERR_CHECK(rc, fn_fail);
             break;
     }
@@ -375,7 +376,7 @@ int yaksa_iov(const char *buf, uintptr_t count, yaksa_type_t type, uintptr_t iov
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = to_iov(buf, count, yaksi_type, iov_offset, iov, max_iov_len, actual_iov_len);
+    rc = yaksi_iov(buf, count, yaksi_type, iov_offset, iov, max_iov_len, actual_iov_len);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

This PR allows pack/unpack to use kernel-based or IOV-based packing/unpacking depending on datatype density.  It also allows users to tune the threshold for the switchover using info arguments.

This is more important for GPU-based pack/unpack, where IOV-based packing can be done entirely with GPU memcpy operations instead of launching a kernel.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
