### PR TITLE
dtpools: warning squash

### DIFF
--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -17,7 +17,7 @@
         intptr_t lb_;                                                   \
         yaksa_type_get_extent(type, &lb_, &type_extent);                     \
         if (type_extent != extent) {                                    \
-            fprintf(stderr, "expected extent of %" PRIuPTR ", but got %" PRIuPTR "\n", extent, type_extent); \
+            fprintf(stderr, "expected extent of %" PRIu64 ", but got %" PRIuPTR "\n", extent, type_extent); \
             fflush(stderr);                                             \
             assert(0);                                                  \
         }                                                               \
@@ -174,7 +174,7 @@ static int construct_resized(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
     rc = yaksa_type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, NULL, newtype);
     DTPI_ERR_CHK_RC(rc);
 
-    confirm_extent(*newtype, attr->u.resized.extent);
+    confirm_extent(*newtype, (uint64_t) attr->u.resized.extent);
 
   fn_exit:
     *new_count = count;


### PR DESCRIPTION
## Pull Request Description

Minor warning squash.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
