### PR TITLE
type: Fix memory leak in struct type creation

### DIFF
--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -114,10 +114,11 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     outtype->u.str.count = count;
     outtype->u.str.array_of_blocklengths = (int *) malloc(count * sizeof(intptr_t));
     outtype->u.str.array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
+    outtype->u.str.array_of_types = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
     for (int i = 0; i < count; i++) {
         outtype->u.str.array_of_blocklengths[i] = array_of_blocklengths[i];
         outtype->u.str.array_of_displs[i] = array_of_displs[i];
-        outtype->u.str.array_of_types = array_of_intypes;
+        outtype->u.str.array_of_types[i] = array_of_intypes[i];
     }
 
     yaksur_type_create_hook(outtype);
@@ -164,6 +165,7 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     *newtype = outtype->id;
+    free(array_of_intypes);
 
   fn_exit:
     return rc;


### PR DESCRIPTION
## Pull Request Description

If struct type uses hindexed as the underlying type, free the
dynamically allocated array of intypes that is no longer needed. Fixes
leak found with AddressSanitizer in MPICH integration.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix leak in struct type creation.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
