### PR TITLE
Allow for concurrent and multiple initializations of the yaksa library

### DIFF
--- a/examples/contig.c
+++ b/examples/contig.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t contig;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/fuf.c
+++ b/examples/fuf.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hindexed.c
+++ b/examples/hindexed.c
@@ -23,8 +23,8 @@ int main()
         36 * sizeof(int), 44 * sizeof(int), 52 * sizeof(int), 60 * sizeof(int)
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hindexed_block.c
+++ b/examples/hindexed_block.c
@@ -27,8 +27,8 @@ int main()
         32 * sizeof(int), 40 * sizeof(int), 48 * sizeof(int), 56 * sizeof(int)
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/hvector.c
+++ b/examples/hvector.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t hvector;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/indexed.c
+++ b/examples/indexed.c
@@ -23,8 +23,8 @@ int main()
         36, 44, 52, 60
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/indexed_block.c
+++ b/examples/indexed_block.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/iov.c
+++ b/examples/iov.c
@@ -22,8 +22,8 @@ int main()
         32, 40, 48, 56
     };
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/resized.c
+++ b/examples/resized.c
@@ -17,7 +17,7 @@ int main()
     yaksa_type_t vector_resized;
     yaksa_type_t transpose;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/subarray.c
+++ b/examples/subarray.c
@@ -21,8 +21,8 @@ int main()
     int array_of_starts[2] = { 4, 4 };
     yaksa_subarray_order_e order = YAKSA_SUBARRAY_ORDER__C;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/vector.c
+++ b/examples/vector.c
@@ -15,8 +15,8 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t vector;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);       /* before any yaksa API is called the library
-                                                 * must be initialized */
+    yaksa_init(NULL);   /* before any yaksa API is called the library
+                         * must be initialized */
 
     init_matrix(input_matrix, ROWS, COLS);
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/src/frontend/bounds/yaksa_bounds.c
+++ b/src/frontend/bounds/yaksa_bounds.c
@@ -13,7 +13,7 @@ int yaksa_type_get_size(yaksa_type_t type, uintptr_t * size)
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -31,7 +31,7 @@ int yaksa_type_get_extent(yaksa_type_t type, intptr_t * lb, uintptr_t * extent)
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -50,7 +50,7 @@ int yaksa_type_get_true_extent(yaksa_type_t type, intptr_t * lb, uintptr_t * ext
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/flatten/yaksa_flatten.c
+++ b/src/frontend/flatten/yaksa_flatten.c
@@ -102,7 +102,7 @@ int yaksa_flatten(yaksa_type_t type, void *flattened_type)
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/flatten/yaksa_flatten_size.c
+++ b/src/frontend/flatten/yaksa_flatten_size.c
@@ -96,7 +96,7 @@ int yaksa_flatten_size(yaksa_type_t type, uintptr_t * flattened_type_size)
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -132,7 +132,7 @@ int yaksa_unflatten(yaksa_type_t * type, const void *flattened_type)
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = unflatten(&yaksi_type, flattened_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -131,22 +131,6 @@ typedef enum {
 /*! @} */
 
 
-/*! \addtogroup yaksa-init-attr Yaksa initialization attributes
- * @{
- */
-
-/**
- * \brief yaksa initialization attributes
- */
-/* currently there are no init attributes */
-typedef struct {
-    int __reserved_for_future_use;
-} yaksa_init_attr_t;
-extern yaksa_init_attr_t YAKSA_INIT_ATTR__DEFAULT;
-
-/*! @} */
-
-
 /*! \addtogroup yaksa-info Yaksa info object
  * @{
  */
@@ -171,7 +155,7 @@ typedef void *yaksa_info_t;
 /*!
  * \brief initializes the yaksa library
  */
-int yaksa_init(yaksa_init_attr_t attr);
+int yaksa_init(yaksa_info_t info);
 
 /*!
  * \brief finalizes the yaksa library

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -153,6 +153,31 @@ typedef void *yaksa_info_t;
 /* YAKSA PUBLIC FUNCTIONS */
 /******************************************************************************/
 /*!
+ * \brief creates an info object
+ *
+ * \param[out] info              Info object being created
+ */
+int yaksa_info_create(yaksa_info_t * info);
+
+/*!
+ * \brief frees the info object
+ *
+ * \param[in]  info              Info object being freed
+ */
+int yaksa_info_free(yaksa_info_t info);
+
+/*!
+ * \brief append a hint to the info object
+ *
+ * \param[in]  info              Info object
+ * \param[in]  key               Hint key
+ * \param[in]  val               Hint value
+ * \param[in]  vallen            Length of the hint value
+ */
+int yaksa_info_keyval_append(yaksa_info_t info, const char *key, const void *val,
+                             unsigned int vallen);
+
+/*!
  * \brief initializes the yaksa library
  */
 int yaksa_init(yaksa_info_t info);
@@ -361,31 +386,6 @@ int yaksa_request_test(yaksa_request_t request, int *completed);
  * \param[in]  request           The request object that needs to be waited up on
  */
 int yaksa_request_wait(yaksa_request_t request);
-
-/*!
- * \brief creates an info object
- *
- * \param[out] info              Info object being created
- */
-int yaksa_info_create(yaksa_info_t * info);
-
-/*!
- * \brief frees the info object
- *
- * \param[in]  info              Info object being freed
- */
-int yaksa_info_free(yaksa_info_t info);
-
-/*!
- * \brief append a hint to the info object
- *
- * \param[in]  info              Info object
- * \param[in]  key               Hint key
- * \param[in]  val               Hint value
- * \param[in]  vallen            Length of the hint value
- */
-int yaksa_info_keyval_append(yaksa_info_t info, const char *key, const void *val,
-                             unsigned int vallen);
 
 /*!
  * \brief packs the data represented by the (incount, type) tuple into a contiguous buffer

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -25,6 +25,8 @@
 
 #define YAKSI_ENV_DEFAULT_NESTING_LEVEL  (3)
 
+extern yaksu_atomic_int yaksi_is_initialized;
+
 typedef enum {
     YAKSI_TYPE_KIND__BUILTIN,
     YAKSI_TYPE_KIND__CONTIG,
@@ -45,7 +47,6 @@ struct yaksi_request_s;
 typedef struct {
     yaksu_handle_pool_s type_handle_pool;
     yaksu_handle_pool_s request_handle_pool;
-    int is_initialized;
 } yaksi_global_s;
 extern yaksi_global_s yaksi_global;
 

--- a/src/frontend/info/yaksa_info.c
+++ b/src/frontend/info/yaksa_info.c
@@ -14,7 +14,7 @@ int yaksa_info_create(yaksa_info_t * info)
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_info = (yaksi_info_s *) malloc(sizeof(yaksi_info_s));
 
@@ -32,7 +32,7 @@ int yaksa_info_free(yaksa_info_t info)
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksur_info_free_hook(yaksi_info);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -51,7 +51,7 @@ int yaksa_info_keyval_append(yaksa_info_t info, const char *key, const void *val
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksur_info_keyval_append(yaksi_info, key, val, vallen);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -111,14 +111,13 @@
     } while (0)
 
 yaksi_global_s yaksi_global = { 0 };
-yaksa_init_attr_t YAKSA_INIT_ATTR__DEFAULT = { 0 };
 
 yaksu_atomic_int yaksi_is_initialized = 0;
 static pthread_mutex_t init_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #define CHUNK_SIZE (1024)
 
-int yaksa_init(yaksa_init_attr_t attr)
+int yaksa_init(yaksa_info_t info)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/iov/yaksa_iov.c
+++ b/src/frontend/iov/yaksa_iov.c
@@ -372,7 +372,7 @@ int yaksa_iov(const char *buf, uintptr_t count, yaksa_type_t type, uintptr_t iov
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/iov/yaksa_iov_len.c
+++ b/src/frontend/iov/yaksa_iov_len.c
@@ -25,7 +25,7 @@ int yaksa_iov_len(uintptr_t count, yaksa_type_t type, uintptr_t * iov_len)
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     rc = yaksi_type_get(type, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -13,7 +13,7 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     if (incount == 0) {
         *actual_pack_bytes = 0;

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -15,7 +15,7 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     if (outcount == 0) {
         *actual_unpack_bytes = 0;

--- a/src/frontend/pup/yaksa_request.c
+++ b/src/frontend/pup/yaksa_request.c
@@ -11,7 +11,7 @@ int yaksa_request_test(yaksa_request_t request, int *completed)
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     if (request == YAKSA_REQUEST__NULL) {
         *completed = 1;
@@ -44,7 +44,7 @@ int yaksa_request_wait(yaksa_request_t request)
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     if (request == YAKSA_REQUEST__NULL) {
         goto fn_exit;

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -108,7 +108,7 @@ int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t 
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
@@ -141,7 +141,7 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
     intptr_t *real_array_of_displs = NULL;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -62,7 +62,7 @@ int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_type_t * new
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_dup.c
+++ b/src/frontend/types/yaksa_dup.c
@@ -22,7 +22,7 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_free.c
+++ b/src/frontend/types/yaksa_free.c
@@ -90,7 +90,7 @@ int yaksa_type_free(yaksa_type_t type)
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     if (type == YAKSA_TYPE__NULL)
         goto fn_exit;

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -126,7 +126,7 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
@@ -166,7 +166,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
     int rc = YAKSA_SUCCESS;
     intptr_t *real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_resized.c
+++ b/src/frontend/types/yaksa_resized.c
@@ -62,7 +62,7 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t exten
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -139,7 +139,7 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     uintptr_t total_size;
     total_size = 0;

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -142,7 +142,7 @@ int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -82,7 +82,7 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);
@@ -114,7 +114,7 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
 {
     int rc = YAKSA_SUCCESS;
 
-    assert(yaksi_global.is_initialized);
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
 
     yaksi_type_s *intype;
     rc = yaksi_type_get(oldtype, &intype);

--- a/test/flatten/flatten.c
+++ b/test/flatten/flatten.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
 
     dtp = (DTP_pool_s *) malloc(num_threads * sizeof(DTP_pool_s));
     for (uintptr_t i = 0; i < num_threads; i++) {

--- a/test/iov/iov.c
+++ b/test/iov/iov.c
@@ -351,7 +351,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
 
     dtp = (DTP_pool_s *) malloc(num_threads * sizeof(DTP_pool_s));
     for (uintptr_t i = 0; i < num_threads; i++) {

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -450,7 +450,7 @@ int main(int argc, char **argv)
         exit(1);
     }
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
     init_devices();
 
     dtp = (DTP_pool_s *) malloc(num_threads * sizeof(DTP_pool_s));

--- a/test/simple/simple_test.c
+++ b/test/simple/simple_test.c
@@ -17,7 +17,7 @@ int main()
     yaksa_type_t vector, vector_vector;
     uintptr_t actual;
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
 
     rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, &vector);
     assert(rc == YAKSA_SUCCESS);

--- a/test/simple/threaded_test.c
+++ b/test/simple/threaded_test.c
@@ -23,6 +23,8 @@ void *thread_fn(void *arg)
     int *inbuf = inbuf_[tid];
     int *outbuf = outbuf_[tid];
 
+    yaksa_init(NULL);
+
     rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, &vector);
     assert(rc == YAKSA_SUCCESS);
 
@@ -79,6 +81,8 @@ void *thread_fn(void *arg)
     yaksa_type_free(vector_vector);
     yaksa_type_free(vector);
 
+    yaksa_finalize();
+
     return NULL;
 }
 
@@ -88,8 +92,6 @@ void *thread_fn(void *arg)
 int main()
 {
     pthread_t thread[MAX_THREADS];
-
-    yaksa_init(NULL);
 
     inbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));
     outbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));
@@ -112,8 +114,6 @@ int main()
     }
     free(inbuf_);
     free(outbuf_);
-
-    yaksa_finalize();
 
     return 0;
 }

--- a/test/simple/threaded_test.c
+++ b/test/simple/threaded_test.c
@@ -89,7 +89,7 @@ int main()
 {
     pthread_t thread[MAX_THREADS];
 
-    yaksa_init(YAKSA_INIT_ATTR__DEFAULT);
+    yaksa_init(NULL);
 
     inbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));
     outbuf_ = (int **) malloc(MAX_THREADS * sizeof(int *));


### PR DESCRIPTION
## Pull Request Description

Yaksa might be used by multiple layers of the software stack, such as the application, MPI, UCX, etc.  This PR allows each of these layers to independently (and potentially concurrently) initialize and finalize yaksa.  Yaksa would internally simply maintain a refcount and create/destroy when the refcount hits zero.

It is possible that the user might reinitialize yaksa after it is finalized.  In this case, the internal resources are recreated.  This is possible, but can be expensive because it might require creation of new GPU resources, for example.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
