### PR TITLE
request: destroy event after completion

### DIFF
--- a/src/backend/src/yaksur_request.c
+++ b/src/backend/src/yaksur_request.c
@@ -23,6 +23,11 @@ int yaksur_request_test(yaksi_request_s * request)
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         if (completed) {
+            /* Destroy complete event, in case request is still pending,
+             * and would check this event again in future. */
+            rc = yaksuri_global.gpudriver[id].info->event_destroy(backend->event);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+            backend->event = NULL;
             yaksu_atomic_decr(&request->cc);
         }
     }


### PR DESCRIPTION
Completed event should be destroyed after completion. In case pending
request would query its status again and decrease counter again in
future.

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
