### PR TITLE
Fixes for 32-bit systems

### DIFF
--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -17,7 +17,7 @@
         intptr_t lb_;                                                   \
         yaksa_type_get_extent(type, &lb_, &type_extent);                     \
         if (type_extent != extent) {                                    \
-            fprintf(stderr, "expected extent of %" PRIxPTR ", but got %" PRIxPTR "\n", extent, type_extent); \
+            fprintf(stderr, "expected extent of %" PRIuPTR ", but got %" PRIuPTR "\n", extent, type_extent); \
             fflush(stderr);                                             \
             assert(0);                                                  \
         }                                                               \

--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -30,7 +30,7 @@ static int construct_contig(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -113,7 +113,8 @@ static int construct_resized(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
                              yaksa_type_t * newtype, uintptr_t * new_count)
 {
     intptr_t true_lb, lb;
-    uintptr_t true_extent, extent;
+    uintptr_t true_extent;
+    uint64_t extent;
     yaksa_type_t type;
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
@@ -194,7 +195,7 @@ static int construct_vector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -303,7 +304,7 @@ static int construct_hvector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -416,7 +417,7 @@ static int construct_blkindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -553,7 +554,7 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -693,7 +694,7 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -864,7 +865,7 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -1039,7 +1040,7 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
     uintptr_t count;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);
@@ -1156,7 +1157,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
     uintptr_t count = 0;
     DTPI_pool_s *dtpi = dtp.priv;
     int rc = DTP_SUCCESS;
-    uintptr_t extent;
+    uint64_t extent;
 
     /* setup the child type first */
     rc = DTPI_construct_datatype(dtp, attr_tree_depth - 1, &attr->child, &type, &count);

--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -9,7 +9,7 @@
 #include <inttypes.h>
 
 #define VALUE_FITS_IN_INT(val) ((val) <= INT_MAX)
-#define VALUE_FITS_IN_SIZE_T(val) ((val) <= (((uint64_t) 1 << (sizeof(uintptr_t) * 8 - 1)) - 1))
+#define VALUE_FITS_IN_UINTPTR_T(val) ((val) <= (((uint64_t) 1 << (sizeof(uintptr_t) * 8 - 1)) - 1))
 
 #define confirm_extent(type, extent)                                    \
     do {                                                                \
@@ -58,7 +58,7 @@ static int construct_contig(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
 
         count /= attr->u.contig.blklen;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -163,7 +163,7 @@ static int construct_resized(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
             DTPI_ERR_ASSERT(0, rc);
         }
 
-        if (!VALUE_FITS_IN_SIZE_T(e * count))
+        if (!VALUE_FITS_IN_UINTPTR_T(e * count))
             continue;
 
         attr->u.resized.extent = (intptr_t) e;
@@ -273,7 +273,7 @@ static int construct_vector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
         extent *= attr->u.vector.stride * max_displ_idx -
             attr->u.vector.stride * min_displ_idx + attr->u.vector.blklen;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -362,7 +362,7 @@ static int construct_hvector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
         } else {
             DTPI_ERR_ASSERT(0, rc);
         }
-        if (!VALUE_FITS_IN_SIZE_T(stride))
+        if (!VALUE_FITS_IN_UINTPTR_T(stride))
             goto retry;
         attr->u.hvector.stride = (intptr_t) stride;
 
@@ -386,7 +386,7 @@ static int construct_hvector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
             attr->u.hvector.stride * min_displ_idx +
             attr->u.hvector.blklen * attr->child_type_extent;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -523,7 +523,7 @@ static int construct_blkindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
         extent *= attr->u.blkindx.array_of_displs[max_displ_idx] -
             attr->u.blkindx.array_of_displs[min_displ_idx] + attr->u.blkindx.blklen;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -612,14 +612,14 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + 1) * attr->child_type_extent;
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__LARGE) {
             for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen * 4) * attr->child_type_extent;
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__REDUCING) {
@@ -627,14 +627,14 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
                 int idx = attr->u.blkhindx.numblks - i - 1;
                 attr->u.blkhindx.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + 1) * attr->child_type_extent;
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__UNEVEN) {
             for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + i) * attr->child_type_extent;
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else {
@@ -663,7 +663,7 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             attr->u.blkhindx.array_of_displs[min_displ_idx] +
             attr->u.blkindx.blklen * attr->child_type_extent;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -834,7 +834,7 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
             attr->u.indexed.array_of_displs[min_displ_idx] +
             attr->u.indexed.array_of_blklens[max_displ_idx];
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -955,14 +955,14 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             for (int i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] + 1);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__LARGE) {
             for (int i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] * 4);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__REDUCING) {
@@ -971,14 +971,14 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
                 attr->u.hindexed.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.hindexed.array_of_blklens[idx] + 1);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__UNEVEN) {
             for (int i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] + i);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else {
@@ -1009,7 +1009,7 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             attr->u.hindexed.array_of_displs[min_displ_idx] +
             attr->u.hindexed.array_of_blklens[max_displ_idx] * extent;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -1115,7 +1115,7 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             DTPI_ERR_ASSERT(0, rc);
         }
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 
@@ -1248,7 +1248,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] + 1);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__LARGE) {
@@ -1256,7 +1256,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] * 4);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__REDUCING) {
@@ -1265,7 +1265,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                 attr->u.structure.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[idx] + 1);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__UNEVEN) {
@@ -1273,7 +1273,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] + i);
-                if (!VALUE_FITS_IN_SIZE_T(total_displ))
+                if (!VALUE_FITS_IN_UINTPTR_T(total_displ))
                     goto retry;
             }
         } else {
@@ -1305,7 +1305,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
             attr->u.structure.array_of_displs[min_displ_idx] +
             attr->u.structure.array_of_blklens[max_displ_idx] * extent;
 
-        if (VALUE_FITS_IN_SIZE_T(extent * count))
+        if (VALUE_FITS_IN_UINTPTR_T(extent * count))
             break;
     }
 


### PR DESCRIPTION
## Pull Request Description

We calculate the potential extent of a datatype, make sure it fits inside yaksa's extent type format, and then decide whether we can use this datatype or not.  For this, we need the internal calculation of the extent to always be done with 64 bits, so we can eventually check if it is within the required range or not.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
