### PR TITLE
types: include all C99 primitive types

### DIFF
--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -20,20 +20,9 @@ import gencomm
 
 num_paren_open = 0
 blklens = [ "generic" ]
-builtin_types = [ "char", "wchar_t", "int", "short", "long", "long long", "int8_t", "int16_t", \
-                  "int32_t", "int64_t", "float", "double" ]
+builtin_types = [ "_Bool", "char", "wchar_t", "int8_t", "int16_t", "int32_t", "int64_t", "float", "double" ]
 builtin_maps = {
-    "YAKSA_TYPE__UNSIGNED_CHAR": "char",
-    "YAKSA_TYPE__UNSIGNED": "int",
-    "YAKSA_TYPE__UNSIGNED_SHORT": "short",
-    "YAKSA_TYPE__UNSIGNED_LONG": "long",
     "YAKSA_TYPE__LONG_DOUBLE": "double",
-    "YAKSA_TYPE__UNSIGNED_LONG_LONG": "long_long",
-    "YAKSA_TYPE__UINT8_T": "int8_t",
-    "YAKSA_TYPE__UINT16_T": "int16_t",
-    "YAKSA_TYPE__UINT32_T": "int32_t",
-    "YAKSA_TYPE__UINT64_T": "int64_t",
-    "YAKSA_TYPE__BYTE": "int8_t"
 }
 
 

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -19,21 +19,10 @@ import gencomm
 ########################################################################################
 
 num_paren_open = 0
-builtin_types = [ "char", "wchar_t", "int", "short", "long", "long long", "int8_t", "int16_t", \
+builtin_types = [ "_Bool", "char", "wchar_t", "int8_t", "int16_t", \
                   "int32_t", "int64_t", "float", "double", "long double" ]
 blklens = [ "1", "2", "3", "4", "5", "6", "7", "8", "generic" ]
-builtin_maps = {
-    "YAKSA_TYPE__UNSIGNED_CHAR": "char",
-    "YAKSA_TYPE__UNSIGNED": "int",
-    "YAKSA_TYPE__UNSIGNED_SHORT": "short",
-    "YAKSA_TYPE__UNSIGNED_LONG": "long",
-    "YAKSA_TYPE__UNSIGNED_LONG_LONG": "long_long",
-    "YAKSA_TYPE__UINT8_T": "int8_t",
-    "YAKSA_TYPE__UINT16_T": "int16_t",
-    "YAKSA_TYPE__UINT32_T": "int32_t",
-    "YAKSA_TYPE__UINT64_T": "int64_t",
-    "YAKSA_TYPE__BYTE": "int8_t"
-}
+builtin_maps = { }
 
 
 ########################################################################################

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -36,46 +36,77 @@ typedef uint64_t yaksa_type_t;
  */
 /* generic */
 #define YAKSA_TYPE__NULL                              ((yaksa_type_t) 0)
-#define YAKSA_TYPE__BYTE                              ((yaksa_type_t) 1)
+#define YAKSA_TYPE___BOOL                             ((yaksa_type_t) 1)
 
 /* char types */
 #define YAKSA_TYPE__CHAR                              ((yaksa_type_t) 2)
-#define YAKSA_TYPE__UNSIGNED_CHAR                     ((yaksa_type_t) 3)
-#define YAKSA_TYPE__WCHAR_T                           ((yaksa_type_t) 4)
+#define YAKSA_TYPE__SIGNED_CHAR                       ((yaksa_type_t) 3)
+#define YAKSA_TYPE__UNSIGNED_CHAR                     ((yaksa_type_t) 4)
+#define YAKSA_TYPE__WCHAR_T                           ((yaksa_type_t) 5)
 
 /* int types */
-#define YAKSA_TYPE__INT                               ((yaksa_type_t) 5)
-#define YAKSA_TYPE__UNSIGNED                          ((yaksa_type_t) 6)
-#define YAKSA_TYPE__SHORT                             ((yaksa_type_t) 7)
-#define YAKSA_TYPE__UNSIGNED_SHORT                    ((yaksa_type_t) 8)
-#define YAKSA_TYPE__LONG                              ((yaksa_type_t) 9)
-#define YAKSA_TYPE__UNSIGNED_LONG                     ((yaksa_type_t) 10)
-#define YAKSA_TYPE__LONG_LONG                         ((yaksa_type_t) 11)
-#define YAKSA_TYPE__UNSIGNED_LONG_LONG                ((yaksa_type_t) 12)
-#define YAKSA_TYPE__INT8_T                            ((yaksa_type_t) 13)
-#define YAKSA_TYPE__INT16_T                           ((yaksa_type_t) 14)
-#define YAKSA_TYPE__INT32_T                           ((yaksa_type_t) 15)
-#define YAKSA_TYPE__INT64_T                           ((yaksa_type_t) 16)
-#define YAKSA_TYPE__UINT8_T                           ((yaksa_type_t) 17)
-#define YAKSA_TYPE__UINT16_T                          ((yaksa_type_t) 18)
-#define YAKSA_TYPE__UINT32_T                          ((yaksa_type_t) 19)
-#define YAKSA_TYPE__UINT64_T                          ((yaksa_type_t) 20)
+#define YAKSA_TYPE__INT8_T                            ((yaksa_type_t) 6)
+#define YAKSA_TYPE__INT16_T                           ((yaksa_type_t) 7)
+#define YAKSA_TYPE__INT32_T                           ((yaksa_type_t) 8)
+#define YAKSA_TYPE__INT64_T                           ((yaksa_type_t) 9)
+#define YAKSA_TYPE__UINT8_T                           ((yaksa_type_t) 10)
+#define YAKSA_TYPE__UINT16_T                          ((yaksa_type_t) 11)
+#define YAKSA_TYPE__UINT32_T                          ((yaksa_type_t) 12)
+#define YAKSA_TYPE__UINT64_T                          ((yaksa_type_t) 13)
+
+#define YAKSA_TYPE__INT                               ((yaksa_type_t) 14)
+#define YAKSA_TYPE__UNSIGNED                          ((yaksa_type_t) 15)
+#define YAKSA_TYPE__SHORT                             ((yaksa_type_t) 16)
+#define YAKSA_TYPE__UNSIGNED_SHORT                    ((yaksa_type_t) 17)
+#define YAKSA_TYPE__LONG                              ((yaksa_type_t) 18)
+#define YAKSA_TYPE__UNSIGNED_LONG                     ((yaksa_type_t) 19)
+#define YAKSA_TYPE__LONG_LONG                         ((yaksa_type_t) 20)
+#define YAKSA_TYPE__UNSIGNED_LONG_LONG                ((yaksa_type_t) 21)
+
+#define YAKSA_TYPE__INT_FAST8_T                       ((yaksa_type_t) 22)
+#define YAKSA_TYPE__INT_FAST16_T                      ((yaksa_type_t) 23)
+#define YAKSA_TYPE__INT_FAST32_T                      ((yaksa_type_t) 24)
+#define YAKSA_TYPE__INT_FAST64_T                      ((yaksa_type_t) 25)
+#define YAKSA_TYPE__UINT_FAST8_T                      ((yaksa_type_t) 26)
+#define YAKSA_TYPE__UINT_FAST16_T                     ((yaksa_type_t) 27)
+#define YAKSA_TYPE__UINT_FAST32_T                     ((yaksa_type_t) 28)
+#define YAKSA_TYPE__UINT_FAST64_T                     ((yaksa_type_t) 29)
+
+#define YAKSA_TYPE__INT_LEAST8_T                      ((yaksa_type_t) 30)
+#define YAKSA_TYPE__INT_LEAST16_T                     ((yaksa_type_t) 31)
+#define YAKSA_TYPE__INT_LEAST32_T                     ((yaksa_type_t) 32)
+#define YAKSA_TYPE__INT_LEAST64_T                     ((yaksa_type_t) 33)
+#define YAKSA_TYPE__UINT_LEAST8_T                     ((yaksa_type_t) 34)
+#define YAKSA_TYPE__UINT_LEAST16_T                    ((yaksa_type_t) 35)
+#define YAKSA_TYPE__UINT_LEAST32_T                    ((yaksa_type_t) 36)
+#define YAKSA_TYPE__UINT_LEAST64_T                    ((yaksa_type_t) 37)
+
+#define YAKSA_TYPE__BYTE                              ((yaksa_type_t) 38)
+#define YAKSA_TYPE__INTMAX_T                          ((yaksa_type_t) 39)
+#define YAKSA_TYPE__UINTMAX_T                         ((yaksa_type_t) 40)
+
+#define YAKSA_TYPE__SIZE_T                            ((yaksa_type_t) 41)
+
+/* pointer type */
+#define YAKSA_TYPE__INTPTR_T                          ((yaksa_type_t) 42)
+#define YAKSA_TYPE__UINTPTR_T                         ((yaksa_type_t) 43)
+#define YAKSA_TYPE__PTRDIFF_T                         ((yaksa_type_t) 44)
 
 /* float types */
-#define YAKSA_TYPE__FLOAT                             ((yaksa_type_t) 21)
-#define YAKSA_TYPE__DOUBLE                            ((yaksa_type_t) 22)
-#define YAKSA_TYPE__LONG_DOUBLE                       ((yaksa_type_t) 23)
+#define YAKSA_TYPE__FLOAT                             ((yaksa_type_t) 45)
+#define YAKSA_TYPE__DOUBLE                            ((yaksa_type_t) 46)
+#define YAKSA_TYPE__LONG_DOUBLE                       ((yaksa_type_t) 47)
 
 /* pair types */
-#define YAKSA_TYPE__C_COMPLEX                         ((yaksa_type_t) 24)
-#define YAKSA_TYPE__C_DOUBLE_COMPLEX                  ((yaksa_type_t) 25)
-#define YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX             ((yaksa_type_t) 26)
-#define YAKSA_TYPE__FLOAT_INT                         ((yaksa_type_t) 27)
-#define YAKSA_TYPE__DOUBLE_INT                        ((yaksa_type_t) 28)
-#define YAKSA_TYPE__LONG_INT                          ((yaksa_type_t) 29)
-#define YAKSA_TYPE__2INT                              ((yaksa_type_t) 30)
-#define YAKSA_TYPE__SHORT_INT                         ((yaksa_type_t) 31)
-#define YAKSA_TYPE__LONG_DOUBLE_INT                   ((yaksa_type_t) 32)
+#define YAKSA_TYPE__C_COMPLEX                         ((yaksa_type_t) 48)
+#define YAKSA_TYPE__C_DOUBLE_COMPLEX                  ((yaksa_type_t) 49)
+#define YAKSA_TYPE__C_LONG_DOUBLE_COMPLEX             ((yaksa_type_t) 50)
+#define YAKSA_TYPE__FLOAT_INT                         ((yaksa_type_t) 51)
+#define YAKSA_TYPE__DOUBLE_INT                        ((yaksa_type_t) 52)
+#define YAKSA_TYPE__LONG_INT                          ((yaksa_type_t) 53)
+#define YAKSA_TYPE__2INT                              ((yaksa_type_t) 54)
+#define YAKSA_TYPE__SHORT_INT                         ((yaksa_type_t) 55)
+#define YAKSA_TYPE__LONG_DOUBLE_INT                   ((yaksa_type_t) 56)
 
 /*! @} */
 

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -26,6 +26,39 @@
         assert(user_handle->id == YAKSA_TYPE__##TYPE);                  \
     } while (0)
 
+#define ASSIGN_TYPE_HANDLE(OLDTYPE, NEWTYPE, rc, fn_fail)               \
+    do {                                                                \
+        yaksi_type_s *tmp_type_;                                        \
+                                                                        \
+        rc = yaksi_type_get(YAKSA_TYPE__##OLDTYPE, &tmp_type_);         \
+        YAKSU_ERR_CHECK(rc, fn_fail);                                   \
+        yaksu_atomic_incr(&tmp_type_->refcount);                        \
+                                                                        \
+        yaksi_type_user_handle_s *user_handle;                          \
+        user_handle = (yaksi_type_user_handle_s *) malloc(sizeof(yaksi_type_user_handle_s)); \
+        YAKSU_ERR_CHKANDJUMP(!user_handle, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail); \
+                                                                        \
+        rc = yaksi_type_handle_alloc(tmp_type_, &user_handle->id);      \
+        YAKSU_ERR_CHECK(rc, fn_fail);                                   \
+                                                                        \
+        assert(user_handle->id == YAKSA_TYPE__##NEWTYPE);               \
+    } while (0)
+
+#define INT_MATCH_HANDLE(ctype, TYPE, rc, fn_fail)              \
+    do {                                                        \
+        if (sizeof(ctype) == 1) {                               \
+            ASSIGN_TYPE_HANDLE(INT8_T, TYPE, rc, fn_fail);      \
+        } else if (sizeof(ctype) == 2) {                        \
+            ASSIGN_TYPE_HANDLE(INT16_T, TYPE, rc, fn_fail);     \
+        } else if (sizeof(ctype) == 4) {                        \
+            ASSIGN_TYPE_HANDLE(INT32_T, TYPE, rc, fn_fail);     \
+        } else if (sizeof(ctype) == 8) {                        \
+            ASSIGN_TYPE_HANDLE(INT64_T, TYPE, rc, fn_fail);     \
+        } else {                                                \
+            assert(0);                                          \
+        }                                                       \
+    } while (0)
+
 #define INIT_BUILTIN_TYPE(c_type, TYPE, rc, fn_fail)            \
     do {                                                        \
         yaksi_type_s *tmp_type_;                                \
@@ -159,28 +192,58 @@ int yaksa_init(yaksa_info_t info)
     null_type->num_contig = 0;
     yaksur_type_create_hook(null_type);
 
-    INIT_BUILTIN_TYPE(uint8_t, BYTE, rc, fn_fail);
+    INIT_BUILTIN_TYPE(_Bool, _BOOL, rc, fn_fail);
 
     INIT_BUILTIN_TYPE(char, CHAR, rc, fn_fail);
-    INIT_BUILTIN_TYPE(unsigned char, UNSIGNED_CHAR, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(CHAR, SIGNED_CHAR, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(CHAR, UNSIGNED_CHAR, rc, fn_fail);
     INIT_BUILTIN_TYPE(wchar_t, WCHAR_T, rc, fn_fail);
 
-    INIT_BUILTIN_TYPE(int, INT, rc, fn_fail);
-    INIT_BUILTIN_TYPE(unsigned, UNSIGNED, rc, fn_fail);
-    INIT_BUILTIN_TYPE(short, SHORT, rc, fn_fail);
-    INIT_BUILTIN_TYPE(unsigned short, UNSIGNED_SHORT, rc, fn_fail);
-    INIT_BUILTIN_TYPE(long, LONG, rc, fn_fail);
-    INIT_BUILTIN_TYPE(unsigned long, UNSIGNED_LONG, rc, fn_fail);
-    INIT_BUILTIN_TYPE(long long, LONG_LONG, rc, fn_fail);
-    INIT_BUILTIN_TYPE(unsigned long long, UNSIGNED_LONG_LONG, rc, fn_fail);
     INIT_BUILTIN_TYPE(int8_t, INT8_T, rc, fn_fail);
     INIT_BUILTIN_TYPE(int16_t, INT16_T, rc, fn_fail);
     INIT_BUILTIN_TYPE(int32_t, INT32_T, rc, fn_fail);
     INIT_BUILTIN_TYPE(int64_t, INT64_T, rc, fn_fail);
-    INIT_BUILTIN_TYPE(uint8_t, UINT8_T, rc, fn_fail);
-    INIT_BUILTIN_TYPE(uint16_t, UINT16_T, rc, fn_fail);
-    INIT_BUILTIN_TYPE(uint32_t, UINT32_T, rc, fn_fail);
-    INIT_BUILTIN_TYPE(uint64_t, UINT64_T, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(INT8_T, UINT8_T, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(INT16_T, UINT16_T, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(INT32_T, UINT32_T, rc, fn_fail);
+    ASSIGN_TYPE_HANDLE(INT64_T, UINT64_T, rc, fn_fail);
+
+    INT_MATCH_HANDLE(int, INT, rc, fn_fail);
+    INT_MATCH_HANDLE(unsigned, UNSIGNED, rc, fn_fail);
+    INT_MATCH_HANDLE(short, SHORT, rc, fn_fail);
+    INT_MATCH_HANDLE(unsigned short, UNSIGNED_SHORT, rc, fn_fail);
+    INT_MATCH_HANDLE(long, LONG, rc, fn_fail);
+    INT_MATCH_HANDLE(unsigned long, UNSIGNED_LONG, rc, fn_fail);
+    INT_MATCH_HANDLE(long long, LONG_LONG, rc, fn_fail);
+    INT_MATCH_HANDLE(unsigned long long, UNSIGNED_LONG_LONG, rc, fn_fail);
+
+    INT_MATCH_HANDLE(int_fast8_t, INT_FAST8_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_fast16_t, INT_FAST16_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_fast32_t, INT_FAST32_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_fast64_t, INT_FAST64_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_fast8_t, UINT_FAST8_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_fast16_t, UINT_FAST16_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_fast32_t, UINT_FAST32_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_fast64_t, UINT_FAST64_T, rc, fn_fail);
+
+    INT_MATCH_HANDLE(int_least8_t, INT_LEAST8_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_least16_t, INT_LEAST16_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_least32_t, INT_LEAST32_T, rc, fn_fail);
+    INT_MATCH_HANDLE(int_least64_t, INT_LEAST64_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_least8_t, UINT_LEAST8_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_least16_t, UINT_LEAST16_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_least32_t, UINT_LEAST32_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uint_least64_t, UINT_LEAST64_T, rc, fn_fail);
+
+    ASSIGN_TYPE_HANDLE(UINT8_T, BYTE, rc, fn_fail);
+
+    INT_MATCH_HANDLE(intmax_t, INTMAX_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uintmax_t, UINTMAX_T, rc, fn_fail);
+    INT_MATCH_HANDLE(size_t, SIZE_T, rc, fn_fail);
+
+    INT_MATCH_HANDLE(intptr_t, INTPTR_T, rc, fn_fail);
+    INT_MATCH_HANDLE(uintptr_t, UINTPTR_T, rc, fn_fail);
+    INT_MATCH_HANDLE(ptrdiff_t, PTRDIFF_T, rc, fn_fail);
 
     INIT_BUILTIN_TYPE(float, FLOAT, rc, fn_fail);
     INIT_BUILTIN_TYPE(double, DOUBLE, rc, fn_fail);
@@ -237,11 +300,21 @@ int yaksa_finalize(void)
 
     /* free the builtin datatypes */
     FINALIZE_BUILTIN_TYPE(NULL, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(BYTE, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(_BOOL, rc, fn_fail);
 
     FINALIZE_BUILTIN_TYPE(CHAR, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(SIGNED_CHAR, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(UNSIGNED_CHAR, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(WCHAR_T, rc, fn_fail);
+
+    FINALIZE_BUILTIN_TYPE(INT8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT64_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT64_T, rc, fn_fail);
 
     FINALIZE_BUILTIN_TYPE(INT, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(UNSIGNED, rc, fn_fail);
@@ -251,14 +324,33 @@ int yaksa_finalize(void)
     FINALIZE_BUILTIN_TYPE(UNSIGNED_LONG, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(LONG_LONG, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(UNSIGNED_LONG_LONG, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(INT8_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(INT16_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(INT32_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(INT64_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(UINT8_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(UINT16_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(UINT32_T, rc, fn_fail);
-    FINALIZE_BUILTIN_TYPE(UINT64_T, rc, fn_fail);
+
+    FINALIZE_BUILTIN_TYPE(INT_FAST8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_FAST16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_FAST32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_FAST64_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_FAST8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_FAST16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_FAST32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_FAST64_T, rc, fn_fail);
+
+    FINALIZE_BUILTIN_TYPE(INT_LEAST8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_LEAST16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_LEAST32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INT_LEAST64_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_LEAST8_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_LEAST16_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_LEAST32_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINT_LEAST64_T, rc, fn_fail);
+
+    FINALIZE_BUILTIN_TYPE(BYTE, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(INTMAX_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINTMAX_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(SIZE_T, rc, fn_fail);
+
+    FINALIZE_BUILTIN_TYPE(INTPTR_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(UINTPTR_T, rc, fn_fail);
+    FINALIZE_BUILTIN_TYPE(PTRDIFF_T, rc, fn_fail);
 
     FINALIZE_BUILTIN_TYPE(FLOAT, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(DOUBLE, rc, fn_fail);

--- a/test/dtpools/src/dtpools_init_verify.c
+++ b/test/dtpools/src/dtpools_init_verify.c
@@ -5,6 +5,7 @@
 
 #include "dtpools_internal.h"
 #include <stdint.h>
+#include <stddef.h>
 
 #define MAX_ERRCOUNT 10
 
@@ -55,8 +56,16 @@ static int init_verify_basic_datatype(yaksa_type_t type_, char *buf, int val, in
     int rc = DTP_SUCCESS;
 
     switch (type) {
+        case YAKSA_TYPE___BOOL:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, _Bool);
+            val += val_stride;
+            break;
         case YAKSA_TYPE__CHAR:
             INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, char);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__SIGNED_CHAR:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, signed char);
             val += val_stride;
             break;
         case YAKSA_TYPE__UNSIGNED_CHAR:
@@ -128,6 +137,82 @@ static int init_verify_basic_datatype(yaksa_type_t type_, char *buf, int val, in
             INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint64_t);
             val += val_stride;
             break;
+        case YAKSA_TYPE__INT_FAST8_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_fast8_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_FAST16_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_fast16_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_FAST32_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_fast32_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_FAST64_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_fast64_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_FAST8_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_fast8_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_FAST16_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_fast16_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_FAST32_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_fast32_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_FAST64_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_fast64_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_LEAST8_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_least8_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_LEAST16_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_least16_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_LEAST32_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_least32_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INT_LEAST64_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, int_least64_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_LEAST8_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_least8_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_LEAST16_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_least16_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_LEAST32_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_least32_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINT_LEAST64_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uint_least64_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INTMAX_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, intmax_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINTMAX_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uintmax_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__SIZE_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, size_t);
+            val += val_stride;
+            break;
         case YAKSA_TYPE__FLOAT:
             INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, float);
             val += val_stride;
@@ -138,6 +223,18 @@ static int init_verify_basic_datatype(yaksa_type_t type_, char *buf, int val, in
             break;
         case YAKSA_TYPE__LONG_DOUBLE:
             INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, long double);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__INTPTR_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, intptr_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__UINTPTR_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, uintptr_t);
+            val += val_stride;
+            break;
+        case YAKSA_TYPE__PTRDIFF_T:
+            INIT_VERIFY_SINGLE_VAL(rc, buf, val, verify, ptrdiff_t);
             val += val_stride;
             break;
         case YAKSA_TYPE__C_COMPLEX:

--- a/test/dtpools/src/dtpools_misc.c
+++ b/test/dtpools/src/dtpools_misc.c
@@ -15,8 +15,12 @@ int DTPI_func_nesting = -1;
 
 static yaksa_type_t name_to_type(const char *name)
 {
-    if (!strcmp(name, "char"))
+    if (!strcmp(name, "_Bool") || !strcmp(name, "bool"))
+        return YAKSA_TYPE___BOOL;
+    else if (!strcmp(name, "char"))
         return YAKSA_TYPE__CHAR;
+    else if (!strcmp(name, "signed_char"))
+        return YAKSA_TYPE__SIGNED_CHAR;
     else if (!strcmp(name, "unsigned_char"))
         return YAKSA_TYPE__UNSIGNED_CHAR;
     else if (!strcmp(name, "wchar"))
@@ -53,12 +57,56 @@ static yaksa_type_t name_to_type(const char *name)
         return YAKSA_TYPE__UINT32_T;
     else if (!strcmp(name, "uint64_t"))
         return YAKSA_TYPE__UINT64_T;
+    else if (!strcmp(name, "int_fast8_t"))
+        return YAKSA_TYPE__INT_FAST8_T;
+    else if (!strcmp(name, "int_fast16_t"))
+        return YAKSA_TYPE__INT_FAST16_T;
+    else if (!strcmp(name, "int_fast32_t"))
+        return YAKSA_TYPE__INT_FAST32_T;
+    else if (!strcmp(name, "int_fast64_t"))
+        return YAKSA_TYPE__INT_FAST64_T;
+    else if (!strcmp(name, "uint_fast8_t"))
+        return YAKSA_TYPE__UINT_FAST8_T;
+    else if (!strcmp(name, "uint_fast16_t"))
+        return YAKSA_TYPE__UINT_FAST16_T;
+    else if (!strcmp(name, "uint_fast32_t"))
+        return YAKSA_TYPE__UINT_FAST32_T;
+    else if (!strcmp(name, "uint_fast64_t"))
+        return YAKSA_TYPE__UINT_FAST64_T;
+    else if (!strcmp(name, "int_least8_t"))
+        return YAKSA_TYPE__INT_LEAST8_T;
+    else if (!strcmp(name, "int_least16_t"))
+        return YAKSA_TYPE__INT_LEAST16_T;
+    else if (!strcmp(name, "int_least32_t"))
+        return YAKSA_TYPE__INT_LEAST32_T;
+    else if (!strcmp(name, "int_least64_t"))
+        return YAKSA_TYPE__INT_LEAST64_T;
+    else if (!strcmp(name, "uint_least8_t"))
+        return YAKSA_TYPE__UINT_LEAST8_T;
+    else if (!strcmp(name, "uint_least16_t"))
+        return YAKSA_TYPE__UINT_LEAST16_T;
+    else if (!strcmp(name, "uint_least32_t"))
+        return YAKSA_TYPE__UINT_LEAST32_T;
+    else if (!strcmp(name, "uint_least64_t"))
+        return YAKSA_TYPE__UINT_LEAST64_T;
+    else if (!strcmp(name, "intmax_t"))
+        return YAKSA_TYPE__INTMAX_T;
+    else if (!strcmp(name, "uintmax_t"))
+        return YAKSA_TYPE__UINTMAX_T;
+    else if (!strcmp(name, "size_t"))
+        return YAKSA_TYPE__SIZE_T;
     else if (!strcmp(name, "float"))
         return YAKSA_TYPE__FLOAT;
     else if (!strcmp(name, "double"))
         return YAKSA_TYPE__DOUBLE;
     else if (!strcmp(name, "long_double"))
         return YAKSA_TYPE__LONG_DOUBLE;
+    else if (!strcmp(name, "intptr_t"))
+        return YAKSA_TYPE__INTPTR_T;
+    else if (!strcmp(name, "uintptr_t"))
+        return YAKSA_TYPE__UINTPTR_T;
+    else if (!strcmp(name, "ptrdiff_t"))
+        return YAKSA_TYPE__PTRDIFF_T;
     else if (!strcmp(name, "c_complex"))
         return YAKSA_TYPE__C_COMPLEX;
     else if (!strcmp(name, "c_double_complex"))


### PR DESCRIPTION
## Pull Request Description

We create a number of user-visible handles, one for each c99 datatype,
but they all internally map to a smaller set of objects.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
