### PR TITLE
Several warning squashes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,7 @@ Backends supported: ${supported_backends}
 ${backend_info}
 
 ##################################################################
-# End of yaksa build
+# End of yaksa configure
 ##################################################################
 
 EOF

--- a/m4/aclocal_cc.m4
+++ b/m4/aclocal_cc.m4
@@ -534,14 +534,19 @@ if test "$enable_strict_done" != "yes" ; then
         -Wold-style-definition
         -Wno-multichar
         -Wno-deprecated-declarations
-        -Wpacked
         -Wnested-externs
         -Winvalid-pch
         -Wno-pointer-sign
         -Wvariadic-macros
-        -Wno-format-zero-length
-	-Wno-type-limits
+        -Wtype-limits
         -Werror-implicit-function-declaration
+        -Wstack-usage=262144
+        -Wredundant-decls
+        -Waggregate-return
+        -Werror-implicit-function-declaration
+        -Wcast-align
+        -Wpacked
+        -Wshorten-64-to-32
     "
 
     enable_c89=no
@@ -585,14 +590,6 @@ if test "$enable_strict_done" != "yes" ; then
 		enable_strict_done="yes"
 		enable_opt=no
 		;;
-             extra)
-                pac_common_strict_flags="$pac_common_strict_flags
-                    -Wredundant-decls
-                    -Waggregate-return
-                    -Werror-implicit-function-declaration
-                    -Wcast-align
-                    -Wshorten-64-to-32"
-                ;;
 	     all|yes)
 		enable_strict_done="yes"
 		enable_c99=yes

--- a/maint/clmake
+++ b/maint/clmake
@@ -1,0 +1,251 @@
+#! /usr/bin/env perl
+##
+## Copyright (C) by Argonne National Laboratory
+##     See COPYRIGHT in top-level directory
+##
+
+# Set Defaults
+$debug = 0;
+$debugDir = 0;
+$gDebugOther = 0;
+
+$summaryOutput = 0;
+$terseOutput = 1;
+$rootSrcDir = "";
+# Define the known commands, along with known make noise (results of
+# echo)
+# We include /bin/rm and /bin/mv because some Makefile authors prefer
+# to get the full path for these routines
+@commands = ( "cc", "pgcc", "gcc", "icc", "acc", 
+              "rm", "mv", "cp", "ar", "ranlib", "perl", "for", 
+	      "/bin/rm", "/bin/mv", "/bin/cp", "/bin/chmod",
+	      "rm", "mv", "cp", "chmod",
+	      "if", "make", "gnumake", 
+	      "[A-Za-z0-9_\/\.-]*\/mpicc",
+	      "[A-Za-z0-9_\/\.-]*\/mpifort",
+	      "[A-Za-z0-9_\/\.-]*\/mpicxx",
+	      "cleaning", "sleep", "date", "g77", "f77", "f90", "f95", "pgCC",
+	      "pgf77", "pgf90", "CC", "g95", "g\\+\\+", "c\\+\\+",
+	      "acc\\+\\+", "xlc", "xlf", "xlC", "xlf90", "gfortran", 
+	      "ifort", "ifc", "test",
+	      "true", "false", "/[A-Za-z0-9_\/\.-]*createshlib", 
+	      "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+\(--tag=\\w+\)*\\s+--mode=\\w+",
+	      "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--mode=\\w+",
+	      "/bin/sh\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
+	      "/bin/bash\\s+[A-Za-z0-9_\/\.-]*libtool\\s+--finish",
+	      "libtool:\\s+compile:",
+	      "libtool:\\s+link:",
+	      "libtool:\\s+install:",
+	      "libtool:\\s+finish:",
+	      "[A-Za-z0-9_\/-]*\/icc",
+	      "[A-Za-z0-9_\/-]*\/install-sh",
+	      "/usr/bin/ar", "mkdir",
+              "/bin/mkdir",
+              "/.*bin/mkdir",
+	      "/usr/ucb/ld",
+	      "mpicc", "mpicxx",
+	      "compiling ROMIO in", 
+	      "Make completed",
+	      "echo", "cat",
+	      "CC", "CCLD", "AR", "RANLIB", "LIBTOOL", "MV", 
+              "MOD", "GEN", "F77", "FC", "CXXLD", "CXX", "FCLD",
+	      "CP", # "terse" make versions
+	      "\\(?cd",
+	      "\\(\\s*cd",
+	      "creating\s+lib.*",
+	      "cd\\s+\&\&\\s+make",
+	      "sed -e",
+	      "PATH=\"\\\$PATH.*\\sldconfig\\s",
+	      "building profiling interface in directory",
+	      "/usr/bin/install",
+              "/.*bin/install",
+              ".*confdb/install-sh",
+	      "Copying Upshot",
+	      "Cleaning directory",
+	      "[*][*][*][*] Making .*\.\.\.\.",
+	      "Making .* in .*",
+	      "Making upshot", "\\s*\$",
+              "ld: warning: directory not found for option '-L\\S*src/mpl'",
+              "ld: warning: directory not found for option '-L\\S*src/openpa/src'",
+	      "copying selected object files to avoid basename conflicts...",
+);
+
+# OtherNoise is an array of patterns that describe blocks of
+# text that we'd like to skip.  The initial use it to handle 
+# libtool install output.
+# The PG entries are work-arounds for bugs in the PG header files that have
+# small incompatibilities with the system header file /usr/include/unistd.h
+#
+@OtherNoise = ( 'Libraries have been installed in:<SEP>more information, such as the ld\(1\) and ld.so\(8\) manual pages.<SEP>20',
+		'^\s*-+\s*$<SEP><SEP>1', 
+		'^In directory:<SEP><SEP>1',
+		'^creating\s<SEP><SEP>1', 
+#		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 189<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 189<SEP>2',
+#		'^PGC-W-0114-More than one type.*/usr/include/unistd.h: 243<SEP>^PGC-W-0143-Useless typedef.*/usr/include/unistd.h: 243<SEP>2',
+		'^PGC.*: compilation completed with warnings<SEP><SEP>1',
+# This next is a general version to handle all of these mistakes
+		'^PGC-W-0114-More than one type specified.*/usr/include<SEP>^PGC-W-0143-Useless typedef declaration \(no declarators present\).*/usr/include<SEP>2',
+		'copying python',
+		'LOOP WAS VECTORIZED',
+		'Using variables ',
+		);
+# In the past, we also needed
+# WARNING 84.*not used for resolving any symbol
+# Info: File not optimized
+
+
+$trimCompileLine = 1;
+
+# Create the variables that keep track of state
+# dirstack keeps the directory name that gnumake and similar make
+# implementations echo as a directory is entered or exited (this can generate
+# a great deal of output noise that can obscure important data.  However, when
+# a problem *does* occur, this directory information is valuable.
+# dirprinted is a parallel array that indicates whether the corresponding
+# directory entry has been printed.
+@dirstack = ();
+@dirprinted = ();
+
+# Process arguments to select options
+foreach $_ (@ARGV) {
+    if (/^--?debug/) { $debug = 1; }
+    elsif (/^--?showdir/) { $debugDir = 1; }
+    elsif (/^--?summary/) { $summaryOutput = 1; }
+    elsif (/^--?notrimcompileline/) { $trimCompileLine = 0; }
+    elsif (/^-/) {
+	print STDERR "Unrecognized argument $_\n";
+	print STDERR "clmake [ -debug ] [ -showdir ] [ -summary ]\n";
+	exit(1);
+    }
+    else { last; }
+    shift @ARGV;
+}
+# Read lines.  Categorize lines as commands and output.  This
+# script suppresses commands that generate no extra output.
+# The approach is to read a line and then read the next line.
+# While the line is a command and the next line is not, output the
+# line.
+#
+# We use eof() (see man perlfun) so that we can accept filenames on the
+# commandline.
+#
+$cmdline = "";
+T:
+while ($line = <>) {
+    if (eof()) { next; }
+
+    $line =~ s/\r//;    # remove returns from line (de DOSify)
+
+    # Read the next line, including handling any continuation lines
+    while ($line =~ /\\$/) {
+	print "Read continuation line (cmd) ... \n" if $debug;
+	$line .= <>;
+    }
+
+    # Check for noise
+    foreach my $pat (@OtherNoise) {
+	# maxlines is the maximum number of lines to match
+	my ($beginpat,$endpat,$maxlines) = split( '<SEP>', $pat );
+	print "Trying to match $beginpat\n" if $gDebugOther;
+	if ($line =~ /$beginpat/) {
+	    $maxlines --;
+	    print "Found match to $beginpat\n" if $gDebugOther;
+	    # Found the beginning.  Look for the end (if one requested)
+	    if ($endpat =~ /\S/) {
+		print "Trying to match endpat $endpat\n" if $gDebugOther;
+		while ($line = <>) {
+		    if (eof()) { last; }
+		    print "Trying to match to $line" if $gDebugOther;
+		    if ($line =~ /$endpat/) { last; }
+		    if ($maxlines-- <= 0) { 
+			print STDOUT "Failed to match $endpat; last line was $line";
+			last; 
+		    }
+		}
+	    }
+	    next T;
+	}
+    }
+    
+    # Is the line a command (including a directory change?)
+    # Check first for a directory change
+    if ($line =~ /^\s*make.* Entering directory \`([^\']*)\'/) {
+	my $dirname = $1;
+	$dirstack[$#dirstack+1] = $dirname;
+	$dirprinted[$#dirprinted+1] = 0;
+	print ">>entering $dirname\n" if $debugDir;
+	$cmdline = "";
+	next;
+    }
+    elsif ($line =~ /^\s*make.* Leaving directory \`([^\']*)\'/) {
+	# We should check that the directory names match
+	my $dirname = $1;
+	print ">>leaving $dirname\n" if $debugDir;
+	if ($dirname ne $dirstack[$#dirstack]) {
+	    print STDERR "Warning: leaving directory $dirname but expected to leave directory " . $dirstack[$#dirstack] . "\n";
+	}
+	$#dirstack--;
+	$#dirprinted--;
+	$cmdline = "";
+	next;
+    }
+    else {
+	$is_command = 0;
+	foreach $cmdname (@commands) {
+	    if ($line =~ /^\s*$cmdname\W/) {
+		$is_command = 1;
+		$cmdline = $line;
+		last;
+	    }
+	}
+	if ($is_command) { 
+	    if ($summaryOutput) {
+		# FIXME: Summarize the command
+		if ($terseOutput) {
+		    if ($rootSrcDir eq "") {
+			if ($line =~ /\s(\/\S+\/src\/)/) {
+			    $rootSrcDir = $1;
+			    print "rootSrcDir = $rootSrcDir\n";
+			}
+		    }
+		    else {
+			$line =~ s/$rootSrcDir//g;
+		    }
+		    # Compiler options to remove
+		    $line =~ s/-I\S+\s+//g;
+		    $line =~ s/-W\S+\s+//g;
+		    $line =~ s/-D\S+\s+//g;
+		}
+		print $line;
+	    }
+	    next; 
+	}
+    }
+
+    # If we got to this point, the line was not a recognized command or
+    # ignorable output.  Output the line, including the command if this 
+    # is the first time.  We can then forget the command 
+    if ($#dirstack >= 0 && $dirprinted[$#dirstack] == 0) {
+	print "In directory: ". $dirstack[$#dirstack] . "\n";
+	$dirprinted[$#dirstack] = 1;
+    }
+    if ($cmdline ne "") { 
+	if ($trimCompileLine) {
+	    # Simplify the command line before printing
+	    $cmdline =~ s/-I\S*\s+//g;
+	    $cmdline =~ s/-ansi//g;
+	    $cmdline =~ s/-W\S*\s+//g;
+	    $cmdline =~ s/-DHAVE_CONFIG_H//g;
+	    $cmdline =~ s/-DGCC_WALL//g;
+	}
+	# We could print a newline here to separate commands
+	print $cmdline;
+	$cmdline = "";
+    }
+    print $line;
+}
+
+#
+# ToDo:
+# Handle lines containing just ----, e.g., patterns of the form
+# -*

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -28,7 +28,10 @@ int yaksur_init_hook(void)
 
 
     /* final setup for all backends */
-    for (id = YAKSURI_GPUDRIVER_ID__UNSET + 1; id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+    for (id = YAKSURI_GPUDRIVER_ID__UNSET; id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             yaksuri_global.gpudriver[id].host.slab = NULL;
             yaksuri_global.gpudriver[id].host.slab_head_offset = 0;
@@ -61,8 +64,11 @@ int yaksur_finalize_hook(void)
     rc = yaksuri_seq_finalize_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             if (yaksuri_global.gpudriver[id].host.slab) {
                 yaksuri_global.gpudriver[id].info->host_free(yaksuri_global.gpudriver[id].
@@ -100,8 +106,11 @@ int yaksur_type_create_hook(yaksi_type_s * type)
     rc = yaksuri_seq_type_create_hook(type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             rc = yaksuri_global.gpudriver[id].info->type_create(type);
             YAKSU_ERR_CHECK(rc, fn_fail);
@@ -121,8 +130,11 @@ int yaksur_type_free_hook(yaksi_type_s * type)
     rc = yaksuri_seq_type_free_hook(type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             rc = yaksuri_global.gpudriver[id].info->type_free(type);
             YAKSU_ERR_CHECK(rc, fn_fail);
@@ -175,8 +187,11 @@ int yaksur_info_create_hook(yaksi_info_s * info)
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             rc = yaksuri_global.gpudriver[id].info->info_create(info);
             YAKSU_ERR_CHECK(rc, fn_fail);
@@ -196,8 +211,11 @@ int yaksur_info_free_hook(yaksi_info_s * info)
     rc = yaksuri_seq_info_free_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             rc = yaksuri_global.gpudriver[id].info->info_free(info);
             YAKSU_ERR_CHECK(rc, fn_fail);
@@ -218,8 +236,11 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
     rc = yaksuri_seq_info_keyval_append(info, key, val, vallen);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET + 1;
+    for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
+        if (id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[id].info) {
             rc = yaksuri_global.gpudriver[id].info->info_keyval_append(info, key, val, vallen);
             YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -14,7 +14,10 @@ static int get_ptr_attr(const void *buf, yaksur_ptr_attr_s * ptrattr, yaksuri_gp
     int rc = YAKSA_SUCCESS;
 
     /* Each GPU backend can claim "ownership" of the input buffer */
-    for (*id = YAKSURI_GPUDRIVER_ID__UNSET + 1; *id < YAKSURI_GPUDRIVER_ID__LAST; (*id)++) {
+    for (*id = YAKSURI_GPUDRIVER_ID__UNSET; *id < YAKSURI_GPUDRIVER_ID__LAST; (*id)++) {
+        if (*id == YAKSURI_GPUDRIVER_ID__UNSET)
+            continue;
+
         if (yaksuri_global.gpudriver[*id].info) {
             rc = yaksuri_global.gpudriver[*id].info->get_ptr_attr(buf, ptrattr);
             YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -16,7 +16,7 @@ static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
     const char *flatbuf = (const char *) flattened_type;
 
     if (((yaksi_type_s *) flattened_type)->kind == YAKSI_TYPE_KIND__BUILTIN) {
-        int id = ((yaksi_type_s *) flattened_type)->id;
+        yaksa_type_t id = ((yaksi_type_s *) flattened_type)->id;
         yaksi_type_s *tmp;
         rc = yaksi_type_get(id, &tmp);
         YAKSU_ERR_CHECK(rc, fn_fail);
@@ -30,7 +30,7 @@ static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
         /* don't overwrite the local ID with the unflattened type ID,
          * which potentially belongs to a different process or a
          * different type. */
-        unsigned int local_id;
+        yaksa_type_t local_id;
         local_id = newtype->id;
         memcpy(newtype, flatbuf, sizeof(yaksi_type_s));
         flatbuf += sizeof(yaksi_type_s);

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -12,7 +12,7 @@
 static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
 {
     int rc = YAKSA_SUCCESS;
-    yaksi_type_s *newtype;
+    yaksi_type_s *newtype = NULL;
     const char *flatbuf = (const char *) flattened_type;
 
     if (((yaksi_type_s *) flattened_type)->kind == YAKSI_TYPE_KIND__BUILTIN) {

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <stdint.h>
+#include <limits.h>
 
 #define INIT_BUILTIN(c_type, TYPE, rc, fn_fail)                         \
     do {                                                                \
@@ -95,7 +96,7 @@ int yaksa_init(yaksa_init_attr_t attr)
     int rc = YAKSA_SUCCESS;
 
     /* initialize the type pool */
-    rc = yaksu_pool_alloc(sizeof(yaksi_type_s), CHUNK_SIZE, UINTPTR_MAX, malloc, free,
+    rc = yaksu_pool_alloc(sizeof(yaksi_type_s), CHUNK_SIZE, UINT_MAX, malloc, free,
                           &yaksi_global.type_pool);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -112,7 +113,7 @@ int yaksa_init(yaksa_init_attr_t attr)
     }
 
     /* initialize the request pool */
-    rc = yaksu_pool_alloc(sizeof(yaksi_request_s), CHUNK_SIZE, UINTPTR_MAX, malloc, free,
+    rc = yaksu_pool_alloc(sizeof(yaksi_request_s), CHUNK_SIZE, UINT_MAX, malloc, free,
                           &yaksi_global.request_pool);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -102,7 +102,7 @@ int yaksa_init(yaksa_init_attr_t attr)
     /* these are the first set of allocations for our builtin
      * datatypes, so the indices should match that of the datatype
      * themselves */
-    for (int i = 0; i < YAKSI_TYPE__LAST; i++) {
+    for (yaksa_type_t i = YAKSA_TYPE__NULL; i < YAKSI_TYPE__LAST; i++) {
         struct yaksi_type_s *type;
 
         rc = yaksi_type_alloc(&type);
@@ -119,7 +119,7 @@ int yaksa_init(yaksa_init_attr_t attr)
     /* these are the first set of allocations for our builtin
      * requests, so the indices should match that of the request
      * themselves */
-    for (int i = 0; i < YAKSI_REQUEST__LAST; i++) {
+    for (yaksa_request_t i = YAKSA_REQUEST__NULL; i < YAKSI_REQUEST__LAST; i++) {
         struct yaksi_request_s *request;
 
         rc = yaksi_request_create(&request);
@@ -219,7 +219,7 @@ int yaksa_finalize(void)
 
 
     /* free the builtin datatypes */
-    for (int i = 0; i < YAKSI_TYPE__LAST; i++) {
+    for (yaksa_type_t i = YAKSA_TYPE__NULL; i < YAKSI_TYPE__LAST; i++) {
         yaksi_type_s *type;
 
         rc = yaksi_type_get(i, &type);
@@ -234,7 +234,7 @@ int yaksa_finalize(void)
 
 
     /* free the builtin requests */
-    for (int i = 0; i < YAKSI_REQUEST__LAST; i++) {
+    for (yaksa_request_t i = YAKSA_REQUEST__NULL; i < YAKSI_REQUEST__LAST; i++) {
         yaksi_request_s *request;
 
         rc = yaksi_request_get(i, &request);

--- a/src/frontend/iov/yaksa_iov.c
+++ b/src/frontend/iov/yaksa_iov.c
@@ -14,32 +14,33 @@
     do {                                                                \
         TYPE tmp;                                                       \
         bool element_is_contig;                                         \
+        uintptr_t offset = (const char *) &tmp.y - (const char *) &tmp; \
                                                                         \
-        if ((const char *) &tmp.y - (const char *) &tmp == sizeof(TYPE1)) \
+        if (offset == sizeof(TYPE1))                                    \
             element_is_contig = true;                                   \
         else                                                            \
             element_is_contig = false;                                  \
                                                                         \
         idx = 0;                                                        \
         if (element_is_contig) {                                        \
-            TYPE *z = (TYPE *) buf + iov_offset;                        \
-            int real_count = YAKSU_MIN(max_iov_len, count - iov_offset); \
+            const char *z = (const char *) buf + (iov_offset * sizeof(TYPE)); \
+            uintptr_t real_count = YAKSU_MIN(max_iov_len, count - iov_offset); \
             for (int x = 0; x < real_count; x++) {                      \
-                iov[x].iov_base = z;                                    \
+                iov[x].iov_base = (void *) z;                           \
                 iov[x].iov_len = sizeof(TYPE1) + sizeof(TYPE2);         \
-                z++;                                                    \
+                z += sizeof(TYPE);                                      \
                 (idx)++;                                                \
             }                                                           \
         } else {                                                        \
             assert(iov_offset % 2 == 0);                                \
-            TYPE *z = (TYPE *) buf + iov_offset / 2;                    \
-            int real_count = YAKSU_MIN(max_iov_len - 1, count * 2 - iov_offset); \
+            const char *z = (const char *) buf + (iov_offset * sizeof(TYPE) / 2); \
+            uintptr_t real_count = YAKSU_MIN(max_iov_len - 1, count * 2 - iov_offset); \
             for (int x = 0; x < real_count; x += 2) {                   \
-                iov[x].iov_base = z;                                    \
+                iov[x].iov_base = (void *) z;                           \
                 iov[x].iov_len = sizeof(TYPE1);                         \
-                iov[x+1].iov_base = &z->y;                              \
+                iov[x+1].iov_base = (void *) (z + offset);              \
                 iov[x+1].iov_len = sizeof(TYPE2);                       \
-                z++;                                                    \
+                z += sizeof(TYPE);                                      \
                 (idx) += 2;                                             \
             }                                                           \
         }                                                               \

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -9,7 +9,7 @@
 int yaksi_request_create(yaksi_request_s ** request)
 {
     int rc = YAKSA_SUCCESS;
-    int idx;
+    unsigned int idx;
 
     rc = yaksu_pool_elem_alloc(yaksi_global.request_pool, (void **) request, &idx);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -14,7 +14,7 @@ int yaksi_request_create(yaksi_request_s ** request)
     rc = yaksu_pool_elem_alloc(yaksi_global.request_pool, (void **) request, &idx);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    (*request)->id = idx;
+    (*request)->id = (yaksa_request_t) idx;
     yaksu_atomic_store(&(*request)->cc, 0);
 
     rc = yaksur_request_create_hook(*request);

--- a/src/frontend/types/yaksi_type.c
+++ b/src/frontend/types/yaksi_type.c
@@ -9,7 +9,7 @@
 int yaksi_type_alloc(struct yaksi_type_s **type)
 {
     int rc = YAKSA_SUCCESS;
-    int idx;
+    unsigned int idx;
 
     rc = yaksu_pool_elem_alloc(yaksi_global.type_pool, (void **) type, &idx);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/types/yaksi_type.c
+++ b/src/frontend/types/yaksi_type.c
@@ -14,7 +14,7 @@ int yaksi_type_alloc(struct yaksi_type_s **type)
     rc = yaksu_pool_elem_alloc(yaksi_global.type_pool, (void **) type, &idx);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    (*type)->id = idx;
+    (*type)->id = (yaksa_type_t) idx;
     yaksu_atomic_store(&(*type)->refcount, 1);
 
   fn_exit:

--- a/src/util/yaksu_pool.c
+++ b/src/util/yaksu_pool.c
@@ -99,6 +99,7 @@ int yaksu_pool_elem_alloc(yaksu_pool_s pool, void **elem, int *elem_idx)
     int rc = YAKSA_SUCCESS;
     pool_head_s *pool_head = (pool_head_s *) pool;
     int idx;
+    pool_elem_s *new = NULL;
 
     pthread_mutex_lock(&pool_head->mutex);
 
@@ -124,7 +125,7 @@ int yaksu_pool_elem_alloc(yaksu_pool_s pool, void **elem, int *elem_idx)
 
     /* allocate another chunk */
     idx = 0;
-    pool_elem_s *new = (pool_elem_s *) malloc(sizeof(pool_elem_s));
+    new = (pool_elem_s *) malloc(sizeof(pool_elem_s));
     YAKSU_ERR_CHKANDJUMP(!new, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail);
 
     new->slab = pool_head->malloc_fn(pool_head->elems_in_chunk * pool_head->elemsize);

--- a/src/util/yaksu_pool.h
+++ b/src/util/yaksu_pool.h
@@ -11,11 +11,11 @@ typedef void *yaksu_pool_s;
 typedef void *(*yaksu_malloc_fn) (uintptr_t);
 typedef void (*yaksu_free_fn) (void *);
 
-int yaksu_pool_alloc(uintptr_t elemsize, uintptr_t elems_in_chunk, uintptr_t maxelems,
+int yaksu_pool_alloc(uintptr_t elemsize, unsigned int elems_in_chunk, unsigned int maxelems,
                      yaksu_malloc_fn malloc_fn, yaksu_free_fn free_fn, yaksu_pool_s * pool);
 int yaksu_pool_free(yaksu_pool_s pool);
-int yaksu_pool_elem_alloc(yaksu_pool_s pool, void **elem, int *elem_idx);
-int yaksu_pool_elem_free(yaksu_pool_s pool, int idx);
-int yaksu_pool_elem_get(yaksu_pool_s pool, int elem_idx, void **elem);
+int yaksu_pool_elem_alloc(yaksu_pool_s pool, void **elem, unsigned int *elem_idx);
+int yaksu_pool_elem_free(yaksu_pool_s pool, unsigned int idx);
+int yaksu_pool_elem_get(yaksu_pool_s pool, unsigned int elem_idx, void **elem);
 
 #endif /* YAKSU_POOL_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

The previous warning tests in yaksa were basically bogus.  The strict option was missing the optimization flag (which disabled some warnings), and the setting of the compiler to `gcc-4` and `gcc-9` was completely bogus (it was never getting set in the jenkins script).  Plus, there was no testing with other compilers.  This PR was done in conjunction with improving the jenkins test for better warning checking.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
