### PR TITLE
autogen: add check for YAKSA_AUTOGEN_PUP_NESTING

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -20,10 +20,15 @@ error() {
 
 
 ########################################################################
-## Parse user arguments
+## Parse user environment and arguments
 ########################################################################
 
 genpup_args=
+
+if test -n "$YAKSA_AUTOGEN_PUP_NESTING" ; then
+    genpup_args=$YAKSA_AUTOGEN_PUP_NESTING
+fi
+
 for arg in "$@" ; do
     case $arg in
         -pup-max-nesting=*|--pup-max-nesting=*)
@@ -35,7 +40,6 @@ for arg in "$@" ; do
             ;;
     esac
 done
-
 
 ########################################################################
 ## Generating required files


### PR DESCRIPTION
## Pull Request Description

This allows CI jobs to easily control nested pup levels. The direct
autogen argument can't be used without changing the default for embedded
builds such as mpich.



<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
