### PR TITLE
Fix memory leaks in init and pool allocator

### DIFF
--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -178,8 +178,6 @@ int yaksa_init(yaksa_init_attr_t attr)
 
 
     /* special initialzation for the NULL type */
-    INIT_BUILTIN(uint8_t, NULL, rc, fn_fail);
-
     yaksi_type_s *null_type;
     rc = yaksi_type_get(YAKSA_TYPE__NULL, &null_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/util/yaksu_pool.c
+++ b/src/util/yaksu_pool.c
@@ -77,6 +77,7 @@ int yaksu_pool_free(yaksu_pool_s pool)
                 count++;
 
         pool_head->free_fn(tmp->slab);
+        free(tmp->elems);
         free(tmp);
         tmp = next;
     }


### PR DESCRIPTION
## Pull Request Description

Fix remaining leaks found with AddressSanitizer. One in initialization, and one in the pool allocator.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix memory leaks.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
