### PR TITLE
comment: fix typos in yaksa.h.in

### DIFF
--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -391,7 +391,7 @@ int yaksa_type_get_size(yaksa_type_t type, uintptr_t * size);
  * \brief gets the true extent (true span) of the datatype
  *
  * \param[in]  type         The datatype whose extent is being requested
- * \param[in]  lb           The lowerbound of the datatype
+ * \param[out] lb           The lowerbound of the datatype
  *                          (only used to calculate the extent; does
  *                          not change where the buffer points to)
  * \param[out] extent       The extent of the datatype
@@ -406,7 +406,7 @@ int yaksa_type_get_true_extent(yaksa_type_t type, intptr_t * lb, uintptr_t * ext
  * \brief gets the extent (span) of the datatype
  *
  * \param[in]  type         The datatype whose extent is being requested
- * \param[in]  lb           The lowerbound of the datatype
+ * \param[out] lb           The lowerbound of the datatype
  *                          (only used to calculate the extent; does
  *                          not change where the buffer points to)
  * \param[out] extent       The extent of the datatype


### PR DESCRIPTION
## Pull Request Description

The embedded documentation in `yaksa.h.in` had typos mistaking the `lb` parameter as `[in]` when they should be `[out]`.
<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
