### PR TITLE
Lockfree conversion of handle to internal object

### DIFF
--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -139,7 +139,7 @@ int yaksa_unflatten(yaksa_type_t * type, const void *flattened_type)
 
     assert(yaksi_type);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(yaksi_type, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -114,9 +114,6 @@ typedef uint64_t yaksa_type_t;
 #define YAKSA_TYPE__SHORT_INT                         ((yaksa_type_t) 55)
 #define YAKSA_TYPE__LONG_DOUBLE_INT                   ((yaksa_type_t) 56)
 
-/* internal: should not be used in applications */
-#define YAKSI_TYPE__LAST                              ((yaksa_type_t) 57)
-
 /*! @} */
 
 

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -70,10 +70,6 @@ struct yaksi_request_s;
 typedef struct {
     yaksu_handle_pool_s type_handle_pool;
     yaksu_handle_pool_s request_handle_pool;
-
-    /* keep a cache of the builtin types, so we do not have to get a
-     * lock to query for them each time */
-    struct yaksi_type_s *yaksi_builtin_types[YAKSI_TYPE__LAST];
 } yaksi_global_s;
 extern yaksi_global_s yaksi_global;
 

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -42,6 +42,30 @@ typedef enum {
 struct yaksi_type_s;
 struct yaksi_request_s;
 
+/*
+ * The type handle is divided into the following parts:
+ *
+ *    32 bits -- unused
+ *    32 bits -- type object id
+ */
+#define YAKSI_TYPE_UNUSED_BITS                  (32)
+#define YAKSI_TYPE_OBJECT_ID_BITS               (32)
+
+#define YAKSI_TYPE_GET_OBJECT_ID(handle) \
+    ((handle) << (64 - YAKSI_TYPE_OBJECT_ID_BITS) >> (64 - YAKSI_TYPE_OBJECT_ID_BITS))
+
+/*
+ * The request handle is divided into the following parts:
+ *
+ *    32 bits -- unused
+ *    32 bits -- request object id
+ */
+#define YAKSI_REQUEST_UNUSED_BITS                  (32)
+#define YAKSI_REQUEST_OBJECT_ID_BITS               (32)
+
+#define YAKSI_REQUEST_GET_OBJECT_ID(handle) \
+    ((handle) << (64 - YAKSI_REQUEST_OBJECT_ID_BITS) >> (64 - YAKSI_REQUEST_OBJECT_ID_BITS))
+
 /* global variables */
 typedef struct {
     yaksu_handle_pool_s type_handle_pool;
@@ -121,7 +145,7 @@ typedef struct yaksi_type_s {
 } yaksi_type_s;
 
 typedef struct yaksi_request_s {
-    uint32_t id;
+    yaksu_handle_t id;
     yaksu_atomic_int cc;        /* completion counter */
 
     /* give some private space for the backend to store content */
@@ -232,8 +256,8 @@ int yaksi_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t i
 int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size);
 
 /* type pool */
-int yaksi_type_handle_alloc(yaksi_type_s * type, uint32_t * handle);
-int yaksi_type_handle_dealloc(uint32_t handle, yaksi_type_s ** type);
+int yaksi_type_handle_alloc(yaksi_type_s * type, yaksu_handle_t * handle);
+int yaksi_type_handle_dealloc(yaksu_handle_t handle, yaksi_type_s ** type);
 int yaksi_type_get(yaksa_type_t type, yaksi_type_s ** yaksi_type);
 
 /* request pool */

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -17,12 +17,12 @@
         YAKSU_ERR_CHKANDJUMP(!tmp_type_, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail); \
         yaksu_atomic_store(&tmp_type_->refcount, 1);                    \
                                                                         \
-        uint32_t id;                                                    \
+        yaksu_handle_t id;                                              \
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
         yaksi_global.yaksi_builtin_types[YAKSA_TYPE__##TYPE] = tmp_type_; \
-        assert(id == (uint32_t) YAKSA_TYPE__##TYPE);                    \
+        assert(id == (yaksu_handle_t) YAKSA_TYPE__##TYPE);              \
     } while (0)
 
 #define ASSIGN_TYPE_HANDLE(OLDTYPE, NEWTYPE, rc, fn_fail)               \
@@ -33,12 +33,12 @@
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
         yaksu_atomic_incr(&tmp_type_->refcount);                        \
                                                                         \
-        uint32_t id;                                                    \
+        yaksu_handle_t id;                                              \
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
         yaksi_global.yaksi_builtin_types[YAKSA_TYPE__##NEWTYPE] = tmp_type_; \
-        assert(id == (uint32_t) YAKSA_TYPE__##NEWTYPE);                 \
+        assert(id == (yaksu_handle_t) YAKSA_TYPE__##NEWTYPE);           \
     } while (0)
 
 #define INT_MATCH_HANDLE(ctype, TYPE, rc, fn_fail)              \
@@ -130,7 +130,7 @@
 
 #define FINALIZE_BUILTIN_TYPE(TYPE, rc, fn_fail)                        \
     do {                                                                \
-        uint32_t id = (uint32_t) YAKSA_TYPE__##TYPE;                    \
+        yaksu_handle_t id = (yaksu_handle_t) YAKSA_TYPE__##TYPE;        \
         yaksi_type_s *tmp_type_;                                        \
                                                                         \
         rc = yaksi_type_handle_dealloc(id, &tmp_type_);                 \
@@ -371,8 +371,8 @@ int yaksa_finalize(void)
 
 
     /* free the NULL request */
-    uint32_t id;
-    id = (uint32_t) YAKSA_REQUEST__NULL;
+    yaksu_handle_t id;
+    id = (yaksu_handle_t) YAKSA_REQUEST__NULL;
     yaksi_request_s *request;
 
     rc = yaksi_request_get(id, &request);

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -21,7 +21,6 @@
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
-        yaksi_global.yaksi_builtin_types[YAKSA_TYPE__##TYPE] = tmp_type_; \
         assert(id == (yaksu_handle_t) YAKSA_TYPE__##TYPE);              \
     } while (0)
 
@@ -37,7 +36,6 @@
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
-        yaksi_global.yaksi_builtin_types[YAKSA_TYPE__##NEWTYPE] = tmp_type_; \
         assert(id == (yaksu_handle_t) YAKSA_TYPE__##NEWTYPE);           \
     } while (0)
 
@@ -188,7 +186,6 @@ int yaksa_init(yaksa_info_t info)
     null_type->is_contig = true;
     null_type->num_contig = 0;
     yaksur_type_create_hook(null_type);
-    yaksi_global.yaksi_builtin_types[YAKSA_TYPE__NULL] = null_type;
 
     INIT_BUILTIN_TYPE(_Bool, _BOOL, rc, fn_fail);
 

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -18,6 +18,8 @@ int yaksi_request_create(yaksi_request_s ** request)
     rc = yaksu_handle_pool_elem_alloc(yaksi_global.request_handle_pool, &req->id, req);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
+    assert(req->id < ((yaksa_request_t) 1 << YAKSI_REQUEST_OBJECT_ID_BITS));
+
     yaksu_atomic_store(&req->cc, 0);
 
     rc = yaksur_request_create_hook(req);
@@ -52,7 +54,7 @@ int yaksi_request_free(yaksi_request_s * request)
 int yaksi_request_get(yaksa_request_t request, struct yaksi_request_s **yaksi_request)
 {
     int rc = YAKSA_SUCCESS;
-    uint32_t id = (uint32_t) request;
+    yaksu_handle_t id = YAKSI_REQUEST_GET_OBJECT_ID(request);
 
     rc = yaksu_handle_pool_elem_get(yaksi_global.request_handle_pool, id,
                                     (const void **) yaksi_request);

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -124,7 +124,7 @@ int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t 
     rc = yaksi_type_create_hindexed_block(count, blocklength, array_of_displs, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -164,7 +164,7 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
                                           &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -78,7 +78,7 @@ int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
     rc = yaksi_type_create_contig(count, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_dup.c
+++ b/src/frontend/types/yaksa_dup.c
@@ -32,7 +32,7 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t 
     rc = yaksi_type_create_dup(intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_free.c
+++ b/src/frontend/types/yaksa_free.c
@@ -95,8 +95,8 @@ int yaksa_type_free(yaksa_type_t type)
     if (type == YAKSA_TYPE__NULL)
         goto fn_exit;
 
-    uint32_t id;
-    id = (uint32_t) type;
+    yaksu_handle_t id;
+    id = (yaksu_handle_t) type;
     rc = yaksi_type_handle_dealloc(id, &yaksi_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -147,7 +147,7 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
                                     &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -190,7 +190,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                                     &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_resized.c
+++ b/src/frontend/types/yaksa_resized.c
@@ -72,7 +72,7 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t exten
     rc = yaksi_type_create_resized(intype, lb, extent, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -169,7 +169,7 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                                   &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -158,7 +158,7 @@ int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *
                                     order, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -97,7 +97,7 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
     rc = yaksi_type_create_hvector(count, blocklength, stride, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -130,7 +130,7 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
                                    &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    uint32_t id;
+    yaksu_handle_t id;
     rc = yaksi_type_handle_alloc(outtype, &id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/types/yaksi_type.c
+++ b/src/frontend/types/yaksi_type.c
@@ -43,14 +43,8 @@ int yaksi_type_get(yaksa_type_t type, struct yaksi_type_s **yaksi_type)
     int rc = YAKSA_SUCCESS;
     yaksu_handle_t id = YAKSI_TYPE_GET_OBJECT_ID(type);
 
-    if (id < YAKSI_TYPE__LAST) {
-        assert(yaksi_global.yaksi_builtin_types[id]);
-        *yaksi_type = yaksi_global.yaksi_builtin_types[id];
-    } else {
-        rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, id,
-                                        (const void **) yaksi_type);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
+    rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, id, (const void **) yaksi_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
     return rc;

--- a/src/frontend/types/yaksi_type.c
+++ b/src/frontend/types/yaksi_type.c
@@ -7,12 +7,14 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksi_type_handle_alloc(yaksi_type_s * type, uint32_t * handle)
+int yaksi_type_handle_alloc(yaksi_type_s * type, yaksu_handle_t * handle)
 {
     int rc = YAKSA_SUCCESS;
 
     rc = yaksu_handle_pool_elem_alloc(yaksi_global.type_handle_pool, handle, type);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    assert(*handle < ((yaksa_type_t) 1 << YAKSI_TYPE_OBJECT_ID_BITS));
 
   fn_exit:
     return rc;
@@ -20,7 +22,7 @@ int yaksi_type_handle_alloc(yaksi_type_s * type, uint32_t * handle)
     goto fn_exit;
 }
 
-int yaksi_type_handle_dealloc(uint32_t handle, yaksi_type_s ** type)
+int yaksi_type_handle_dealloc(yaksu_handle_t handle, yaksi_type_s ** type)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -39,7 +41,7 @@ int yaksi_type_handle_dealloc(uint32_t handle, yaksi_type_s ** type)
 int yaksi_type_get(yaksa_type_t type, struct yaksi_type_s **yaksi_type)
 {
     int rc = YAKSA_SUCCESS;
-    uint32_t id = (uint32_t) type;
+    yaksu_handle_t id = YAKSI_TYPE_GET_OBJECT_ID(type);
 
     if (id < YAKSI_TYPE__LAST) {
         assert(yaksi_global.yaksi_builtin_types[id]);

--- a/src/util/yaksu_handle_pool.c
+++ b/src/util/yaksu_handle_pool.c
@@ -27,7 +27,7 @@
  */
 
 typedef struct handle {
-    uint32_t id;
+    yaksu_handle_t id;
     const void *data;
 
     /* free handles are maintained as a linked list */
@@ -41,7 +41,7 @@ typedef struct handle {
 typedef struct handle_pool {
     pthread_mutex_t mutex;
 
-    uint32_t next_handle;       /* next brand-new handle (never allocated) */
+    yaksu_handle_t next_handle; /* next brand-new handle (never allocated) */
     handle_s *free_handles;     /* list of handles that were allocated, but later freed */
     handle_s *used_handles;     /* hashmap of handles in use */
 } handle_pool_s;
@@ -102,7 +102,8 @@ int yaksu_handle_pool_free(yaksu_handle_pool_s pool)
     return rc;
 }
 
-int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, uint32_t * handle, const void *data)
+int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, yaksu_handle_t * handle,
+                                 const void *data)
 {
     int rc = YAKSA_SUCCESS;
     handle_pool_s *handle_pool = (handle_pool_s *) pool;
@@ -122,7 +123,7 @@ int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, uint32_t * handle, co
     }
 
     el->data = data;
-    HASH_ADD(hh, handle_pool->used_handles, id, sizeof(uint32_t), el);
+    HASH_ADD(hh, handle_pool->used_handles, id, sizeof(yaksu_handle_t), el);
 
     *handle = el->id;
 
@@ -133,7 +134,7 @@ int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, uint32_t * handle, co
     goto fn_exit;
 }
 
-int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, uint32_t handle)
+int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, yaksu_handle_t handle)
 {
     int rc = YAKSA_SUCCESS;
     handle_pool_s *handle_pool = (handle_pool_s *) pool;
@@ -141,7 +142,7 @@ int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, uint32_t handle)
     pthread_mutex_lock(&handle_pool->mutex);
 
     handle_s *el = NULL;
-    HASH_FIND(hh, handle_pool->used_handles, &handle, sizeof(uint32_t), el);
+    HASH_FIND(hh, handle_pool->used_handles, &handle, sizeof(yaksu_handle_t), el);
     assert(el);
 
     DL_PREPEND(handle_pool->free_handles, el);
@@ -151,7 +152,7 @@ int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, uint32_t handle)
     return rc;
 }
 
-int yaksu_handle_pool_elem_get(yaksu_handle_pool_s pool, uint32_t handle, const void **data)
+int yaksu_handle_pool_elem_get(yaksu_handle_pool_s pool, yaksu_handle_t handle, const void **data)
 {
     int rc = YAKSA_SUCCESS;
     handle_pool_s *handle_pool = (handle_pool_s *) pool;
@@ -159,7 +160,7 @@ int yaksu_handle_pool_elem_get(yaksu_handle_pool_s pool, uint32_t handle, const 
     pthread_mutex_lock(&handle_pool->mutex);
 
     handle_s *el = NULL;
-    HASH_FIND(hh, handle_pool->used_handles, &handle, sizeof(uint32_t), el);
+    HASH_FIND(hh, handle_pool->used_handles, &handle, sizeof(yaksu_handle_t), el);
     assert(el);
 
     *data = el->data;

--- a/src/util/yaksu_handle_pool.h
+++ b/src/util/yaksu_handle_pool.h
@@ -7,11 +7,13 @@
 #define YAKSU_HANDLE_POOL_H_INCLUDED
 
 typedef void *yaksu_handle_pool_s;
+typedef uint64_t yaksu_handle_t;
 
 int yaksu_handle_pool_alloc(yaksu_handle_pool_s * pool);
 int yaksu_handle_pool_free(yaksu_handle_pool_s pool);
-int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, uint32_t * handle, const void *data);
-int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, uint32_t handle);
-int yaksu_handle_pool_elem_get(yaksu_handle_pool_s pool, uint32_t handle, const void **data);
+int yaksu_handle_pool_elem_alloc(yaksu_handle_pool_s pool, yaksu_handle_t * handle,
+                                 const void *data);
+int yaksu_handle_pool_elem_free(yaksu_handle_pool_s pool, yaksu_handle_t handle);
+int yaksu_handle_pool_elem_get(yaksu_handle_pool_s pool, yaksu_handle_t handle, const void **data);
 
 #endif /* YAKSU_HANDLE_POOL_H_INCLUDED */


### PR DESCRIPTION
## Pull Request Description

Generalize handle management, and create a handle cache, for faster conversion of handles to internal objects.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
