### PR TITLE
cuda: add device lazy initialization option

### DIFF
--- a/src/backend/cuda/pup/yaksuri_cudai_event.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_event.c
@@ -72,14 +72,18 @@ int yaksuri_cudai_event_add_dependency(void *event, int device)
     cerr = cudaGetDevice(&cur_device);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(device);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (device != cur_device) {
+        cerr = cudaSetDevice(device);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
     cerr = cudaStreamWaitEvent(yaksuri_cudai_global.stream[device], (cudaEvent_t) event, 0);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(cur_device);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (device != cur_device) {
+        cerr = cudaSetDevice(cur_device);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
   fn_exit:
     return rc;

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -85,8 +85,10 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     cerr = cudaGetDevice(&cur_device);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(target);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (target != cur_device) {
+        cerr = cudaSetDevice(target);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
     if (*event == NULL) {
         cerr = cudaEventCreate((cudaEvent_t *) event);
@@ -178,8 +180,10 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     cerr = cudaEventRecord((cudaEvent_t) * event, yaksuri_cudai_global.stream[target]);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(cur_device);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (target != cur_device) {
+        cerr = cudaSetDevice(cur_device);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
   fn_exit:
     return rc;
@@ -212,8 +216,10 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
     cerr = cudaGetDevice(&cur_device);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(target);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (target != cur_device) {
+        cerr = cudaSetDevice(target);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
     if (*event == NULL) {
         cerr = cudaEventCreate((cudaEvent_t *) event);
@@ -307,8 +313,10 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
     cerr = cudaEventRecord((cudaEvent_t) * event, yaksuri_cudai_global.stream[target]);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaSetDevice(cur_device);
-    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    if (target != cur_device) {
+        cerr = cudaSetDevice(cur_device);
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
 
   fn_exit:
     return rc;


### PR DESCRIPTION
For systems without NVIDIA Multi-Process Service (MPS) support,
allows yaska to initialize and hook to the current CUDA device only,
and avoids unnecessary cudaSetDevice() from replacing CUDA
driver context. This lazy initialization is controlled by the environment
variable YAKSA_LAZY_INIT_DEVICE.

#114 

Signed-off-by: Huang, Hua <huangh223@gatech.edu>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
