### PR TITLE
Suppress unused variable warning

### DIFF
--- a/src/frontend/pup/yaksi_iunpack.c
+++ b/src/frontend/pup/yaksi_iunpack.c
@@ -13,9 +13,8 @@ int yaksi_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
                   yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
-    uintptr_t total_bytes = outcount * type->size - outoffset;
 
-    assert(insize <= total_bytes);
+    assert(insize <= outcount * type->size - outoffset);
 
     *actual_unpack_bytes = 0;
 


### PR DESCRIPTION
## Pull Request Description

Cleans up a warning for an unused variable when `assert` goes away.

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
