### PR TITLE
gentest.py: fix struct type string - using '+' instead of ','

### DIFF
--- a/maint/gentests.py
+++ b/maint/gentests.py
@@ -15,7 +15,7 @@ iters = {
     1075: 128,
     65536: 32,
 }
-types = [ "int", "short_int", "int:3,double:2" ]
+types = [ "int", "short_int", "int:3+double:2" ]
 seed = 1
 
 ##### simple tests generator


### PR DESCRIPTION
## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
