### PR TITLE
init: free builtin types properly in finalize

### DIFF
--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -226,7 +226,7 @@ int yaksa_finalize(void)
         rc = yaksi_type_get(i, &type);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
-        rc = yaksi_type_dealloc(type);
+        rc = yaksi_type_free(type);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
 


### PR DESCRIPTION
## Pull Request Description

Use yaksa_type_free so that hooks are executed. Fixes memory leaka
found with AddressSanitizer. See #89.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix memory leaks.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
