### PR TITLE
types: update type creation functions to take an info hint

### DIFF
--- a/examples/contig.c
+++ b/examples/contig.c
@@ -22,7 +22,7 @@ int main()
     set_matrix(pack_buf, ROWS, COLS, 0);
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
-    rc = yaksa_type_create_contig(SIZE, YAKSA_TYPE__INT, &contig);
+    rc = yaksa_type_create_contig(SIZE, YAKSA_TYPE__INT, NULL, &contig);
     assert(rc == YAKSA_SUCCESS);
 
     /* pack */

--- a/examples/fuf.c
+++ b/examples/fuf.c
@@ -30,7 +30,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_indexed_block(ROWS, BLKLEN, array_of_displacements, YAKSA_TYPE__INT,
-                                         &indexed_block);
+                                         NULL, &indexed_block);
     assert(rc == YAKSA_SUCCESS);
 
     uintptr_t flatten_size;

--- a/examples/hindexed.c
+++ b/examples/hindexed.c
@@ -31,7 +31,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_hindexed(ROWS - 1, array_of_blocklengths, array_of_displacements,
-                                    YAKSA_TYPE__INT, &hindexed);
+                                    YAKSA_TYPE__INT, NULL, &hindexed);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/hindexed_block.c
+++ b/examples/hindexed_block.c
@@ -35,7 +35,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_hindexed_block(ROWS, BLKLEN, array_of_displacements, YAKSA_TYPE__INT,
-                                          &hindexed_block);
+                                          NULL, &hindexed_block);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/hvector.c
+++ b/examples/hvector.c
@@ -22,7 +22,7 @@ int main()
     set_matrix(pack_buf, ROWS, COLS, 0);
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
-    rc = yaksa_type_create_hvector(ROWS, 1, COLS * sizeof(int), YAKSA_TYPE__INT, &hvector);
+    rc = yaksa_type_create_hvector(ROWS, 1, COLS * sizeof(int), YAKSA_TYPE__INT, NULL, &hvector);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;
@@ -65,10 +65,10 @@ int main()
     /* matrix transposition using hvector */
     yaksa_type_t vector;
 
-    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, &vector);
+    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, NULL, &vector);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_type_create_hvector(COLS, 1, sizeof(int), vector, &hvector);
+    rc = yaksa_type_create_hvector(COLS, 1, sizeof(int), vector, NULL, &hvector);
     assert(rc == YAKSA_SUCCESS);
 
     set_matrix(pack_buf, ROWS, COLS, 0);

--- a/examples/indexed.c
+++ b/examples/indexed.c
@@ -31,7 +31,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_indexed(ROWS - 1, array_of_blocklengths, array_of_displacements,
-                                   YAKSA_TYPE__INT, &indexed);
+                                   YAKSA_TYPE__INT, NULL, &indexed);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/indexed_block.c
+++ b/examples/indexed_block.c
@@ -30,7 +30,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_indexed_block(ROWS, BLKLEN, array_of_displacements, YAKSA_TYPE__INT,
-                                         &indexed_block);
+                                         NULL, &indexed_block);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/iov.c
+++ b/examples/iov.c
@@ -30,7 +30,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_indexed_block(ROWS, BLKLEN, array_of_displacements, YAKSA_TYPE__INT,
-                                         &indexed_block);
+                                         NULL, &indexed_block);
     assert(rc == YAKSA_SUCCESS);
 
     /* create an iov of the datatype */

--- a/examples/resized.c
+++ b/examples/resized.c
@@ -23,11 +23,11 @@ int main()
     set_matrix(pack_buf, ROWS, COLS, 0);
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
-    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, &vector);
+    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, NULL, &vector);
     assert(rc == YAKSA_SUCCESS);
-    rc = yaksa_type_create_resized(vector, 0, sizeof(int), &vector_resized);
+    rc = yaksa_type_create_resized(vector, 0, sizeof(int), NULL, &vector_resized);
     assert(rc == YAKSA_SUCCESS);
-    rc = yaksa_type_create_contig(COLS, vector_resized, &transpose);
+    rc = yaksa_type_create_contig(COLS, vector_resized, NULL, &transpose);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/subarray.c
+++ b/examples/subarray.c
@@ -29,7 +29,7 @@ int main()
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
     rc = yaksa_type_create_subarray(ndims, array_of_sizes, array_of_subsizes,
-                                    array_of_starts, order, YAKSA_TYPE__INT, &subarray);
+                                    array_of_starts, order, YAKSA_TYPE__INT, NULL, &subarray);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/examples/vector.c
+++ b/examples/vector.c
@@ -22,7 +22,7 @@ int main()
     set_matrix(pack_buf, ROWS, COLS, 0);
     set_matrix(unpack_buf, ROWS, COLS, 0);
 
-    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, &vector);
+    rc = yaksa_type_create_vector(ROWS, 1, COLS, YAKSA_TYPE__INT, NULL, &vector);
     assert(rc == YAKSA_SUCCESS);
 
     yaksa_request_t request;

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -232,10 +232,11 @@ int yaksa_finalize(void);
  * \param[in]  stride       Increment from the start of one block to another
  *                          (represented in terms of the count of the oldtype)
  * \param[in]  oldtype      Base datatype forming each element in the vector
+ * \param[in]  info         Hint to the type creation function
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
-                             yaksa_type_t * newtype);
+                             yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hvector layout
@@ -245,27 +246,31 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
  * \param[in]  stride       Increment from the start of one block to another
  *                          (represented in bytes)
  * \param[in]  oldtype      Base datatype forming each element in the vector
+ * \param[in]  info         Hint to the type creation function
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
-                              yaksa_type_t * newtype);
+                              yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a contig layout
  *
  * \param[in]  count        Number of elements of the oldtype
  * \param[in]  oldtype      Base datatype forming each element in the contig
+ * \param[in]  info         Hint to the type creation function
  * \param[out] newtype      Final generated type
  */
-int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_type_t * newtype);
+int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
+                             yaksa_type_t * newtype);
 
 /*!
  * \brief creates a copy of the oldtype
  *
  * \param[in]  oldtype      Base datatype being dup'ed
+ * \param[in]  info         Hint to the type creation function
  * \param[out] newtype      Final generated type
  */
-int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_type_t * newtype);
+int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a block-indexed layout
@@ -275,10 +280,12 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_type_t * newtype);
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in terms of the count of the oldtype)
  * \param[in]  oldtype                Base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
-                                    yaksa_type_t oldtype, yaksa_type_t * newtype);
+                                    yaksa_type_t oldtype, yaksa_info_t info,
+                                    yaksa_type_t * newtype);
 
 /*!
  * \brief creates a block-hindexed layout
@@ -288,11 +295,12 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  oldtype                Base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_hindexed_block(int count, int blocklength,
                                      const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                                     yaksa_type_t * newtype);
+                                     yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a indexed layout
@@ -302,11 +310,12 @@ int yaksa_type_create_hindexed_block(int count, int blocklength,
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in terms of the count of the oldtype)
  * \param[in]  oldtype                Base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                               const int *array_of_displacements, yaksa_type_t oldtype,
-                              yaksa_type_t * newtype);
+                              yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hindexed layout
@@ -316,11 +325,12 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  oldtype                Base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                               yaksa_type_t * newtype);
+                               yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a resized layout with updated lower and extent
@@ -328,10 +338,11 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
  * \param[in]  oldtype                Base datatype forming each element in the new type
  * \param[in]  lb                     New lower bound to use
  * \param[in]  extent                 New extent to use
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t extent,
-                              yaksa_type_t * newtype);
+                              yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a struct layout
@@ -341,11 +352,13 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t exten
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  array_of_types         Array of base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                              const intptr_t * array_of_displacements,
-                             const yaksa_type_t * array_of_types, yaksa_type_t * newtype);
+                             const yaksa_type_t * array_of_types, yaksa_info_t info,
+                             yaksa_type_t * newtype);
 
 /*!
  * \brief creates a subarray layout
@@ -356,11 +369,12 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
  * \param[in]  array_of_starts        Start location ("corner representing the start") of the subarray
  * \param[in]  order                  Data layout order (C or Fortran)
  * \param[in]  oldtype                Base datatype forming each element in the new type
+ * \param[in]  info                   Hint to the type creation function
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
                                const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksa_type_t oldtype, yaksa_type_t * newtype);
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief gets the size of (number of bytes in) the datatype

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -104,7 +104,8 @@ int yaksi_type_create_hindexed_block(int count, int blocklength, const intptr_t 
 }
 
 int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t * array_of_displs,
-                                     yaksa_type_t oldtype, yaksa_type_t * newtype)
+                                     yaksa_type_t oldtype, yaksa_info_t info,
+                                     yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -136,7 +137,7 @@ int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t 
 }
 
 int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displs,
-                                    yaksa_type_t oldtype, yaksa_type_t * newtype)
+                                    yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     intptr_t *real_array_of_displs = NULL;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -58,7 +58,8 @@ int yaksi_type_create_contig(int count, yaksi_type_s * intype, yaksi_type_s ** n
     goto fn_exit;
 }
 
-int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_type_t * newtype)
+int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
+                             yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_dup.c
+++ b/src/frontend/types/yaksa_dup.c
@@ -18,7 +18,7 @@ int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** newtype)
     return rc;
 }
 
-int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_type_t * newtype)
+int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -122,7 +122,7 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
 
 int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
                                const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                               yaksa_type_t * newtype)
+                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -161,7 +161,7 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
 
 int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                               const int *array_of_displs, yaksa_type_t oldtype,
-                              yaksa_type_t * newtype)
+                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
     intptr_t *real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));

--- a/src/frontend/types/yaksa_resized.c
+++ b/src/frontend/types/yaksa_resized.c
@@ -58,7 +58,7 @@ int yaksi_type_create_resized(yaksi_type_s * intype, intptr_t lb, uintptr_t exte
 }
 
 int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t extent,
-                              yaksa_type_t * newtype)
+                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -135,7 +135,7 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
 
 int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                              const intptr_t * array_of_displs, const yaksa_type_t * array_of_types,
-                             yaksa_type_t * newtype)
+                             yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -138,7 +138,7 @@ int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *
 
 int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
                                const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksa_type_t oldtype, yaksa_type_t * newtype)
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -78,7 +78,7 @@ int yaksi_type_create_hvector(int count, int blocklength, intptr_t stride, yaksi
 }
 
 int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
-                              yaksa_type_t * newtype)
+                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -110,7 +110,7 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
 }
 
 int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
-                             yaksa_type_t * newtype)
+                             yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -62,7 +62,7 @@ static int construct_contig(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
             break;
     }
 
-    rc = yaksa_type_create_contig(attr->u.contig.blklen, type, newtype);
+    rc = yaksa_type_create_contig(attr->u.contig.blklen, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -94,7 +94,7 @@ static int construct_dup(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * attr
     rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
     DTPI_ERR_CHK_RC(rc);
 
-    rc = yaksa_type_create_dup(type, newtype);
+    rc = yaksa_type_create_dup(type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
   fn_exit:
@@ -170,7 +170,7 @@ static int construct_resized(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
         break;
     }
 
-    rc = yaksa_type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, newtype);
+    rc = yaksa_type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, attr->u.resized.extent);
@@ -278,7 +278,8 @@ static int construct_vector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
     }
 
     rc = yaksa_type_create_vector(attr->u.vector.numblks,
-                                  attr->u.vector.blklen, attr->u.vector.stride, type, newtype);
+                                  attr->u.vector.blklen, attr->u.vector.stride, type, NULL,
+                                  newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -390,7 +391,8 @@ static int construct_hvector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
     }
 
     rc = yaksa_type_create_hvector(attr->u.hvector.numblks,
-                                   attr->u.hvector.blklen, attr->u.hvector.stride, type, newtype);
+                                   attr->u.hvector.blklen, attr->u.hvector.stride, type, NULL,
+                                   newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -527,7 +529,7 @@ static int construct_blkindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
     rc = yaksa_type_create_indexed_block(attr->u.blkindx.numblks,
                                          attr->u.blkindx.blklen,
-                                         attr->u.blkindx.array_of_displs, type, newtype);
+                                         attr->u.blkindx.array_of_displs, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -667,7 +669,7 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
     rc = yaksa_type_create_hindexed_block(attr->u.blkhindx.numblks,
                                           attr->u.blkhindx.blklen,
-                                          attr->u.blkhindx.array_of_displs, type, newtype);
+                                          attr->u.blkhindx.array_of_displs, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -838,7 +840,7 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
     rc = yaksa_type_create_indexed(attr->u.indexed.numblks,
                                    attr->u.indexed.array_of_blklens,
-                                   attr->u.indexed.array_of_displs, type, newtype);
+                                   attr->u.indexed.array_of_displs, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -1013,7 +1015,7 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
     rc = yaksa_type_create_hindexed(attr->u.hindexed.numblks,
                                     attr->u.hindexed.array_of_blklens,
-                                    attr->u.hindexed.array_of_displs, type, newtype);
+                                    attr->u.hindexed.array_of_displs, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -1130,7 +1132,7 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
                                     attr->u.subarray.array_of_sizes,
                                     attr->u.subarray.array_of_subsizes,
                                     attr->u.subarray.array_of_starts,
-                                    attr->u.subarray.order, type, newtype);
+                                    attr->u.subarray.order, type, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
     confirm_extent(*newtype, extent);
@@ -1316,7 +1318,8 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
 
         rc = yaksa_type_create_struct(attr->u.structure.numblks,
                                       attr->u.structure.array_of_blklens,
-                                      attr->u.structure.array_of_displs, array_of_types, newtype);
+                                      attr->u.structure.array_of_displs, array_of_types, NULL,
+                                      newtype);
         DTPI_ERR_CHK_RC(rc);
 
         DTPI_FREE(array_of_types);

--- a/test/dtpools/src/dtpools_misc.c
+++ b/test/dtpools/src/dtpools_misc.c
@@ -217,7 +217,7 @@ int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str)
     }
 
     rc = yaksa_type_create_struct(num_types, array_of_blklens, array_of_displs, array_of_types,
-                                  &dtp->DTP_base_type);
+                                  NULL, &dtp->DTP_base_type);
     DTPI_ERR_CHK_RC(rc);
 
     dtpi->base_type_is_struct = 1;

--- a/test/simple/simple_test.c
+++ b/test/simple/simple_test.c
@@ -19,10 +19,10 @@ int main()
 
     yaksa_init(NULL);
 
-    rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, &vector);
+    rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, NULL, &vector);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_type_create_vector(5, 1, 10, vector, &vector_vector);
+    rc = yaksa_type_create_vector(5, 1, 10, vector, NULL, &vector_vector);
     assert(rc == YAKSA_SUCCESS);
 
     for (int i = 0; i < DIMSIZE * DIMSIZE; i++) {

--- a/test/simple/threaded_test.c
+++ b/test/simple/threaded_test.c
@@ -25,10 +25,10 @@ void *thread_fn(void *arg)
 
     yaksa_init(NULL);
 
-    rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, &vector);
+    rc = yaksa_type_create_vector(3, 2, 3, YAKSA_TYPE__INT, NULL, &vector);
     assert(rc == YAKSA_SUCCESS);
 
-    rc = yaksa_type_create_vector(5, 1, 10, vector, &vector_vector);
+    rc = yaksa_type_create_vector(5, 1, 10, vector, NULL, &vector_vector);
     assert(rc == YAKSA_SUCCESS);
 
     for (int i = 0; i < DIMSIZE * DIMSIZE; i++) {


### PR DESCRIPTION
## Pull Request Description

Adding info hints to type creation routines as requested by the UCX datatypes working group folks.

These hints are unused at this point, but adding them in for future use.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
