### PR TITLE
warnings: avoid inline initialization of POD variables

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -38,10 +38,7 @@ static void *cuda_gpu_malloc(uintptr_t size, int device)
     cerr = cudaSetDevice(cur_device);
     YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);
 
-  fn_exit:
     return ptr;
-  fn_fail:
-    return NULL;
 }
 
 static void cuda_host_free(void *ptr)

--- a/src/backend/cuda/hooks/yaksuri_cudai_type_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cudai_type_hooks.c
@@ -50,7 +50,8 @@ int yaksuri_cudai_type_create_hook(yaksi_type_s * type)
     type->backend.cuda.priv = malloc(sizeof(yaksuri_cudai_type_s));
     YAKSU_ERR_CHKANDJUMP(!type->backend.cuda.priv, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail);
 
-    yaksuri_cudai_type_s *cuda = (yaksuri_cudai_type_s *) type->backend.cuda.priv;
+    yaksuri_cudai_type_s *cuda;
+    cuda = (yaksuri_cudai_type_s *) type->backend.cuda.priv;
 
     cuda->num_elements = get_num_elements(type);
     cuda->md = NULL;

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -44,10 +44,7 @@ static int get_thread_block_dims(uintptr_t count, yaksi_type_s * type, unsigned 
             (unsigned int) (YAKSU_CEIL(n_blocks, (uintptr_t) (*n_blocks_x) * (*n_blocks_y)));
     }
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported)
@@ -60,10 +57,7 @@ int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported)
     else
         *is_supported = false;
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -429,9 +429,12 @@ int yaksuri_progress_poke(void)
     rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    progress_elem_s *elem = progress_head;
-    yaksuri_request_s *request_backend = (yaksuri_request_s *) elem->request->backend.priv;
-    yaksuri_gpudriver_id_e id = request_backend->gpudriver_id;
+    progress_elem_s *elem;
+    elem = progress_head;
+    yaksuri_request_s *request_backend;
+    request_backend = (yaksuri_request_s *) elem->request->backend.priv;
+    yaksuri_gpudriver_id_e id;
+    id = request_backend->gpudriver_id;
 
     /****************************************************************************/
     /* Step 1: Check for completion and free up any held up resources */

--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -35,13 +35,13 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
     rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
     rc = yaksi_ipack(inbuf, incount, yaksi_type, inoffset, outbuf, max_pack_bytes,
                      actual_pack_bytes, yaksi_info, yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    int cc = yaksu_atomic_load(&yaksi_request->cc);
-    if (cc) {
+    if (yaksu_atomic_load(&yaksi_request->cc)) {
         *request = yaksi_request->id;
     } else {
         rc = yaksi_request_free(yaksi_request);

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -33,17 +33,18 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
         goto fn_exit;
     }
 
-    yaksi_request_s *yaksi_request = NULL;
+    yaksi_request_s *yaksi_request;
+    yaksi_request = NULL;
     rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
     rc = yaksi_iunpack(inbuf, insize, outbuf, outcount, yaksi_type, outoffset, actual_unpack_bytes,
                        yaksi_info, yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    int cc = yaksu_atomic_load(&yaksi_request->cc);
-    if (cc) {
+    if (yaksu_atomic_load(&yaksi_request->cc)) {
         *request = yaksi_request->id;
     } else {
         rc = yaksi_request_free(yaksi_request);

--- a/src/frontend/pup/yaksi_ipack.c
+++ b/src/frontend/pup/yaksi_ipack.c
@@ -77,7 +77,8 @@ int yaksi_ipack(const void *inbuf, uintptr_t incount, yaksi_type_s * type, uintp
 
 
     /* step 3: perform a full pack of the next few elements */
-    uintptr_t numelems = rem_pack_bytes / type->size;
+    uintptr_t numelems;
+    numelems = rem_pack_bytes / type->size;
     if (numelems) {
         rc = yaksi_ipack_backend(sbuf, dbuf, numelems, type, info, request);
         YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksi_ipack_element.c
+++ b/src/frontend/pup/yaksi_ipack_element.c
@@ -77,7 +77,8 @@ static int pack_sub_hvector(const void *inbuf, yaksi_type_s * type, uintptr_t in
 
 
     /* step 3: perform a full pack of the next few blocks */
-    uintptr_t numblocks = rem_pack_bytes / bytes_in_block;
+    uintptr_t numblocks;
+    numblocks = rem_pack_bytes / bytes_in_block;
     for (int i = 0; i < numblocks; i++) {
         rc = yaksi_ipack_backend(sbuf, dbuf, type->u.hvector.blocklength, type->u.hvector.child,
                                  info, request);
@@ -161,7 +162,8 @@ static int pack_sub_blkhindx(const void *inbuf, yaksi_type_s * type, uintptr_t i
 
 
     /* step 3: perform a full pack of the next few blocks */
-    uintptr_t numblocks = rem_pack_bytes / bytes_in_block;
+    uintptr_t numblocks;
+    numblocks = rem_pack_bytes / bytes_in_block;
     for (int i = 0; i < numblocks; i++) {
         sbuf = (const char *) inbuf + type->u.blkhindx.array_of_displs[blockid++];
         rc = yaksi_ipack_backend(sbuf, dbuf, type->u.blkhindx.blocklength, type->u.blkhindx.child,

--- a/src/frontend/pup/yaksi_iunpack.c
+++ b/src/frontend/pup/yaksi_iunpack.c
@@ -40,10 +40,14 @@ int yaksi_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
      * In the common case, we expect to execute only step 3.
      */
 
-    const char *sbuf = (const char *) inbuf;
-    char *dbuf = (char *) outbuf;
-    uintptr_t remoffset = outoffset;
-    uintptr_t rem_unpack_bytes = YAKSU_MIN(insize, outcount * type->size - outoffset);
+    const char *sbuf;
+    sbuf = (const char *) inbuf;
+    char *dbuf;
+    dbuf = (char *) outbuf;
+    uintptr_t remoffset;
+    remoffset = outoffset;
+    uintptr_t rem_unpack_bytes;
+    rem_unpack_bytes = YAKSU_MIN(insize, outcount * type->size - outoffset);
 
     /* step 1: skip the first few elements */
     if (remoffset) {
@@ -80,7 +84,8 @@ int yaksi_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
 
 
     /* step 3: perform a full unpack of the next few elements */
-    uintptr_t numelems = rem_unpack_bytes / type->size;
+    uintptr_t numelems;
+    numelems = rem_unpack_bytes / type->size;
     if (numelems) {
         rc = yaksi_iunpack_backend(sbuf, dbuf, numelems, type, info, request);
         YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksi_iunpack_element.c
+++ b/src/frontend/pup/yaksi_iunpack_element.c
@@ -78,7 +78,8 @@ static int unpack_sub_hvector(const void *inbuf, uintptr_t insize, void *outbuf,
 
 
     /* step 3: perform a full pack of the next few elements */
-    uintptr_t numblocks = rem_unpack_bytes / bytes_in_block;
+    uintptr_t numblocks;
+    numblocks = rem_unpack_bytes / bytes_in_block;
     for (int i = 0; i < numblocks; i++) {
         rc = yaksi_iunpack_backend(sbuf, dbuf, type->u.hvector.blocklength, type->u.hvector.child,
                                    info, request);
@@ -164,7 +165,8 @@ static int unpack_sub_blkhindx(const void *inbuf, uintptr_t insize, void *outbuf
 
 
     /* step 3: perform a full pack of the next few elements */
-    uintptr_t numblocks = rem_unpack_bytes / bytes_in_block;
+    uintptr_t numblocks;
+    numblocks = rem_unpack_bytes / bytes_in_block;
     for (int i = 0; i < numblocks; i++) {
         dbuf = (char *) outbuf + type->u.blkhindx.array_of_displs[blockid++];
         rc = yaksi_iunpack_backend(sbuf, dbuf, type->u.blkhindx.blocklength, type->u.blkhindx.child,

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -46,8 +46,10 @@ int yaksi_type_create_hindexed_block(int count, int blocklength, const intptr_t 
     outtype->size = intype->size * blocklength * count;
     outtype->alignment = intype->alignment;
 
-    intptr_t min_disp = array_of_displs[0];
-    intptr_t max_disp = array_of_displs[0];
+    intptr_t min_disp;
+    min_disp = array_of_displs[0];
+    intptr_t max_disp;
+    max_disp = array_of_displs[0];
     for (int i = 1; i < count; i++) {
         if (array_of_displs[i] < min_disp)
             min_disp = array_of_displs[i];

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -42,7 +42,8 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
         outtype->size += intype->size * array_of_blocklengths[i];
     outtype->alignment = intype->alignment;
 
-    int is_set = 0;
+    int is_set;
+    is_set = 0;
     for (int idx = 0; idx < count; idx++) {
         if (array_of_blocklengths[idx] == 0)
             continue;
@@ -130,7 +131,8 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uintptr_t total_size = 0;
+    uintptr_t total_size;
+    total_size = 0;
     for (int i = 0; i < count; i++) {
         total_size += intype->size * array_of_blocklengths[i];
     }
@@ -165,7 +167,8 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
     rc = yaksi_type_get(oldtype, &intype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uintptr_t total_size = 0;
+    uintptr_t total_size;
+    total_size = 0;
     for (int i = 0; i < count; i++) {
         total_size += intype->size * array_of_blocklengths[i];
     }

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -40,7 +40,8 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
         yaksu_atomic_incr(&array_of_intypes[i]->refcount);
     }
 
-    int is_set = 0;
+    int is_set;
+    is_set = 0;
     outtype->alignment = 0;
     for (int idx = 0; idx < count; idx++) {
         if (array_of_blocklengths[idx] == 0)
@@ -75,7 +76,8 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
 
     /* adjust ub based on alignment */
     assert(outtype->alignment);
-    uintptr_t diff = (outtype->ub - outtype->lb) % outtype->alignment;
+    uintptr_t diff;
+    diff = (outtype->ub - outtype->lb) % outtype->alignment;
     if (diff) {
         outtype->ub += outtype->alignment - diff;
     }
@@ -138,7 +140,8 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
 
     assert(yaksi_global.is_initialized);
 
-    uintptr_t total_size = 0;
+    uintptr_t total_size;
+    total_size = 0;
     for (int i = 0; i < count; i++) {
         yaksi_type_s *type;
         rc = yaksi_type_get(array_of_types[i], &type);
@@ -152,7 +155,8 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
     }
 
     assert(count > 0);
-    yaksi_type_s **array_of_intypes = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
+    yaksi_type_s **array_of_intypes;
+    array_of_intypes = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
 
     for (int i = 0; i < count; i++) {
         rc = yaksi_type_get(array_of_types[i], &array_of_intypes[i]);

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -32,7 +32,8 @@ int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *
     /* handle the first dimension separately because it really is a
      * contig, rather than a vector */
 
-    intptr_t stride = intype->extent;
+    intptr_t stride;
+    stride = intype->extent;
 
     yaksi_type_s *current, *next;
     if (order == YAKSA_SUBARRAY_ORDER__C) {
@@ -65,7 +66,8 @@ int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *
         }
     }
 
-    uintptr_t extent = intype->extent;
+    uintptr_t extent;
+    extent = intype->extent;
     for (int i = 0; i < ndims; i++)
         extent *= array_of_sizes[i];
 


### PR DESCRIPTION
## Pull Request Description

As per the C++ standard:

```
It is possible to transfer into a block, but not in a way that
bypasses declarations with initialization. A program that jumps from a
point where a local variable with automatic storage duration is not in
scope to a point where it is in scope is ill-formed unless the
variable has POD type (3.9) and is declared without an initializer
```

I haven't searched for it in the C99 standard, but the concerns are
valid even for C99 and compilers such as PGI seem to throw warnings
for it even with C99 code.  Separating out the declaration statement
from the initialization statement should workaround these warnings.

Signed-off-by: Pavan Balaji <balaji@anl.gov>

## Expected Impact

Warning free builds with the PGI compiler.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
