### PR TITLE
cuda: exclude compute_30 when CUDA 11 is used

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -111,41 +111,28 @@ if test ${have_cuda} = "yes" ; then
         case "$sm" in
             all)
                 if test ${cuda_version} -ge 11 ; then
-                    # ampere
-                    PAC_APPEND_FLAG([80],[CUDA_SM])
+                    # maxwell (52) to ampere (80)
+                    supported_cuda_sms="52 53 60 61 62 70 72 75 80"
+                elif test ${cuda_version} -ge 10 ; then
+                    # kepler (30) to turing (75)
+                    supported_cuda_sms="30 35 37 50 52 53 60 61 62 70 72 75"
+                elif test ${cuda_version} -ge 9 ; then
+                    # kepler (30) to volta (72)
+                    supported_cuda_sms="30 35 37 50 52 53 60 61 62 70 72"
+                elif test ${cuda_version} -ge 8 ; then
+                    # kepler (30) to pascal (62)
+                    supported_cuda_sms="30 35 37 50 52 53 60 61 62"
+                elif test ${cuda_version} -ge 6 ; then
+                    # kepler (30) to maxwell (53)
+                    supported_cuda_sms="30 35 37 50 52 53"
+                elif test ${cuda_version} -ge 5 ; then
+                    # kepler (30) to kepler (37)
+                    supported_cuda_sms="30 35 37"
                 fi
 
-                if test ${cuda_version} -ge 10 ; then
-                    # turing
-                    PAC_APPEND_FLAG([75],[CUDA_SM])
-                fi
-
-                if test ${cuda_version} -ge 9 ; then
-                    # volta
-                    PAC_APPEND_FLAG([70],[CUDA_SM])
-                    PAC_APPEND_FLAG([72],[CUDA_SM])
-                fi
-
-                if test ${cuda_version} -ge 8 ; then
-                    # pascal
-                    PAC_APPEND_FLAG([60],[CUDA_SM])
-                    PAC_APPEND_FLAG([61],[CUDA_SM])
-                    PAC_APPEND_FLAG([62],[CUDA_SM])
-                fi
-
-                if test ${cuda_version} -ge 6 ; then
-                    # maxwell
-                    PAC_APPEND_FLAG([50],[CUDA_SM])
-                    PAC_APPEND_FLAG([52],[CUDA_SM])
-                    PAC_APPEND_FLAG([53],[CUDA_SM])
-                fi
-
-                if test ${cuda_version} -ge 5 ; then
-                    # kepler
-                    PAC_APPEND_FLAG([30],[CUDA_SM])
-                    PAC_APPEND_FLAG([35],[CUDA_SM])
-                    PAC_APPEND_FLAG([37],[CUDA_SM])
-                fi
+                for supported_cuda_sm in $supported_cuda_sms ; do
+                    PAC_APPEND_FLAG([$supported_cuda_sm],[CUDA_SM])
+                done
                 ;;
 
             kepler)


### PR DESCRIPTION
## Pull Request Description

CUDA 11 dropped `compute_30` support http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/), but by default (without explicitly setting `--with-cuda-sm`), Yaksa tries to compile `compute_30`, which causes a compilation error. This patch fixes it by excluding `compute_30` when CUDA 11 is used.

For example, `compute_30` is not in allowed values.
```sh
$ nvcc --help
...
--gpu-architecture <arch>                       (-arch)
        ...
        Note: the values compute_30, compute_32, compute_35, compute_37, compute_50,
        sm_30, sm_32, sm_35, sm_37 and sm_50 are deprecated and may be removed in
        a future release.
        Allowed values for this option:  'compute_35','compute_37','compute_50',
        'compute_52','compute_53','compute_60','compute_61','compute_62','compute_70',
        'compute_72','compute_75','compute_80','lto_35','lto_37','lto_50','lto_52',
        'lto_53','lto_60','lto_61','lto_62','lto_70','lto_72','lto_75','lto_80',
        'sm_35','sm_37','sm_50','sm_52','sm_53','sm_60','sm_61','sm_62','sm_70',
        'sm_72','sm_75','sm_80'.
...
```

I have tested it on Summit with CUDA 11.0.3

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

None.

By default CUDA 11 shows many warnings while compiling Yaksa. Maybe we would like to exclude them when CUDA 11 is used.
```sh
nvcc warning : The 'compute_35', 'compute_37', 'compute_50', 'sm_35', 'sm_37' and 'sm_50' architectures are deprecated, and may be removed in a future release (Use -Wno-deprecated-gpu-targets to suppress warning).
```

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
