### PR TITLE
Revamped progress engine

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -165,6 +165,8 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info)
     (*info)->ipack = yaksuri_cudai_ipack;
     (*info)->iunpack = yaksuri_cudai_iunpack;
     (*info)->pup_is_supported = yaksuri_cudai_pup_is_supported;
+    (*info)->get_iov_pack_threshold = yaksuri_cudai_get_iov_pack_threshold;
+    (*info)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
     (*info)->host_malloc = cuda_host_malloc;
     (*info)->host_free = cuda_host_free;
     (*info)->gpu_malloc = cuda_gpu_malloc;

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -169,7 +169,9 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info)
     (*info)->host_free = cuda_host_free;
     (*info)->gpu_malloc = cuda_gpu_malloc;
     (*info)->gpu_free = cuda_gpu_free;
+    (*info)->event_create = yaksuri_cudai_event_create;
     (*info)->event_destroy = yaksuri_cudai_event_destroy;
+    (*info)->event_record = yaksuri_cudai_event_record;
     (*info)->event_query = yaksuri_cudai_event_query;
     (*info)->event_synchronize = yaksuri_cudai_event_synchronize;
     (*info)->event_add_dependency = yaksuri_cudai_event_add_dependency;

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -108,7 +108,7 @@ static int check_p2p_comm(int sdev, int ddev, bool * is_enabled)
     return YAKSA_SUCCESS;
 }
 
-int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info)
+int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
 {
     int rc = YAKSA_SUCCESS;
     cudaError_t cerr;
@@ -159,28 +159,28 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info)
     cerr = cudaSetDevice(cur_device);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    *info = (yaksur_gpudriver_info_s *) malloc(sizeof(yaksur_gpudriver_info_s));
-    (*info)->get_num_devices = get_num_devices;
-    (*info)->check_p2p_comm = check_p2p_comm;
-    (*info)->ipack = yaksuri_cudai_ipack;
-    (*info)->iunpack = yaksuri_cudai_iunpack;
-    (*info)->pup_is_supported = yaksuri_cudai_pup_is_supported;
-    (*info)->get_iov_pack_threshold = yaksuri_cudai_get_iov_pack_threshold;
-    (*info)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
-    (*info)->host_malloc = cuda_host_malloc;
-    (*info)->host_free = cuda_host_free;
-    (*info)->gpu_malloc = cuda_gpu_malloc;
-    (*info)->gpu_free = cuda_gpu_free;
-    (*info)->event_create = yaksuri_cudai_event_create;
-    (*info)->event_destroy = yaksuri_cudai_event_destroy;
-    (*info)->event_record = yaksuri_cudai_event_record;
-    (*info)->event_query = yaksuri_cudai_event_query;
-    (*info)->event_synchronize = yaksuri_cudai_event_synchronize;
-    (*info)->event_add_dependency = yaksuri_cudai_event_add_dependency;
-    (*info)->type_create = yaksuri_cudai_type_create_hook;
-    (*info)->type_free = yaksuri_cudai_type_free_hook;
-    (*info)->get_ptr_attr = yaksuri_cudai_get_ptr_attr;
-    (*info)->finalize = finalize_hook;
+    *hooks = (yaksur_gpudriver_hooks_s *) malloc(sizeof(yaksur_gpudriver_hooks_s));
+    (*hooks)->get_num_devices = get_num_devices;
+    (*hooks)->check_p2p_comm = check_p2p_comm;
+    (*hooks)->ipack = yaksuri_cudai_ipack;
+    (*hooks)->iunpack = yaksuri_cudai_iunpack;
+    (*hooks)->pup_is_supported = yaksuri_cudai_pup_is_supported;
+    (*hooks)->get_iov_pack_threshold = yaksuri_cudai_get_iov_pack_threshold;
+    (*hooks)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
+    (*hooks)->host_malloc = cuda_host_malloc;
+    (*hooks)->host_free = cuda_host_free;
+    (*hooks)->gpu_malloc = cuda_gpu_malloc;
+    (*hooks)->gpu_free = cuda_gpu_free;
+    (*hooks)->event_create = yaksuri_cudai_event_create;
+    (*hooks)->event_destroy = yaksuri_cudai_event_destroy;
+    (*hooks)->event_record = yaksuri_cudai_event_record;
+    (*hooks)->event_query = yaksuri_cudai_event_query;
+    (*hooks)->event_synchronize = yaksuri_cudai_event_synchronize;
+    (*hooks)->event_add_dependency = yaksuri_cudai_event_add_dependency;
+    (*hooks)->type_create = yaksuri_cudai_type_create_hook;
+    (*hooks)->type_free = yaksuri_cudai_type_free_hook;
+    (*hooks)->get_ptr_attr = yaksuri_cudai_get_ptr_attr;
+    (*hooks)->finalize = finalize_hook;
 
   fn_exit:
     return rc;

--- a/src/backend/cuda/include/yaksuri_cuda_post.h
+++ b/src/backend/cuda/include/yaksuri_cuda_post.h
@@ -6,6 +6,6 @@
 #ifndef YAKSURI_CUDA_POST_H_INCLUDED
 #define YAKSURI_CUDA_POST_H_INCLUDED
 
-int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info);
+int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks);
 
 #endif /* YAKSURI_CUDA_H_INCLUDED */

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -68,9 +68,9 @@ int yaksuri_cudai_md_alloc(yaksi_type_s * type);
 int yaksuri_cudai_populate_pupfns(yaksi_type_s * type);
 
 int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                        void *gpu_tmpbuf, int device, yaksi_info_s * info, void **event);
+                        yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target);
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                          void *gpu_tmpbuf, int device, yaksi_info_s * info, void **event);
+                          yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported);
 
 /* *INDENT-OFF* */

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -79,6 +79,8 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                           yaksi_info_s * info, int target);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported);
+uintptr_t yaksuri_cudai_get_iov_pack_threshold(yaksi_info_s * info);
+uintptr_t yaksuri_cudai_get_iov_unpack_threshold(yaksi_info_s * info);
 
 /* *INDENT-OFF* */
 #ifdef __cplusplus

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -49,6 +49,11 @@ typedef struct {
     uintptr_t iov_unpack_threshold;
 } yaksuri_cudai_info_s;
 
+typedef struct {
+    cudaEvent_t event;
+    int device;
+} yaksuri_cudai_event_s;
+
 int yaksuri_cudai_finalize_hook(void);
 int yaksuri_cudai_type_create_hook(yaksi_type_s * type);
 int yaksuri_cudai_type_free_hook(yaksi_type_s * type);
@@ -57,7 +62,9 @@ int yaksuri_cudai_info_free_hook(yaksi_info_s * info);
 int yaksuri_cudai_info_keyval_append(yaksi_info_s * info, const char *key, const void *val,
                                      unsigned int vallen);
 
+int yaksuri_cudai_event_create(int device, void **event);
 int yaksuri_cudai_event_destroy(void *event);
+int yaksuri_cudai_event_record(void *event);
 int yaksuri_cudai_event_query(void *event, int *completed);
 int yaksuri_cudai_event_synchronize(void *event);
 int yaksuri_cudai_event_add_dependency(void *event, int device);
@@ -68,9 +75,9 @@ int yaksuri_cudai_md_alloc(yaksi_type_s * type);
 int yaksuri_cudai_populate_pupfns(yaksi_type_s * type);
 
 int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                        yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target);
+                        yaksi_info_s * info, int target);
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                          yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target);
+                          yaksi_info_s * info, int target);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported);
 
 /* *INDENT-OFF* */

--- a/src/backend/cuda/pup/yaksuri_cudai_event.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_event.c
@@ -10,63 +10,13 @@
 #include "yaksu.h"
 #include "yaksuri_cudai.h"
 
-int yaksuri_cudai_event_destroy(void *event)
-{
-    int rc = YAKSA_SUCCESS;
-
-    if (event) {
-        cudaError_t cerr = cudaEventDestroy((cudaEvent_t) event);
-        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
-    }
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksuri_cudai_event_query(void *event, int *completed)
-{
-    int rc = YAKSA_SUCCESS;
-
-    if (event) {
-        cudaError_t cerr = cudaEventQuery((cudaEvent_t) event);
-        if (cerr == cudaSuccess) {
-            *completed = 1;
-        } else if (cerr == cudaErrorNotReady) {
-            *completed = 0;
-        } else {
-            YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
-        }
-    } else {
-        *completed = 1;
-    }
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksuri_cudai_event_synchronize(void *event)
-{
-    int rc = YAKSA_SUCCESS;
-
-    if (event) {
-        cudaError_t cerr = cudaEventSynchronize((cudaEvent_t) event);
-        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
-    }
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksuri_cudai_event_add_dependency(void *event, int device)
+int yaksuri_cudai_event_create(int device, void **event_)
 {
     int rc = YAKSA_SUCCESS;
     cudaError_t cerr;
+    yaksuri_cudai_event_s *event;
+
+    event = (yaksuri_cudai_event_s *) malloc(sizeof(yaksuri_cudai_event_s));
 
     int cur_device;
     cerr = cudaGetDevice(&cur_device);
@@ -75,7 +25,100 @@ int yaksuri_cudai_event_add_dependency(void *event, int device)
     cerr = cudaSetDevice(device);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaStreamWaitEvent(yaksuri_cudai_global.stream[device], (cudaEvent_t) event, 0);
+    cerr = cudaEventCreate(&event->event);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+    cerr = cudaSetDevice(cur_device);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+    event->device = device;
+
+    *event_ = event;
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_cudai_event_destroy(void *event_)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_event_s *event = (yaksuri_cudai_event_s *) event_;
+
+    cudaError_t cerr = cudaEventDestroy(event->event);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+    free(event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_cudai_event_record(void *event_)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_event_s *event = (yaksuri_cudai_event_s *) event_;
+
+    cudaError_t cerr = cudaEventRecord(event->event, yaksuri_cudai_global.stream[event->device]);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_cudai_event_query(void *event_, int *completed)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_event_s *event = (yaksuri_cudai_event_s *) event_;
+
+    cudaError_t cerr = cudaEventQuery(event->event);
+    if (cerr == cudaSuccess) {
+        *completed = 1;
+    } else if (cerr == cudaErrorNotReady) {
+        *completed = 0;
+    } else {
+        YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_cudai_event_synchronize(void *event_)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_cudai_event_s *event = (yaksuri_cudai_event_s *) event_;
+
+    cudaError_t cerr = cudaEventSynchronize(event->event);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_cudai_event_add_dependency(void *event_, int device)
+{
+    int rc = YAKSA_SUCCESS;
+    cudaError_t cerr;
+    yaksuri_cudai_event_s *event = (yaksuri_cudai_event_s *) event_;
+
+    int cur_device;
+    cerr = cudaGetDevice(&cur_device);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+    cerr = cudaSetDevice(device);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+    cerr = cudaStreamWaitEvent(yaksuri_cudai_global.stream[device], event->event, 0);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     cerr = cudaSetDevice(cur_device);

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -61,7 +61,7 @@ int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported)
 }
 
 int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                        void *gpu_tmpbuf, int target, yaksi_info_s * info, void **event)
+                        yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_cudai_type_s *cuda_type = (yaksuri_cudai_type_s *) type->backend.cuda.priv;
@@ -188,7 +188,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
 }
 
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                          void *gpu_tmpbuf, int target, yaksi_info_s * info, void **event)
+                          yaksi_info_s * info, void **event, void *gpu_tmpbuf, int target)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_cudai_type_s *cuda_type = (yaksuri_cudai_type_s *) type->backend.cuda.priv;

--- a/src/backend/cuda/stub/yaksuri_cuda_post.h
+++ b/src/backend/cuda/stub/yaksuri_cuda_post.h
@@ -6,10 +6,10 @@
 #ifndef YAKSURI_CUDA_POST_H_INCLUDED
 #define YAKSURI_CUDA_POST_H_INCLUDED
 
-static int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info) ATTRIBUTE((unused));
-static int yaksuri_cuda_init_hook(yaksur_gpudriver_info_s ** info)
+static int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks) ATTRIBUTE((unused));
+static int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
 {
-    *info = NULL;
+    *hooks = NULL;
 
     return YAKSA_SUCCESS;
 }

--- a/src/backend/seq/include/yaksuri_seq_post.h
+++ b/src/backend/seq/include/yaksuri_seq_post.h
@@ -16,9 +16,9 @@ int yaksuri_seq_info_keyval_append(yaksi_info_s * info, const char *key, const v
                                    unsigned int vallen);
 
 int yaksuri_seq_pup_is_supported(yaksi_type_s * type, bool * is_supported);
-int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_info_s * info,
-                      yaksi_type_s * type);
-int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_info_s * info,
-                        yaksi_type_s * type);
+int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                      yaksi_info_s * info);
+int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                        yaksi_info_s * info);
 
 #endif /* YAKSURI_SEQ_H_INCLUDED */

--- a/src/backend/seq/pup/yaksuri_seq_pup.c
+++ b/src/backend/seq/pup/yaksuri_seq_pup.c
@@ -24,8 +24,8 @@ int yaksuri_seq_pup_is_supported(yaksi_type_s * type, bool * is_supported)
     return rc;
 }
 
-int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_info_s * info,
-                      yaksi_type_s * type)
+int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                      yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_seqi_type_s *seq_type = (yaksuri_seqi_type_s *) type->backend.seq.priv;
@@ -92,8 +92,8 @@ int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_in
     goto fn_exit;
 }
 
-int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_info_s * info,
-                        yaksi_type_s * type)
+int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                        yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_seqi_type_s *seq_type = (yaksuri_seqi_type_s *) type->backend.seq.priv;

--- a/src/backend/seq/pup/yaksuri_seq_pup.c
+++ b/src/backend/seq/pup/yaksuri_seq_pup.c
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#define MAX_IOV_LENGTH (16384)
+#define MAX_IOV_LENGTH (8192)
 
 int yaksuri_seq_pup_is_supported(yaksi_type_s * type, bool * is_supported)
 {
@@ -39,51 +39,25 @@ int yaksuri_seq_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_ty
     if (type->is_contig) {
         memcpy(outbuf, (const char *) inbuf + type->true_lb, type->size * count);
     } else if (type->size / type->num_contig >= iov_pack_threshold) {
-        struct iovec *iov;
-        uintptr_t actual_iov_len;
-
-        if (type->num_contig * count <= MAX_IOV_LENGTH) {
-            iov = (struct iovec *) malloc(type->num_contig * count * sizeof(struct iovec));
-
-            rc = yaksi_iov(inbuf, count, type, 0, iov, MAX_IOV_LENGTH, &actual_iov_len);
+        struct iovec iov[MAX_IOV_LENGTH];
+        char *dbuf = (char *) outbuf;
+        uintptr_t offset = 0;
+        while (offset < type->num_contig * count) {
+            uintptr_t actual_iov_len;
+            rc = yaksi_iov(inbuf, count, type, offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            assert(actual_iov_len == type->num_contig * count);
 
-            char *dbuf = (char *) outbuf;
             for (uintptr_t i = 0; i < actual_iov_len; i++) {
                 memcpy(dbuf, iov[i].iov_base, iov[i].iov_len);
                 dbuf += iov[i].iov_len;
             }
 
-            free(iov);
-        } else if (type->num_contig <= MAX_IOV_LENGTH) {
-            iov = (struct iovec *) malloc(type->num_contig * sizeof(struct iovec));
-
-            uintptr_t iov_offset = 0;
-            char *dbuf = (char *) outbuf;
-            const char *sbuf = (const char *) inbuf;
-            for (uintptr_t i = 0; i < count; i++) {
-                rc = yaksi_iov(sbuf, 1, type, iov_offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
-                YAKSU_ERR_CHECK(rc, fn_fail);
-                assert(actual_iov_len == type->num_contig);
-
-                for (uintptr_t j = 0; j < actual_iov_len; j++) {
-                    memcpy(dbuf, iov[j].iov_base, iov[j].iov_len);
-                    dbuf += iov[j].iov_len;
-                }
-
-                sbuf += type->extent;
-            }
-
-            free(iov);
-        } else {
-            rc = YAKSA_ERR__NOT_SUPPORTED;
+            offset += actual_iov_len;
         }
-    } else if (seq_type->pack) {
+    } else {
+        assert(seq_type->pack);
         rc = seq_type->pack(inbuf, outbuf, count, type);
         YAKSU_ERR_CHECK(rc, fn_fail);
-    } else {
-        rc = YAKSA_ERR__NOT_SUPPORTED;
     }
 
   fn_exit:
@@ -107,51 +81,26 @@ int yaksuri_seq_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     if (type->is_contig) {
         memcpy((char *) outbuf + type->true_lb, inbuf, type->size * count);
     } else if (type->size / type->num_contig >= iov_unpack_threshold) {
-        struct iovec *iov;
-        uintptr_t actual_iov_len;
+        struct iovec iov[MAX_IOV_LENGTH];
+        const char *sbuf = (const char *) inbuf;
+        uintptr_t offset = 0;
 
-        if (type->num_contig * count <= MAX_IOV_LENGTH) {
-            iov = (struct iovec *) malloc(type->num_contig * count * sizeof(struct iovec));
-
-            rc = yaksi_iov(outbuf, count, type, 0, iov, MAX_IOV_LENGTH, &actual_iov_len);
+        while (offset < type->num_contig * count) {
+            uintptr_t actual_iov_len;
+            rc = yaksi_iov(outbuf, count, type, offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            assert(actual_iov_len == type->num_contig * count);
 
-            const char *sbuf = (const char *) inbuf;
             for (uintptr_t i = 0; i < actual_iov_len; i++) {
                 memcpy(iov[i].iov_base, sbuf, iov[i].iov_len);
                 sbuf += iov[i].iov_len;
             }
 
-            free(iov);
-        } else if (type->num_contig <= MAX_IOV_LENGTH) {
-            iov = (struct iovec *) malloc(type->num_contig * sizeof(struct iovec));
-
-            uintptr_t iov_offset = 0;
-            char *dbuf = (char *) outbuf;
-            const char *sbuf = (const char *) inbuf;
-            for (uintptr_t i = 0; i < count; i++) {
-                rc = yaksi_iov(dbuf, 1, type, iov_offset, iov, MAX_IOV_LENGTH, &actual_iov_len);
-                YAKSU_ERR_CHECK(rc, fn_fail);
-                assert(actual_iov_len == type->num_contig);
-
-                for (uintptr_t j = 0; j < actual_iov_len; j++) {
-                    memcpy(iov[j].iov_base, sbuf, iov[j].iov_len);
-                    sbuf += iov[j].iov_len;
-                }
-
-                dbuf += type->extent;
-            }
-
-            free(iov);
-        } else {
-            rc = YAKSA_ERR__NOT_SUPPORTED;
+            offset += actual_iov_len;
         }
-    } else if (seq_type->unpack) {
+    } else {
+        assert(seq_type->unpack);
         rc = seq_type->unpack(inbuf, outbuf, count, type);
         YAKSU_ERR_CHECK(rc, fn_fail);
-    } else {
-        rc = YAKSA_ERR__NOT_SUPPORTED;
     }
 
   fn_exit:

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -154,6 +154,7 @@ int yaksur_request_create_hook(yaksi_request_s * request)
     request->backend.priv = malloc(sizeof(yaksuri_request_s));
     yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
 
+    backend->optype = YAKSURI_OPTYPE__UNSET;
     backend->event = NULL;
     backend->kind = YAKSURI_REQUEST_KIND__UNSET;
 

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -27,7 +27,6 @@ struct yaksi_type_s;
 struct yaksi_info_s;
 
 typedef struct yaksur_type_s {
-    void *priv;
     yaksuri_seq_type_s seq;
     yaksuri_cuda_type_s cuda;
 } yaksur_type_s;

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -48,10 +48,10 @@ typedef struct yaksur_gpudriver_info_s {
 
     /* pup functions */
     int (*ipack) (const void *inbuf, void *outbuf, uintptr_t count,
-                  struct yaksi_type_s * type, void *device_tmpbuf, int device,
-                  struct yaksi_info_s * info, void **event);
+                  struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
+                  void *device_tmpbuf, int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,
-                    void *device_tmpbuf, int device, struct yaksi_info_s * info, void **event);
+                    struct yaksi_info_s * info, void **event, void *device_tmpbuf, int device);
     int (*pup_is_supported) (struct yaksi_type_s * type, bool * is_supported);
 
     /* memory management */

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -47,6 +47,10 @@ typedef struct yaksur_gpudriver_info_s {
     int (*finalize) (void);
 
     /* pup functions */
+    /* *INDENT-OFF* */
+    uintptr_t (*get_iov_pack_threshold) (struct yaksi_info_s * info);
+    uintptr_t (*get_iov_unpack_threshold) (struct yaksi_info_s * info);
+    /* *INDENT-ON* */
     int (*ipack) (const void *inbuf, void *outbuf, uintptr_t count,
                   struct yaksi_type_s * type, struct yaksi_info_s * info, int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -48,10 +48,9 @@ typedef struct yaksur_gpudriver_info_s {
 
     /* pup functions */
     int (*ipack) (const void *inbuf, void *outbuf, uintptr_t count,
-                  struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
-                  void *device_tmpbuf, int device);
+                  struct yaksi_type_s * type, struct yaksi_info_s * info, int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,
-                    struct yaksi_info_s * info, void **event, void *device_tmpbuf, int device);
+                    struct yaksi_info_s * info, int device);
     int (*pup_is_supported) (struct yaksi_type_s * type, bool * is_supported);
 
     /* memory management */
@@ -62,7 +61,9 @@ typedef struct yaksur_gpudriver_info_s {
     int (*get_ptr_attr) (const void *buf, yaksur_ptr_attr_s * ptrattr);
 
     /* events */
+    int (*event_create) (int device, void **event);
     int (*event_destroy) (void *event);
+    int (*event_record) (void *event);
     int (*event_query) (void *event, int *completed);
     int (*event_synchronize) (void *event);
     int (*event_add_dependency) (void *event, int device);

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -40,7 +40,7 @@ typedef struct {
     yaksuri_cuda_info_s cuda;
 } yaksur_info_s;
 
-typedef struct yaksur_gpudriver_info_s {
+typedef struct yaksur_gpudriver_hooks_s {
     /* miscellaneous */
     int (*get_num_devices) (int *ndevices);
     int (*check_p2p_comm) (int sdev, int ddev, bool * is_enabled);
@@ -81,6 +81,6 @@ typedef struct yaksur_gpudriver_info_s {
     int (*info_free) (struct yaksi_info_s * info);
     int (*info_keyval_append) (struct yaksi_info_s * info, const char *key, const void *val,
                                unsigned int vallen);
-} yaksur_gpudriver_info_s;
+} yaksur_gpudriver_hooks_s;
 
 #endif /* YAKSUR_PRE_H_INCLUDED */

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -56,7 +56,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
                 yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
-    yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver, id;
+    yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver;
     yaksuri_request_s *request_backend = (yaksuri_request_s *) request->backend.priv;
 
     if (request_backend->optype == YAKSURI_OPTYPE__PACK) {
@@ -74,20 +74,6 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
                           &outbuf_gpudriver);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
-
-    if (inbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET &&
-        outbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = YAKSURI_GPUDRIVER_ID__UNSET;
-    } else if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET &&
-               outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        assert(inbuf_gpudriver == outbuf_gpudriver);
-        id = inbuf_gpudriver;
-    } else if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = inbuf_gpudriver;
-    } else if (outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = outbuf_gpudriver;
-    }
-
 
     /* if this can be handled by the CPU, wrap it up */
     if (request_backend->inattr.type != YAKSUR_PTR_TYPE__GPU &&
@@ -110,101 +96,23 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
         goto fn_exit;
     }
 
+    /* if this cannot be handled by the CPU, queue it up for the GPU
+     * to handle */
+    assert(inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET ||
+           outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET);
 
-    /* if we are here, one of the GPU backends should have claimed the
-     * buffers */
-    assert(id != YAKSURI_GPUDRIVER_ID__UNSET);
+    if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET &&
+        outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
+        assert(inbuf_gpudriver == outbuf_gpudriver);
+        request_backend->gpudriver_id = inbuf_gpudriver;
+    } else if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
+        request_backend->gpudriver_id = inbuf_gpudriver;
+    } else if (outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
+        request_backend->gpudriver_id = outbuf_gpudriver;
+    }
 
-    /* if the GPU backend cannot support this type, return */
-    bool is_supported;
-    rc = yaksuri_global.gpudriver[id].info->pup_is_supported(type, &is_supported);
+    rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    if (!is_supported) {
-        rc = YAKSA_ERR__NOT_SUPPORTED;
-        goto fn_exit;
-    }
-
-
-    request_backend->gpudriver_id = id;
-    assert(yaksuri_global.gpudriver[id].info);
-
-    int (*pupfn) (const void *inbuf, void *outbuf, uintptr_t count,
-                  struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
-                  void *device_tmpbuf, int device);
-    if (request_backend->optype == YAKSURI_OPTYPE__PACK) {
-        pupfn = yaksuri_global.gpudriver[id].info->ipack;
-    } else {
-        pupfn = yaksuri_global.gpudriver[id].info->iunpack;
-    }
-
-    if (request_backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
-        request_backend->outattr.type == YAKSUR_PTR_TYPE__GPU &&
-        request_backend->inattr.device == request_backend->outattr.device) {
-        /* gpu-to-gpu copies do not need temporary buffers */
-        bool first_event = !request_backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &request_backend->event, NULL,
-                   request_backend->inattr.device);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else if (type->is_contig && request_backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
-               request_backend->outattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !request_backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &request_backend->event, NULL,
-                   request_backend->inattr.device);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else if (type->is_contig && request_backend->inattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST
-               && request_backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !request_backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &request_backend->event, NULL,
-                   request_backend->outattr.device);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else {
-        /* we need temporary buffers and pipelining; queue it up in
-         * the progress engine */
-        request_backend->kind = YAKSURI_REQUEST_KIND__STAGED;
-
-        rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        rc = yaksuri_progress_poke();
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
 
   fn_exit:
     return rc;

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -53,14 +53,14 @@ static int get_ptr_attr(const void *buf, yaksur_ptr_attr_s * ptrattr, yaksuri_gp
  */
 
 static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                yaksi_info_s * info, yaksi_request_s * request, yaksuri_puptype_e puptype)
+                yaksi_info_s * info, yaksi_request_s * request, yaksuri_optype_e optype)
 {
     int rc = YAKSA_SUCCESS;
     yaksur_ptr_attr_s inattr, outattr;
     yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver, id;
     yaksuri_request_s *request_backend = (yaksuri_request_s *) request->backend.priv;
 
-    if (puptype == YAKSURI_PUPTYPE__PACK) {
+    if (optype == YAKSURI_OPTYPE__PACK) {
         rc = get_ptr_attr((const char *) inbuf + type->true_lb, &inattr, &inbuf_gpudriver);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -97,7 +97,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
         if (!is_supported) {
             rc = YAKSA_ERR__NOT_SUPPORTED;
         } else {
-            if (puptype == YAKSURI_PUPTYPE__PACK) {
+            if (optype == YAKSURI_OPTYPE__PACK) {
                 rc = yaksuri_seq_ipack(inbuf, outbuf, count, type, info);
                 YAKSU_ERR_CHECK(rc, fn_fail);
             } else {
@@ -130,7 +130,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
     int (*pupfn) (const void *inbuf, void *outbuf, uintptr_t count,
                   struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
                   void *device_tmpbuf, int device);
-    if (puptype == YAKSURI_PUPTYPE__PACK) {
+    if (optype == YAKSURI_OPTYPE__PACK) {
         pupfn = yaksuri_global.gpudriver[id].info->ipack;
     } else {
         pupfn = yaksuri_global.gpudriver[id].info->iunpack;
@@ -194,7 +194,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
         request_backend->kind = YAKSURI_REQUEST_KIND__STAGED;
 
         rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request,
-                                      inattr, outattr, puptype);
+                                      inattr, outattr, optype);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = yaksuri_progress_poke();
@@ -212,7 +212,7 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_PUPTYPE__PACK);
+    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_OPTYPE__PACK);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -226,7 +226,7 @@ int yaksur_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_PUPTYPE__UNPACK);
+    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_OPTYPE__UNPACK);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -52,19 +52,27 @@ static int get_ptr_attr(const void *buf, yaksur_ptr_attr_s * ptrattr, yaksuri_gp
  *     (STAGED).
  */
 
-int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                 yaksi_info_s * info, yaksi_request_s * request)
+static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                yaksi_info_s * info, yaksi_request_s * request, yaksuri_puptype_e puptype)
 {
     int rc = YAKSA_SUCCESS;
     yaksur_ptr_attr_s inattr, outattr;
     yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver, id;
     yaksuri_request_s *request_backend = (yaksuri_request_s *) request->backend.priv;
 
-    rc = get_ptr_attr((const char *) inbuf + type->true_lb, &inattr, &inbuf_gpudriver);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (puptype == YAKSURI_PUPTYPE__PACK) {
+        rc = get_ptr_attr((const char *) inbuf + type->true_lb, &inattr, &inbuf_gpudriver);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = get_ptr_attr(outbuf, &outattr, &outbuf_gpudriver);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        rc = get_ptr_attr(outbuf, &outattr, &outbuf_gpudriver);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        rc = get_ptr_attr(inbuf, &inattr, &inbuf_gpudriver);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = get_ptr_attr((char *) outbuf + type->true_lb, &outattr, &outbuf_gpudriver);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     if (inbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET &&
         outbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET) {
@@ -89,8 +97,13 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
         if (!is_supported) {
             rc = YAKSA_ERR__NOT_SUPPORTED;
         } else {
-            rc = yaksuri_seq_ipack(inbuf, outbuf, count, info, type);
-            YAKSU_ERR_CHECK(rc, fn_fail);
+            if (puptype == YAKSURI_PUPTYPE__PACK) {
+                rc = yaksuri_seq_ipack(inbuf, outbuf, count, info, type);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            } else {
+                rc = yaksuri_seq_iunpack(inbuf, outbuf, count, info, type);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            }
         }
         goto fn_exit;
     }
@@ -114,12 +127,20 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
     request_backend->gpudriver_id = id;
     assert(yaksuri_global.gpudriver[id].info);
 
+    int (*pupfn) (const void *inbuf, void *outbuf, uintptr_t count,
+                  struct yaksi_type_s * type, void *device_tmpbuf, int device,
+                  struct yaksi_info_s * info, void **event);
+    if (puptype == YAKSURI_PUPTYPE__PACK) {
+        pupfn = yaksuri_global.gpudriver[id].info->ipack;
+    } else {
+        pupfn = yaksuri_global.gpudriver[id].info->iunpack;
+    }
+
     if (inattr.type == YAKSUR_PTR_TYPE__GPU && outattr.type == YAKSUR_PTR_TYPE__GPU &&
         inattr.device == outattr.device) {
         /* gpu-to-gpu copies do not need temporary buffers */
         bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->ipack(inbuf, outbuf, count, type, NULL,
-                                                      inattr.device, info, &request_backend->event);
+        rc = pupfn(inbuf, outbuf, count, type, NULL, inattr.device, info, &request_backend->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         if (first_event) {
@@ -137,8 +158,7 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
          * temporary buffers either, if the host buffer is registered
          * and the type is contiguous */
         bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->ipack(inbuf, outbuf, count, type, NULL,
-                                                      inattr.device, info, &request_backend->event);
+        rc = pupfn(inbuf, outbuf, count, type, NULL, inattr.device, info, &request_backend->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         if (first_event) {
@@ -156,9 +176,7 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
          * temporary buffers either, if the host buffer is registered
          * and the type is contiguous */
         bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->ipack(inbuf, outbuf, count, type, NULL,
-                                                      outattr.device, info,
-                                                      &request_backend->event);
+        rc = pupfn(inbuf, outbuf, count, type, NULL, outattr.device, info, &request_backend->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         if (first_event) {
@@ -176,7 +194,7 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
         request_backend->kind = YAKSURI_REQUEST_KIND__STAGED;
 
         rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, request,
-                                      inattr, outattr, YAKSURI_PUPTYPE__PACK, info);
+                                      inattr, outattr, puptype, info);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = yaksuri_progress_poke();
@@ -189,138 +207,27 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
     goto fn_exit;
 }
 
+int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                 yaksi_info_s * info, yaksi_request_s * request)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_PUPTYPE__PACK);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
 int yaksur_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                    yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
-    yaksur_ptr_attr_s inattr, outattr;
-    yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver, id;
-    yaksuri_request_s *request_backend = (yaksuri_request_s *) request->backend.priv;
 
-    rc = get_ptr_attr(inbuf, &inattr, &inbuf_gpudriver);
+    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_PUPTYPE__UNPACK);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    rc = get_ptr_attr((char *) outbuf + type->true_lb, &outattr, &outbuf_gpudriver);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    if (inbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET &&
-        outbuf_gpudriver == YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = YAKSURI_GPUDRIVER_ID__UNSET;
-    } else if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET &&
-               outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        assert(inbuf_gpudriver == outbuf_gpudriver);
-        id = inbuf_gpudriver;
-    } else if (inbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = inbuf_gpudriver;
-    } else if (outbuf_gpudriver != YAKSURI_GPUDRIVER_ID__UNSET) {
-        id = outbuf_gpudriver;
-    }
-
-
-    /* if this can be handled by the CPU, wrap it up */
-    if (inattr.type != YAKSUR_PTR_TYPE__GPU && outattr.type != YAKSUR_PTR_TYPE__GPU) {
-        bool is_supported;
-        rc = yaksuri_seq_pup_is_supported(type, &is_supported);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (!is_supported) {
-            rc = YAKSA_ERR__NOT_SUPPORTED;
-        } else {
-            rc = yaksuri_seq_iunpack(inbuf, outbuf, count, info, type);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        }
-        goto fn_exit;
-    }
-
-
-    /* if we are here, one of the GPU backends should have claimed the
-     * buffers */
-    assert(id != YAKSURI_GPUDRIVER_ID__UNSET);
-
-    /* if the GPU backend cannot support this type, return */
-    bool is_supported;
-    rc = yaksuri_global.gpudriver[id].info->pup_is_supported(type, &is_supported);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    if (!is_supported) {
-        rc = YAKSA_ERR__NOT_SUPPORTED;
-        goto fn_exit;
-    }
-
-
-    request_backend->gpudriver_id = id;
-    assert(yaksuri_global.gpudriver[id].info);
-
-    if (inattr.type == YAKSUR_PTR_TYPE__GPU && outattr.type == YAKSUR_PTR_TYPE__GPU &&
-        inattr.device == outattr.device) {
-        /* gpu-to-gpu copies do not need temporary buffers */
-        bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->iunpack(inbuf, outbuf, count, type, NULL,
-                                                        inattr.device, info,
-                                                        &request_backend->event);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else if (type->is_contig && inattr.type == YAKSUR_PTR_TYPE__GPU &&
-               outattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->iunpack(inbuf, outbuf, count, type, NULL,
-                                                        inattr.device, info,
-                                                        &request_backend->event);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else if (type->is_contig && inattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
-               outattr.type == YAKSUR_PTR_TYPE__GPU) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !request_backend->event;
-        rc = yaksuri_global.gpudriver[id].info->iunpack(inbuf, outbuf, count, type, NULL,
-                                                        outattr.device, info,
-                                                        &request_backend->event);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (request_backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            request_backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else {
-        /* we need temporary buffers and pipelining; queue it up in
-         * the progress engine */
-        request_backend->kind = YAKSURI_REQUEST_KIND__STAGED;
-
-        rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, request,
-                                      inattr, outattr, YAKSURI_PUPTYPE__UNPACK, info);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        rc = yaksuri_progress_poke();
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
 
   fn_exit:
     return rc;

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -39,19 +39,6 @@ static int get_ptr_attr(const void *buf, yaksur_ptr_attr_s * ptrattr, yaksuri_gp
     goto fn_exit;
 }
 
-/*
- * In all of the "DIRECT" cases below, there are a few important
- * things to note:
- *
- *  1. We increment the completion counter only for the first
- *     incomplete request.  Future incomplete requests simply
- *     overwrite the event.
- *
- *  2. We use an increment instead of an atomic store, because some
- *     operations in this request might go through the progress engine
- *     (STAGED).
- */
-
 static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                 yaksi_info_s * info, yaksi_request_s * request)
 {

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -53,14 +53,14 @@ static int get_ptr_attr(const void *buf, yaksur_ptr_attr_s * ptrattr, yaksuri_gp
  */
 
 static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                yaksi_info_s * info, yaksi_request_s * request, yaksuri_optype_e optype)
+                yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
     yaksur_ptr_attr_s inattr, outattr;
     yaksuri_gpudriver_id_e inbuf_gpudriver, outbuf_gpudriver, id;
     yaksuri_request_s *request_backend = (yaksuri_request_s *) request->backend.priv;
 
-    if (optype == YAKSURI_OPTYPE__PACK) {
+    if (request_backend->optype == YAKSURI_OPTYPE__PACK) {
         rc = get_ptr_attr((const char *) inbuf + type->true_lb, &inattr, &inbuf_gpudriver);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -97,7 +97,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
         if (!is_supported) {
             rc = YAKSA_ERR__NOT_SUPPORTED;
         } else {
-            if (optype == YAKSURI_OPTYPE__PACK) {
+            if (request_backend->optype == YAKSURI_OPTYPE__PACK) {
                 rc = yaksuri_seq_ipack(inbuf, outbuf, count, type, info);
                 YAKSU_ERR_CHECK(rc, fn_fail);
             } else {
@@ -130,7 +130,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
     int (*pupfn) (const void *inbuf, void *outbuf, uintptr_t count,
                   struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
                   void *device_tmpbuf, int device);
-    if (optype == YAKSURI_OPTYPE__PACK) {
+    if (request_backend->optype == YAKSURI_OPTYPE__PACK) {
         pupfn = yaksuri_global.gpudriver[id].info->ipack;
     } else {
         pupfn = yaksuri_global.gpudriver[id].info->iunpack;
@@ -193,8 +193,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
          * the progress engine */
         request_backend->kind = YAKSURI_REQUEST_KIND__STAGED;
 
-        rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request,
-                                      inattr, outattr, optype);
+        rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request, inattr, outattr);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = yaksuri_progress_poke();
@@ -211,8 +210,10 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
                  yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
 
-    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_OPTYPE__PACK);
+    backend->optype = YAKSURI_OPTYPE__PACK;
+    rc = ipup(inbuf, outbuf, count, type, info, request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -225,8 +226,10 @@ int yaksur_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_
                    yaksi_info_s * info, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_request_s *backend = (yaksuri_request_s *) request->backend.priv;
 
-    rc = ipup(inbuf, outbuf, count, type, info, request, YAKSURI_OPTYPE__UNPACK);
+    backend->optype = YAKSURI_OPTYPE__UNPACK;
+    rc = ipup(inbuf, outbuf, count, type, info, request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -46,9 +46,9 @@ typedef struct {
 } yaksuri_request_s;
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                             yaksi_request_s * request, yaksur_ptr_attr_s inattr,
-                             yaksur_ptr_attr_s outattr, yaksuri_puptype_e puptype,
-                             yaksi_info_s * info);
+                             yaksi_info_s * info, yaksi_request_s * request,
+                             yaksur_ptr_attr_s inattr, yaksur_ptr_attr_s outattr,
+                             yaksuri_puptype_e puptype);
 int yaksuri_progress_poke(void);
 
 #endif /* YAKSURI_H_INCLUDED */

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -37,6 +37,9 @@ extern yaksuri_global_s yaksuri_global;
 
 typedef struct {
     yaksuri_optype_e optype;
+    yaksur_ptr_attr_s inattr;
+    yaksur_ptr_attr_s outattr;
+
     yaksuri_gpudriver_id_e gpudriver_id;
     void *event;
 
@@ -48,8 +51,7 @@ typedef struct {
 } yaksuri_request_s;
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                             yaksi_info_s * info, yaksi_request_s * request,
-                             yaksur_ptr_attr_s inattr, yaksur_ptr_attr_s outattr);
+                             yaksi_info_s * info, yaksi_request_s * request);
 int yaksuri_progress_poke(void);
 
 #endif /* YAKSURI_H_INCLUDED */

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -15,9 +15,9 @@ typedef enum yaksuri_gpudriver_id_e {
 } yaksuri_gpudriver_id_e;
 
 typedef enum yaksuri_pup_e {
-    YAKSURI_PUPTYPE__PACK,
-    YAKSURI_PUPTYPE__UNPACK,
-} yaksuri_puptype_e;
+    YAKSURI_OPTYPE__PACK,
+    YAKSURI_OPTYPE__UNPACK,
+} yaksuri_optype_e;
 
 typedef struct {
     void *slab;
@@ -48,7 +48,7 @@ typedef struct {
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                              yaksi_info_s * info, yaksi_request_s * request,
                              yaksur_ptr_attr_s inattr, yaksur_ptr_attr_s outattr,
-                             yaksuri_puptype_e puptype);
+                             yaksuri_optype_e optype);
 int yaksuri_progress_poke(void);
 
 #endif /* YAKSURI_H_INCLUDED */

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -27,7 +27,7 @@ typedef struct {
     struct {
         yaksu_buffer_pool_s host;
         yaksu_buffer_pool_s *device;
-        yaksur_gpudriver_info_s *info;
+        yaksur_gpudriver_hooks_s *hooks;
         int ndevices;
     } gpudriver[YAKSURI_GPUDRIVER_ID__LAST];
 } yaksuri_global_s;
@@ -70,9 +70,9 @@ typedef struct yaksuri_subreq {
             uintptr_t issued_count;
             yaksuri_subreq_chunk_s *chunks;
 
-            int (*acquire) (struct yaksuri_request * backend, struct yaksuri_subreq * subreq,
+            int (*acquire) (struct yaksuri_request * reqpriv, struct yaksuri_subreq * subreq,
                             struct yaksuri_subreq_chunk ** chunk);
-            int (*release) (struct yaksuri_request * backend, struct yaksuri_subreq * subreq,
+            int (*release) (struct yaksuri_request * reqpriv, struct yaksuri_subreq * subreq,
                             struct yaksuri_subreq_chunk * chunk);
         } multiple;
     } u;

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -15,6 +15,7 @@ typedef enum yaksuri_gpudriver_id_e {
 } yaksuri_gpudriver_id_e;
 
 typedef enum yaksuri_pup_e {
+    YAKSURI_OPTYPE__UNSET,
     YAKSURI_OPTYPE__PACK,
     YAKSURI_OPTYPE__UNPACK,
 } yaksuri_optype_e;
@@ -35,6 +36,7 @@ typedef struct {
 extern yaksuri_global_s yaksuri_global;
 
 typedef struct {
+    yaksuri_optype_e optype;
     yaksuri_gpudriver_id_e gpudriver_id;
     void *event;
 
@@ -47,8 +49,7 @@ typedef struct {
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                              yaksi_info_s * info, yaksi_request_s * request,
-                             yaksur_ptr_attr_s inattr, yaksur_ptr_attr_s outattr,
-                             yaksuri_optype_e optype);
+                             yaksur_ptr_attr_s inattr, yaksur_ptr_attr_s outattr);
 int yaksuri_progress_poke(void);
 
 #endif /* YAKSURI_H_INCLUDED */

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -20,17 +20,15 @@ typedef enum yaksuri_pup_e {
     YAKSURI_OPTYPE__UNPACK,
 } yaksuri_optype_e;
 
-typedef struct {
-    void *slab;
-    uintptr_t slab_head_offset;
-    uintptr_t slab_tail_offset;
-} yaksuri_slab_s;
+#define YAKSURI_TMPBUF_EL_SIZE  (1024 * 1024)
+#define YAKSURI_TMPBUF_NUM_EL   (16)
 
 typedef struct {
     struct {
-        yaksuri_slab_s host;
-        yaksuri_slab_s *device;
+        yaksu_buffer_pool_s host;
+        yaksu_buffer_pool_s *device;
         yaksur_gpudriver_info_s *info;
+        int ndevices;
     } gpudriver[YAKSURI_GPUDRIVER_ID__LAST];
 } yaksuri_global_s;
 extern yaksuri_global_s yaksuri_global;

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -14,50 +14,880 @@
 #include "yaksuri.h"
 #include "yutlist.h"
 
-typedef struct subreq_chunk_s {
-    uintptr_t count_offset;
-    uintptr_t count;
-    void *gpu_tmpbuf;
-    void *host_tmpbuf;
-    void *interm_event;
-    void *event;
-
-    struct subreq_chunk_s *next;
-    struct subreq_chunk_s *prev;
-} subreq_chunk_s;
-
-typedef struct progress_elem_s {
-    struct {
-        const void *inbuf;
-        void *outbuf;
-        uintptr_t count;
-        yaksi_type_s *type;
-
-        uintptr_t completed_count;
-        uintptr_t issued_count;
-        subreq_chunk_s *chunks;
-    } pup;
-
-    yaksi_request_s *request;
-    yaksi_info_s *info;
-
-    struct progress_elem_s *next;
-    struct progress_elem_s *prev;
-} progress_elem_s;
-
-static progress_elem_s *progress_elems = NULL;
+static yaksuri_request_s *pending_reqs = NULL;
 static pthread_mutex_t progress_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-#define ELEM_TO_OPTYPE(elem) \
-    (((yaksuri_request_s *) elem->request->backend.priv)->optype)
-#define ELEM_TO_INATTR_TYPE(elem) \
-    (((yaksuri_request_s *) elem->request->backend.priv)->inattr.type)
-#define ELEM_TO_OUTATTR_TYPE(elem) \
-    (((yaksuri_request_s *) elem->request->backend.priv)->outattr.type)
-#define ELEM_TO_INATTR_DEVICE(elem) \
-    (((yaksuri_request_s *) elem->request->backend.priv)->inattr.device)
-#define ELEM_TO_OUTATTR_DEVICE(elem) \
-    (((yaksuri_request_s *) elem->request->backend.priv)->outattr.device)
+static int icopy(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t bytes,
+                 struct yaksi_info_s *info, int device)
+{
+    int rc = YAKSA_SUCCESS;
+
+    yaksi_type_s *byte_type;
+    rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksuri_global.gpudriver[id].info->ipack(inbuf, outbuf, bytes, byte_type, info, device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int ipack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
+                 struct yaksi_type_s *type, struct yaksi_info_s *info, int device)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->ipack(inbuf, outbuf, count, type, info, device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int iunpack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
+                   struct yaksi_type_s *type, struct yaksi_info_s *info, int device)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->iunpack(inbuf, outbuf, count, type, info, device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int check_p2p_comm(yaksuri_gpudriver_id_e id, int indev, int outdev, bool * is_enabled)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->check_p2p_comm(indev, outdev, is_enabled);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int event_create(yaksuri_gpudriver_id_e id, int device, void **event)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->event_create(device, event);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int event_destroy(yaksuri_gpudriver_id_e id, void *event)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->event_destroy(event);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int event_record(yaksuri_gpudriver_id_e id, void *event)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->event_record(event);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int event_query(yaksuri_gpudriver_id_e id, void *event, int *completed)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->event_query(event, completed);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int event_add_dependency(yaksuri_gpudriver_id_e id, void *event, int device)
+{
+    int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_global.gpudriver[id].info->event_add_dependency(event, device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int alloc_chunk(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                       yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(subreq);
+    assert(subreq->kind == YAKSURI_SUBREQ_KIND__MULTI_CHUNK);
+
+    /* allocate the chunk */
+    *chunk = (yaksuri_subreq_chunk_s *) malloc(sizeof(yaksuri_subreq_chunk_s));
+
+    (*chunk)->count_offset = subreq->u.multiple.issued_count;
+    uintptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / subreq->u.multiple.type->size;
+    if ((*chunk)->count_offset + count_per_chunk <= subreq->u.multiple.count) {
+        (*chunk)->count = count_per_chunk;
+    } else {
+        (*chunk)->count = subreq->u.multiple.count - (*chunk)->count_offset;
+    }
+
+    (*chunk)->event = NULL;
+
+    DL_APPEND(subreq->u.multiple.chunks, (*chunk));
+
+    return rc;
+}
+
+static int simple_release(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                          yaksuri_subreq_chunk_s * chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    /* cleanup */
+    if (chunk->event) {
+        rc = event_destroy(id, chunk->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+    for (int i = 0; i < chunk->num_tmpbufs; i++) {
+        rc = yaksu_buffer_pool_elem_free(chunk->tmpbufs[i].pool, chunk->tmpbufs[i].buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+    DL_DELETE(subreq->u.multiple.chunks, chunk);
+    free(chunk);
+
+    if (subreq->u.multiple.chunks == NULL) {
+        DL_DELETE(backend->subreqs, subreq);
+        free(subreq);
+    }
+    if (backend->subreqs == NULL) {
+        HASH_DEL(pending_reqs, backend);
+        yaksu_atomic_decr(&backend->request->cc);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2d_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                            yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    assert(backend->inattr.device != backend->outattr.device);
+
+    *chunk = NULL;
+
+    bool is_enabled;
+    rc = check_p2p_comm(id, backend->inattr.device, backend->outattr.device, &is_enabled);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+    assert(is_enabled);
+
+    if (is_enabled) {
+        /* p2p is enabled: we need a temporary buffer on the source device */
+        void *d_buf;
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.
+                                          gpudriver[id].device[backend->inattr.device], &d_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (d_buf == NULL)
+            goto fn_exit;
+
+        /* we have the temporary buffer, so we can safely issue this
+         * operation */
+        rc = alloc_chunk(backend, subreq, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        (*chunk)->num_tmpbufs = 1;
+        (*chunk)->tmpbufs[0].buf = d_buf;
+        (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->inattr.device];
+
+        /* first pack data from the origin buffer into the temporary buffer */
+        const char *sbuf =
+            (const char *) subreq->u.multiple.inbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+        rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+                   backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* second copy the data into the target device */
+        char *dbuf =
+            (char *) subreq->u.multiple.outbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+        rc = icopy(id, d_buf, dbuf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+                   backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        event_create(id, backend->inattr.device, &(*chunk)->event);
+        event_record(id, (*chunk)->event);
+    } else {
+        /* p2p is not enabled: we need two temporary buffers, one on
+         * the source device and one on the host */
+        void *d_buf, *rh_buf;
+
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.
+                                          gpudriver[id].device[backend->inattr.device], &d_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (d_buf == NULL)
+            goto fn_exit;
+
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (rh_buf == NULL) {
+            if (d_buf) {
+                rc = yaksu_buffer_pool_elem_free(yaksuri_global.
+                                                 gpudriver[id].device[backend->inattr.device],
+                                                 d_buf);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            }
+            goto fn_exit;
+        }
+
+        /* we have the temporary buffers, so we can safely issue this
+         * operation */
+        rc = alloc_chunk(backend, subreq, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        (*chunk)->num_tmpbufs = 2;
+        (*chunk)->tmpbufs[0].buf = d_buf;
+        (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->inattr.device];
+        (*chunk)->tmpbufs[1].buf = rh_buf;
+        (*chunk)->tmpbufs[1].pool = yaksuri_global.gpudriver[id].host;
+
+        /* first pack data from the origin buffer into the temporary buffer */
+        const char *sbuf =
+            (const char *) subreq->u.multiple.inbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+        rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+                   backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* second copy the data into the temporary host buffer */
+        rc = icopy(id, d_buf, rh_buf, (*chunk)->count * subreq->u.multiple.type->size,
+                   backend->info, backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* third DMA from the host temporary buffer to the target device */
+        void *event;
+        rc = event_create(id, backend->inattr.device, &event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_record(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_add_dependency(id, event, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_destroy(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        char *dbuf =
+            (char *) subreq->u.multiple.outbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+        rc = icopy(id, rh_buf, dbuf, (*chunk)->count * subreq->u.multiple.type->size,
+                   backend->info, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_create(id, backend->outattr.device, &(*chunk)->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_record(id, (*chunk)->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2rh_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                             yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need a temporary buffer on the source device */
+    void *d_buf;
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].device[backend->inattr.device],
+                                      &d_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (d_buf == NULL)
+        goto fn_exit;
+
+    /* we have the temporary buffer, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 1;
+    (*chunk)->tmpbufs[0].buf = d_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->inattr.device];
+
+    /* first pack data from the origin buffer into the temporary buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+    rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+               backend->inattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* second copy the data into the destination buffer */
+    char *dbuf;
+    dbuf =
+        (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+    rc = icopy(id, d_buf, dbuf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+               backend->inattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    event_create(id, backend->inattr.device, &(*chunk)->event);
+    event_record(id, (*chunk)->event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2urh_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                              yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need two temporary buffers, one on the source device and one
+     * on the host */
+    void *d_buf, *rh_buf;
+
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].device[backend->inattr.device],
+                                      &d_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (d_buf == NULL)
+        goto fn_exit;
+
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (rh_buf == NULL) {
+        if (d_buf) {
+            rc = yaksu_buffer_pool_elem_free(yaksuri_global.
+                                             gpudriver[id].device[backend->inattr.device], d_buf);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        goto fn_exit;
+    }
+
+    /* we have the temporary buffers, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 2;
+    (*chunk)->tmpbufs[0].buf = d_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->inattr.device];
+    (*chunk)->tmpbufs[1].buf = rh_buf;
+    (*chunk)->tmpbufs[1].pool = yaksuri_global.gpudriver[id].host;
+
+    /* first pack data from the origin buffer into the temporary buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+    rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+               backend->inattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* second copy the data into the temporary host buffer */
+    rc = icopy(id, d_buf, rh_buf, (*chunk)->count * subreq->u.multiple.type->size,
+               backend->info, backend->inattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = event_create(id, backend->inattr.device, &(*chunk)->event);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = event_record(id, (*chunk)->event);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2urh_release(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                              yaksuri_subreq_chunk_s * chunk)
+{
+    int rc = YAKSA_SUCCESS;
+
+    yaksi_type_s *byte_type;
+    rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    char *dbuf;
+    dbuf = (char *) subreq->u.multiple.outbuf + chunk->count_offset * subreq->u.multiple.type->size;
+    rc = yaksuri_seq_ipack(chunk->tmpbufs[1].buf, dbuf,
+                           chunk->count * subreq->u.multiple.type->size, byte_type, backend->info);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = simple_release(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_h2d_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                            yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need a host temporary buffer */
+    void *rh_buf;
+
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (rh_buf == NULL)
+        goto fn_exit;
+
+    /* we have the temporary buffers, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 1;
+    (*chunk)->tmpbufs[0].buf = rh_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].host;
+
+    /* first pack data from the origin buffer into the temporary buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+    rc = yaksuri_seq_ipack(sbuf, rh_buf, (*chunk)->count, subreq->u.multiple.type, backend->info);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* second copy the data into the target device */
+    char *dbuf;
+    dbuf =
+        (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+    rc = icopy(id, rh_buf, dbuf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+               backend->outattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    event_create(id, backend->outattr.device, &(*chunk)->event);
+    event_record(id, (*chunk)->event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_d2d_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                              yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    assert(backend->inattr.device != backend->outattr.device);
+
+    *chunk = NULL;
+
+    bool is_enabled;
+    rc = check_p2p_comm(id, backend->inattr.device, backend->outattr.device, &is_enabled);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (is_enabled) {
+        /* p2p is enabled: we need a temporary buffer on the destination device */
+        void *d_buf;
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.
+                                          gpudriver[id].device[backend->outattr.device], &d_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (d_buf == NULL)
+            goto fn_exit;
+
+        /* we have the temporary buffer, so we can safely issue this
+         * operation */
+        rc = alloc_chunk(backend, subreq, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        (*chunk)->num_tmpbufs = 1;
+        (*chunk)->tmpbufs[0].buf = d_buf;
+        (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->outattr.device];
+
+        /* first copy the data from the origin buffer into the
+         * temporary buffer */
+        const char *sbuf;
+        sbuf = (const char *) subreq->u.multiple.inbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+        rc = icopy(id, sbuf, d_buf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+                   backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* second unpack the data into the destination buffer */
+        void *event;
+        rc = event_create(id, backend->inattr.device, &event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_record(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_add_dependency(id, event, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_destroy(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        char *dbuf;
+        dbuf = (char *) subreq->u.multiple.outbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+        rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+                     backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        event_create(id, backend->outattr.device, &(*chunk)->event);
+        event_record(id, (*chunk)->event);
+    } else {
+        /* p2p is not enabled: we need two temporary buffers, one on
+         * the destination device and one on the host */
+        void *d_buf, *rh_buf;
+
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.
+                                          gpudriver[id].device[backend->outattr.device], &d_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (d_buf == NULL)
+            goto fn_exit;
+
+        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (rh_buf == NULL) {
+            if (d_buf) {
+                rc = yaksu_buffer_pool_elem_free(yaksuri_global.
+                                                 gpudriver[id].device[backend->outattr.device],
+                                                 d_buf);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            }
+            goto fn_exit;
+        }
+
+        /* we have the temporary buffers, so we can safely issue this
+         * operation */
+        rc = alloc_chunk(backend, subreq, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        (*chunk)->num_tmpbufs = 2;
+        (*chunk)->tmpbufs[0].buf = d_buf;
+        (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->outattr.device];
+        (*chunk)->tmpbufs[1].buf = rh_buf;
+        (*chunk)->tmpbufs[1].pool = yaksuri_global.gpudriver[id].host;
+
+        /* first copy data from the origin buffer into the temporary host buffer */
+        const char *sbuf;
+        sbuf = (const char *) subreq->u.multiple.inbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+        rc = icopy(id, sbuf, rh_buf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+                   backend->inattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* second copy the data from the temporary host buffer into the
+         * temporary destination device buffer */
+        void *event;
+        rc = event_create(id, backend->inattr.device, &event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_record(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_add_dependency(id, event, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_destroy(id, event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, rh_buf, d_buf, (*chunk)->count * subreq->u.multiple.type->size,
+                   backend->info, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        /* third unpack from the temporary device buffer to the destination buffer */
+        char *dbuf;
+        dbuf = (char *) subreq->u.multiple.outbuf +
+            (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+        rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
+                     backend->info, backend->outattr.device);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_create(id, backend->outattr.device, &(*chunk)->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = event_record(id, (*chunk)->event);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_rh2d_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                               yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need a temporary buffer on the destination device */
+    void *d_buf;
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].device[backend->outattr.device],
+                                      &d_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (d_buf == NULL)
+        goto fn_exit;
+
+    /* we have the temporary buffer, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 1;
+    (*chunk)->tmpbufs[0].buf = d_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->outattr.device];
+
+    /* first copy the data from the origin buffer into the temporary
+     * device buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+    rc = icopy(id, sbuf, d_buf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+               backend->outattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* second unpack the data into the destination buffer */
+    char *dbuf;
+    dbuf = (char *) subreq->u.multiple.outbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+    rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+                 backend->outattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    event_create(id, backend->outattr.device, &(*chunk)->event);
+    event_record(id, (*chunk)->event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_urh2d_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                                yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need two temporary buffers, one on the destination device
+     * and one on the host */
+    void *d_buf, *rh_buf;
+
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].device[backend->outattr.device],
+                                      &d_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (d_buf == NULL)
+        goto fn_exit;
+
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (rh_buf == NULL) {
+        if (d_buf) {
+            rc = yaksu_buffer_pool_elem_free(yaksuri_global.
+                                             gpudriver[id].device[backend->outattr.device], d_buf);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        goto fn_exit;
+    }
+
+    /* we have the temporary buffer, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 2;
+    (*chunk)->tmpbufs[0].buf = d_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].device[backend->outattr.device];
+    (*chunk)->tmpbufs[1].buf = rh_buf;
+    (*chunk)->tmpbufs[1].pool = yaksuri_global.gpudriver[id].host;
+
+    /* first copy the data into a temporary host buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+    yaksi_type_s *byte_type;
+    rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksuri_seq_ipack(sbuf, rh_buf, (*chunk)->count * subreq->u.multiple.type->size,
+                           byte_type, backend->info);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* second copy the data from the origin buffer into the temporary
+     * buffer */
+    rc = icopy(id, rh_buf, d_buf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+               backend->outattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    /* third unpack the data into the destination buffer */
+    char *dbuf;
+    dbuf = (char *) subreq->u.multiple.outbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->extent;
+
+    rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, backend->info,
+                 backend->outattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    event_create(id, backend->outattr.device, &(*chunk)->event);
+    event_record(id, (*chunk)->event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_d2h_acquire(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                              yaksuri_subreq_chunk_s ** chunk)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = backend->gpudriver_id;
+
+    *chunk = NULL;
+
+    /* we need a temporary buffer on the host */
+    void *rh_buf;
+    rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host, &rh_buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (rh_buf == NULL)
+        goto fn_exit;
+
+    /* we have the temporary buffer, so we can safely issue this
+     * operation */
+    rc = alloc_chunk(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    (*chunk)->num_tmpbufs = 1;
+    (*chunk)->tmpbufs[0].buf = rh_buf;
+    (*chunk)->tmpbufs[0].pool = yaksuri_global.gpudriver[id].host;
+
+    /* first copy the data from the origin buffer into the temporary
+     * host buffer */
+    const char *sbuf;
+    sbuf = (const char *) subreq->u.multiple.inbuf +
+        (*chunk)->count_offset * subreq->u.multiple.type->size;
+
+    rc = icopy(id, sbuf, rh_buf, (*chunk)->count * subreq->u.multiple.type->size, backend->info,
+               backend->inattr.device);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    event_create(id, backend->inattr.device, &(*chunk)->event);
+    event_record(id, (*chunk)->event);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_d2h_release(yaksuri_request_s * backend, yaksuri_subreq_s * subreq,
+                              yaksuri_subreq_chunk_s * chunk)
+{
+    int rc = YAKSA_SUCCESS;
+
+    char *dbuf;
+    dbuf =
+        (char *) subreq->u.multiple.outbuf + chunk->count_offset * subreq->u.multiple.type->extent;
+    rc = yaksuri_seq_iunpack(chunk->tmpbufs[0].buf, dbuf, chunk->count, subreq->u.multiple.type,
+                             backend->info);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = simple_release(backend, subreq, chunk);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                              yaksi_info_s * info, yaksi_request_s * request)
@@ -67,6 +897,10 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
     yaksuri_gpudriver_id_e id = backend->gpudriver_id;
 
     assert(yaksuri_global.gpudriver[id].info);
+    assert(backend->inattr.type == YAKSUR_PTR_TYPE__GPU ||
+           backend->outattr.type == YAKSUR_PTR_TYPE__GPU);
+
+    backend->info = info;
 
     /* if the GPU backend cannot support this type, return */
     bool is_supported;
@@ -78,277 +912,114 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
         goto fn_exit;
     }
 
-    int (*pupfn) (const void *inbuf, void *outbuf, uintptr_t count,
-                  struct yaksi_type_s * type, struct yaksi_info_s * info, void **event,
-                  void *device_tmpbuf, int device);
+    yaksuri_subreq_s *subreq;
+    subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
+
+    int (*pupfn) (yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
+                  struct yaksi_type_s * type, struct yaksi_info_s * info, int device);
     if (backend->optype == YAKSURI_OPTYPE__PACK) {
-        pupfn = yaksuri_global.gpudriver[id].info->ipack;
+        pupfn = ipack;
     } else {
-        pupfn = yaksuri_global.gpudriver[id].info->iunpack;
+        pupfn = iunpack;
     }
 
     if (backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
         backend->outattr.type == YAKSUR_PTR_TYPE__GPU &&
         backend->inattr.device == backend->outattr.device) {
-        /* gpu-to-gpu copies do not need temporary buffers */
-        bool first_event = !backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &backend->event, NULL, backend->inattr.device);
+
+        subreq->kind = YAKSURI_SUBREQ_KIND__SINGLE_CHUNK;
+        rc = pupfn(id, inbuf, outbuf, count, type, info, backend->inattr.device);
         YAKSU_ERR_CHECK(rc, fn_fail);
+        event_create(id, backend->inattr.device, &subreq->u.single.event);
+        event_record(id, subreq->u.single.event);
 
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
     } else if (type->is_contig && backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
                backend->outattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &backend->event, NULL, backend->inattr.device);
+
+        subreq->kind = YAKSURI_SUBREQ_KIND__SINGLE_CHUNK;
+        rc = pupfn(id, inbuf, outbuf, count, type, info, backend->inattr.device);
         YAKSU_ERR_CHECK(rc, fn_fail);
+        event_create(id, backend->inattr.device, &subreq->u.single.event);
+        event_record(id, subreq->u.single.event);
 
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
+    } else if (type->is_contig && backend->inattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
+               backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
 
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
-    } else if (type->is_contig && backend->inattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST
-               && backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
-        /* gpu-to-host or host-to-gpu copies do not need
-         * temporary buffers either, if the host buffer is registered
-         * and the type is contiguous */
-        bool first_event = !backend->event;
-        rc = pupfn(inbuf, outbuf, count, type, info, &backend->event, NULL,
-                   backend->outattr.device);
+        subreq->kind = YAKSURI_SUBREQ_KIND__SINGLE_CHUNK;
+        rc = pupfn(id, inbuf, outbuf, count, type, info, backend->outattr.device);
         YAKSU_ERR_CHECK(rc, fn_fail);
+        event_create(id, backend->outattr.device, &subreq->u.single.event);
+        event_record(id, subreq->u.single.event);
 
-        if (first_event) {
-            yaksu_atomic_incr(&request->cc);
-        }
-
-        /* if the request kind was already set to STAGED, do not
-         * override it, as a part of the request could be staged */
-        if (backend->kind == YAKSURI_REQUEST_KIND__UNSET) {
-            backend->kind = YAKSURI_REQUEST_KIND__DIRECT;
-        }
     } else {
-        /* if we need to go through the progress engine, make sure we
-         * only take on types, where at least one count of the type
-         * fits into our temporary buffers. */
+        /* we can only take on types where at least one count of the
+         * type fits into our temporary buffers. */
         if (type->size > YAKSURI_TMPBUF_EL_SIZE) {
             rc = YAKSA_ERR__NOT_SUPPORTED;
+            free(subreq);
             goto fn_exit;
         }
 
-        backend->kind = YAKSURI_REQUEST_KIND__STAGED;
+        subreq->kind = YAKSURI_SUBREQ_KIND__MULTI_CHUNK;
 
-        /* enqueue to the progress engine */
-        progress_elem_s *newelem;
-        newelem = (progress_elem_s *) malloc(sizeof(progress_elem_s));
+        subreq->u.multiple.inbuf = inbuf;
+        subreq->u.multiple.outbuf = outbuf;
+        subreq->u.multiple.count = count;
+        subreq->u.multiple.type = type;
+        subreq->u.multiple.issued_count = 0;
+        subreq->u.multiple.chunks = NULL;
 
-        newelem->pup.inbuf = inbuf;
-        newelem->pup.outbuf = outbuf;
-        newelem->pup.count = count;
-        newelem->pup.type = type;
-        newelem->pup.completed_count = 0;
-        newelem->pup.issued_count = 0;
-        newelem->pup.chunks = NULL;
-        newelem->request = request;
-        newelem->info = info;
-        newelem->next = NULL;
-
-        /* enqueue the new element */
-        yaksu_atomic_incr(&request->cc);
-
-        pthread_mutex_lock(&progress_mutex);
-        DL_APPEND(progress_elems, newelem);
-        pthread_mutex_unlock(&progress_mutex);
-
-        rc = yaksuri_progress_poke();
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-static int alloc_chunk(subreq_chunk_s ** chunk)
-{
-    int rc = YAKSA_SUCCESS;
-    progress_elem_s *elem = progress_elems;
-    yaksuri_request_s *request_backend = (yaksuri_request_s *) elem->request->backend.priv;
-    yaksuri_gpudriver_id_e id = request_backend->gpudriver_id;
-    bool need_gpu_tmpbuf = false, need_host_tmpbuf = false;
-    int devid = INT_MIN;
-
-    if ((ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST)) {
-        need_host_tmpbuf = true;
-    }
-
-    if (ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-        ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) {
-        bool is_enabled;
-        rc = yaksuri_global.gpudriver[id].info->check_p2p_comm(ELEM_TO_INATTR_DEVICE(elem),
-                                                               ELEM_TO_OUTATTR_DEVICE(elem),
-                                                               &is_enabled);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (!is_enabled) {
-            need_host_tmpbuf = true;
-        }
-    }
-
-    if ((ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU)) {
-        need_gpu_tmpbuf = true;
-        devid = ELEM_TO_INATTR_DEVICE(elem);
-    }
-
-    if ((ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-        (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-         ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-         ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU)) {
-        need_gpu_tmpbuf = true;
-        devid = ELEM_TO_OUTATTR_DEVICE(elem);
-    }
-
-    assert(need_host_tmpbuf || need_gpu_tmpbuf);
-
-    /* allocate the chunk */
-    *chunk = (subreq_chunk_s *) malloc(sizeof(subreq_chunk_s));
-
-    /* figure out if we actually have enough buffer space */
-    if (need_gpu_tmpbuf) {
-        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].device[devid],
-                                          &(*chunk)->gpu_tmpbuf);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if ((*chunk)->gpu_tmpbuf == NULL) {
-            free(*chunk);
-            *chunk = NULL;
-            goto fn_exit;
-        }
-    } else {
-        (*chunk)->gpu_tmpbuf = NULL;
-    }
-
-    if (need_host_tmpbuf) {
-        rc = yaksu_buffer_pool_elem_alloc(yaksuri_global.gpudriver[id].host,
-                                          &(*chunk)->host_tmpbuf);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if ((*chunk)->host_tmpbuf == NULL) {
-            if (need_gpu_tmpbuf) {
-                rc = yaksu_buffer_pool_elem_free(yaksuri_global.gpudriver[id].device[devid],
-                                                 (*chunk)->gpu_tmpbuf);
-                YAKSU_ERR_CHECK(rc, fn_fail);
+        if (backend->optype == YAKSURI_OPTYPE__PACK) {
+            if (backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
+                backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
+                subreq->u.multiple.acquire = pack_d2d_acquire;
+                subreq->u.multiple.release = simple_release;
+            } else if (backend->inattr.type == YAKSUR_PTR_TYPE__GPU) {
+                if (backend->outattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
+                    subreq->u.multiple.acquire = pack_d2rh_acquire;
+                    subreq->u.multiple.release = simple_release;
+                } else {
+                    subreq->u.multiple.acquire = pack_d2urh_acquire;
+                    subreq->u.multiple.release = pack_d2urh_release;
+                }
+            } else if (backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
+                subreq->u.multiple.acquire = pack_h2d_acquire;
+                subreq->u.multiple.release = simple_release;
             }
-            free(*chunk);
-            *chunk = NULL;
-            goto fn_exit;
+        } else {
+            if (backend->inattr.type == YAKSUR_PTR_TYPE__GPU &&
+                backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
+                subreq->u.multiple.acquire = unpack_d2d_acquire;
+                subreq->u.multiple.release = simple_release;
+            } else if (backend->inattr.type == YAKSUR_PTR_TYPE__GPU) {
+                subreq->u.multiple.acquire = unpack_d2h_acquire;
+                subreq->u.multiple.release = unpack_d2h_release;
+            } else if (backend->outattr.type == YAKSUR_PTR_TYPE__GPU) {
+                if (backend->inattr.type == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
+                    subreq->u.multiple.acquire = unpack_rh2d_acquire;
+                    subreq->u.multiple.release = simple_release;
+                } else {
+                    subreq->u.multiple.acquire = unpack_urh2d_acquire;
+                    subreq->u.multiple.release = simple_release;
+                }
+            }
         }
-    } else {
-        (*chunk)->host_tmpbuf = NULL;
     }
 
-    (*chunk)->count_offset = elem->pup.completed_count + elem->pup.issued_count;
+    pthread_mutex_lock(&progress_mutex);
+    DL_APPEND(backend->subreqs, subreq);
 
-    uintptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / elem->pup.type->size;
-    if ((*chunk)->count_offset + count_per_chunk <= elem->pup.count) {
-        (*chunk)->count = count_per_chunk;
-    } else {
-        (*chunk)->count = elem->pup.count - (*chunk)->count_offset;
+    /* if the request is not in our pending list, add it */
+    yaksuri_request_s *req;
+    HASH_FIND_PTR(pending_reqs, &request, req);
+    if (req == NULL) {
+        HASH_ADD_PTR(pending_reqs, request, backend);
+        yaksu_atomic_incr(&request->cc);
     }
+    pthread_mutex_unlock(&progress_mutex);
 
-    (*chunk)->interm_event = NULL;
-    (*chunk)->event = NULL;
-
-    DL_APPEND(elem->pup.chunks, *chunk);
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-static int free_chunk(subreq_chunk_s * chunk)
-{
-    int rc = YAKSA_SUCCESS;
-    progress_elem_s *elem = progress_elems;
-    yaksuri_request_s *request_backend = (yaksuri_request_s *) elem->request->backend.priv;
-    yaksuri_gpudriver_id_e id = request_backend->gpudriver_id;
-
-    if (chunk->interm_event) {
-        rc = yaksuri_global.gpudriver[id].info->event_destroy(chunk->interm_event);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
-
-    rc = yaksuri_global.gpudriver[id].info->event_destroy(chunk->event);
+    rc = yaksuri_progress_poke();
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    /* free the device buffer */
-    if (chunk->gpu_tmpbuf) {
-        int devid;
-
-        if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK)
-            devid = ELEM_TO_INATTR_DEVICE(elem);
-        else
-            devid = ELEM_TO_OUTATTR_DEVICE(elem);
-
-        rc = yaksu_buffer_pool_elem_free(yaksuri_global.gpudriver[id].device[devid],
-                                         chunk->gpu_tmpbuf);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
-
-    /* free the host buffer */
-    if (chunk->host_tmpbuf) {
-        rc = yaksu_buffer_pool_elem_free(yaksuri_global.gpudriver[id].host, chunk->host_tmpbuf);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
-
-    DL_DELETE(elem->pup.chunks, chunk);
-    free(chunk);
 
   fn_exit:
     return rc;
@@ -359,267 +1030,87 @@ static int free_chunk(subreq_chunk_s * chunk)
 int yaksuri_progress_poke(void)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id;
 
-    /* We only poke the head of the progress engine as all of our
-     * operations are independent.  This reduces the complexity of the
-     * progress engine and keeps the amount of time we spend in the
-     * progress engine small. */
+    /* A progress poke is in two steps.  In the first step, we check
+     * for event completions, finish any post-processing and retire
+     * any temporary resources.  In the second steps, we issue out any
+     * pending operations. */
 
     pthread_mutex_lock(&progress_mutex);
 
-    /* if there's nothing to do, return */
-    if (progress_elems == NULL)
-        goto fn_exit;
-
-    /* the progress engine has three steps: (1) check for completions
-     * and free up any held up resources; (2) if we don't have
-     * anything else to do, return; and (3) issue any pending
-     * chunks. */
     yaksi_type_s *byte_type;
     rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    progress_elem_s *elem;
-    elem = progress_elems;
-    yaksuri_request_s *request_backend;
-    request_backend = (yaksuri_request_s *) elem->request->backend.priv;
-    yaksuri_gpudriver_id_e id;
-    id = request_backend->gpudriver_id;
+    /**********************************************************************/
+    /* Step 1: Check for completions */
+    /**********************************************************************/
+    yaksuri_request_s *backend, *tmp;
+    HASH_ITER(hh, pending_reqs, backend, tmp) {
+        id = backend->gpudriver_id;
+        assert(backend->subreqs);
 
-    /****************************************************************************/
-    /* Step 1: Check for completion and free up any held up resources */
-    /****************************************************************************/
-    subreq_chunk_s *chunk, *tmp;
-    DL_FOREACH_SAFE(elem->pup.chunks, chunk, tmp) {
-        int completed;
-        rc = yaksuri_global.gpudriver[id].info->event_query(chunk->event, &completed);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        yaksuri_subreq_s *subreq, *tmp2;
+        DL_FOREACH_SAFE(backend->subreqs, subreq, tmp2) {
+            if (subreq->kind == YAKSURI_SUBREQ_KIND__SINGLE_CHUNK) {
+                int completed;
+                rc = event_query(id, subreq->u.single.event, &completed);
+                YAKSU_ERR_CHECK(rc, fn_fail);
 
-        if (completed) {
-            if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-                ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST) {
-                char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->size;
-                rc = yaksuri_seq_ipack(chunk->host_tmpbuf, dbuf,
-                                       chunk->count * elem->pup.type->size, byte_type, elem->info);
+                if (!completed)
+                    continue;
+
+                rc = event_destroy(id, subreq->u.single.event);
                 YAKSU_ERR_CHECK(rc, fn_fail);
-            } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                       ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                       (ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST ||
-                        ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST)) {
-                char *dbuf =
-                    (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->extent;
-                rc = yaksuri_seq_iunpack(chunk->host_tmpbuf, dbuf, chunk->count, elem->pup.type,
-                                         elem->info);
-                YAKSU_ERR_CHECK(rc, fn_fail);
+
+                DL_DELETE(backend->subreqs, subreq);
+                free(subreq);
+                if (backend->subreqs == NULL) {
+                    HASH_DEL(pending_reqs, backend);
+                    yaksu_atomic_decr(&backend->request->cc);
+                }
+            } else {
+                yaksuri_subreq_chunk_s *chunk, *tmp3;
+                DL_FOREACH_SAFE(subreq->u.multiple.chunks, chunk, tmp3) {
+                    int completed;
+                    rc = event_query(id, chunk->event, &completed);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
+
+                    if (!completed)
+                        continue;
+
+                    rc = subreq->u.multiple.release(backend, subreq, chunk);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
+                }
             }
-
-            elem->pup.completed_count += chunk->count;
-            elem->pup.issued_count -= chunk->count;
-
-            subreq_chunk_s *tmp = chunk->next;
-            rc = free_chunk(chunk);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-            chunk = tmp;
-        } else {
-            break;
         }
     }
 
+    /**********************************************************************/
+    /* Step 2: Issue new operations */
+    /**********************************************************************/
+    HASH_ITER(hh, pending_reqs, backend, tmp) {
+        id = backend->gpudriver_id;
+        assert(backend->subreqs);
 
-    /****************************************************************************/
-    /* Step 2: If we don't have any more work to do, return */
-    /****************************************************************************/
-    if (elem->pup.completed_count == elem->pup.count) {
-        DL_DELETE(progress_elems, elem);
-        yaksu_atomic_decr(&elem->request->cc);
-        free(elem);
-        goto fn_exit;
-    }
+        yaksuri_subreq_s *subreq, *tmp2;
+        DL_FOREACH_SAFE(backend->subreqs, subreq, tmp2) {
+            if (subreq->kind == YAKSURI_SUBREQ_KIND__SINGLE_CHUNK)
+                continue;
 
+            while (subreq->u.multiple.issued_count < subreq->u.multiple.count) {
+                yaksuri_subreq_chunk_s *chunk;
 
-    /****************************************************************************/
-    /* Step 3: Issue any pending chunks */
-    /****************************************************************************/
-    while (elem->pup.completed_count + elem->pup.issued_count < elem->pup.count) {
-        subreq_chunk_s *chunk;
-
-        rc = alloc_chunk(&chunk);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (chunk == NULL) {
-            break;
-        }
-
-        if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-            ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-            ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->extent;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->size;
-
-            rc = yaksuri_global.gpudriver[id].info->ipack(sbuf, dbuf, chunk->count, elem->pup.type,
-                                                          elem->info, &chunk->event,
-                                                          chunk->gpu_tmpbuf,
-                                                          ELEM_TO_INATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-                   ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                   ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->extent;
-
-            rc = yaksuri_global.gpudriver[id].info->ipack(sbuf, chunk->host_tmpbuf, chunk->count,
-                                                          elem->pup.type, elem->info,
-                                                          &chunk->event, chunk->gpu_tmpbuf,
-                                                          ELEM_TO_INATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if ((ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-                    ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
-                    ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) ||
-                   (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-                    ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST &&
-                    ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU)) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->extent;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->size;
-
-            rc = yaksuri_seq_ipack(sbuf, chunk->host_tmpbuf, chunk->count, elem->pup.type,
-                                   elem->info);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-
-            rc = yaksuri_global.gpudriver[id].info->ipack(chunk->host_tmpbuf, dbuf,
-                                                          chunk->count * elem->pup.type->size,
-                                                          byte_type, elem->info, &chunk->event,
-                                                          NULL, ELEM_TO_OUTATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__PACK &&
-                   ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                   ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) {
-            assert(ELEM_TO_INATTR_DEVICE(elem) != ELEM_TO_OUTATTR_DEVICE(elem));
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->extent;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->size;
-
-            bool is_enabled;
-            rc = yaksuri_global.gpudriver[id].info->check_p2p_comm(ELEM_TO_INATTR_DEVICE(elem),
-                                                                   ELEM_TO_OUTATTR_DEVICE(elem),
-                                                                   &is_enabled);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-
-            if (is_enabled) {
-                rc = yaksuri_global.gpudriver[id].info->ipack(sbuf, dbuf, chunk->count,
-                                                              elem->pup.type, elem->info,
-                                                              &chunk->event, chunk->gpu_tmpbuf,
-                                                              ELEM_TO_INATTR_DEVICE(elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
-            } else {
-                rc = yaksuri_global.gpudriver[id].info->ipack(sbuf, chunk->host_tmpbuf,
-                                                              chunk->count, elem->pup.type,
-                                                              elem->info, &chunk->interm_event,
-                                                              chunk->gpu_tmpbuf,
-                                                              ELEM_TO_INATTR_DEVICE(elem));
+                rc = subreq->u.multiple.acquire(backend, subreq, &chunk);
                 YAKSU_ERR_CHECK(rc, fn_fail);
 
-                rc = yaksuri_global.gpudriver[id].info->event_add_dependency(chunk->interm_event,
-                                                                             ELEM_TO_OUTATTR_DEVICE
-                                                                             (elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
+                if (chunk == NULL)
+                    goto fn_exit;
 
-                rc = yaksuri_global.gpudriver[id].info->ipack(chunk->host_tmpbuf, dbuf,
-                                                              chunk->count * elem->pup.type->size,
-                                                              byte_type, elem->info, &chunk->event,
-                                                              NULL, ELEM_TO_OUTATTR_DEVICE(elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
+                subreq->u.multiple.issued_count += chunk->count;
             }
-        } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                   ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST &&
-                   ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->size;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->extent;
-
-            rc = yaksuri_global.gpudriver[id].info->iunpack(sbuf, dbuf, chunk->count,
-                                                            elem->pup.type, elem->info,
-                                                            &chunk->event, chunk->gpu_tmpbuf,
-                                                            ELEM_TO_OUTATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                   ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST &&
-                   ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->size;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->extent;
-
-            rc = yaksuri_seq_iunpack(sbuf, chunk->host_tmpbuf,
-                                     chunk->count * elem->pup.type->size, byte_type, elem->info);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-
-            rc = yaksuri_global.gpudriver[id].info->iunpack(chunk->host_tmpbuf, dbuf, chunk->count,
-                                                            elem->pup.type, elem->info,
-                                                            &chunk->event, chunk->gpu_tmpbuf,
-                                                            ELEM_TO_OUTATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if ((ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                    ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                    ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__REGISTERED_HOST) ||
-                   (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                    ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                    ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__UNREGISTERED_HOST)) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->size;
-
-            rc = yaksuri_global.gpudriver[id].info->iunpack(sbuf, chunk->host_tmpbuf,
-                                                            chunk->count * elem->pup.type->size,
-                                                            byte_type, elem->info,
-                                                            &chunk->event, NULL,
-                                                            ELEM_TO_INATTR_DEVICE(elem));
-            YAKSU_ERR_CHECK(rc, fn_fail);
-        } else if (ELEM_TO_OPTYPE(elem) == YAKSURI_OPTYPE__UNPACK &&
-                   ELEM_TO_INATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU &&
-                   ELEM_TO_OUTATTR_TYPE(elem) == YAKSUR_PTR_TYPE__GPU) {
-            const char *sbuf = (const char *) elem->pup.inbuf +
-                chunk->count_offset * elem->pup.type->size;
-            char *dbuf = (char *) elem->pup.outbuf + chunk->count_offset * elem->pup.type->extent;
-
-            bool is_enabled;
-            rc = yaksuri_global.gpudriver[id].info->check_p2p_comm(ELEM_TO_INATTR_DEVICE(elem),
-                                                                   ELEM_TO_OUTATTR_DEVICE(elem),
-                                                                   &is_enabled);
-            YAKSU_ERR_CHECK(rc, fn_fail);
-
-            if (is_enabled) {
-                rc = yaksuri_global.gpudriver[id].info->iunpack(sbuf, dbuf, chunk->count,
-                                                                elem->pup.type, elem->info,
-                                                                &chunk->event, chunk->gpu_tmpbuf,
-                                                                ELEM_TO_INATTR_DEVICE(elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
-            } else {
-                rc = yaksuri_global.gpudriver[id].info->iunpack(sbuf, chunk->host_tmpbuf,
-                                                                chunk->count * elem->pup.type->size,
-                                                                byte_type, elem->info,
-                                                                &chunk->interm_event, NULL,
-                                                                ELEM_TO_INATTR_DEVICE(elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
-
-                rc = yaksuri_global.gpudriver[id].info->event_add_dependency(chunk->interm_event,
-                                                                             ELEM_TO_OUTATTR_DEVICE
-                                                                             (elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
-
-                rc = yaksuri_global.gpudriver[id].info->iunpack(chunk->host_tmpbuf, dbuf,
-                                                                chunk->count, elem->pup.type,
-                                                                elem->info, &chunk->event,
-                                                                chunk->gpu_tmpbuf,
-                                                                ELEM_TO_OUTATTR_DEVICE(elem));
-                YAKSU_ERR_CHECK(rc, fn_fail);
-            }
-        } else {
-            rc = YAKSA_ERR__INTERNAL;
-            goto fn_fail;
         }
-
-        elem->pup.issued_count += chunk->count;
     }
 
   fn_exit:

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -139,11 +139,8 @@ int yaksa_unflatten(yaksa_type_t * type, const void *flattened_type)
 
     assert(yaksi_type);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(yaksi_type, &id);
+    rc = yaksi_type_handle_alloc(yaksi_type, type);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *type = (yaksa_type_t) id;
 
   fn_exit:
     return rc;

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -232,7 +232,7 @@ int yaksa_finalize(void);
  * \param[in]  stride       Increment from the start of one block to another
  *                          (represented in terms of the count of the oldtype)
  * \param[in]  oldtype      Base datatype forming each element in the vector
- * \param[in]  info         Hint to the type creation function
+ * \param[in]  info         Hint object
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
@@ -246,7 +246,7 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
  * \param[in]  stride       Increment from the start of one block to another
  *                          (represented in bytes)
  * \param[in]  oldtype      Base datatype forming each element in the vector
- * \param[in]  info         Hint to the type creation function
+ * \param[in]  info         Hint object
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
@@ -257,7 +257,7 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
  *
  * \param[in]  count        Number of elements of the oldtype
  * \param[in]  oldtype      Base datatype forming each element in the contig
- * \param[in]  info         Hint to the type creation function
+ * \param[in]  info         Hint object
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
@@ -267,7 +267,7 @@ int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
  * \brief creates a copy of the oldtype
  *
  * \param[in]  oldtype      Base datatype being dup'ed
- * \param[in]  info         Hint to the type creation function
+ * \param[in]  info         Hint object
  * \param[out] newtype      Final generated type
  */
 int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
@@ -280,7 +280,7 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t 
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in terms of the count of the oldtype)
  * \param[in]  oldtype                Base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
@@ -295,7 +295,7 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  oldtype                Base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_hindexed_block(int count, int blocklength,
@@ -310,7 +310,7 @@ int yaksa_type_create_hindexed_block(int count, int blocklength,
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in terms of the count of the oldtype)
  * \param[in]  oldtype                Base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
@@ -325,7 +325,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  oldtype                Base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
@@ -338,7 +338,7 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
  * \param[in]  oldtype                Base datatype forming each element in the new type
  * \param[in]  lb                     New lower bound to use
  * \param[in]  extent                 New extent to use
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t extent,
@@ -352,7 +352,7 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t exten
  * \param[in]  array_of_displacements Starting offset to each block
  *                                    (represented in bytes)
  * \param[in]  array_of_types         Array of base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
@@ -369,7 +369,7 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
  * \param[in]  array_of_starts        Start location ("corner representing the start") of the subarray
  * \param[in]  order                  Data layout order (C or Fortran)
  * \param[in]  oldtype                Base datatype forming each element in the new type
- * \param[in]  info                   Hint to the type creation function
+ * \param[in]  info                   Hint object
  * \param[out] newtype                Final generated type
  */
 int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
@@ -449,6 +449,7 @@ int yaksa_request_wait(yaksa_request_t request);
  * \param[out] outbuf            Output buffer into which data is being packed
  * \param[in]  max_pack_bytes    Maximum number of bytes that can be packed in the output buffer
  * \param[out] actual_pack_bytes Actual number of bytes that were packed into the output buffer
+ * \param[in]  info              Hint object
  * \param[out] request           Request handle associated with the operation
  *                               (YAKSA_REQUEST__NULL if the request already completed)
  */
@@ -467,6 +468,7 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
  * \param[in]  outoffset         Number of bytes to skip from the layout represented by the
  *                               (incount, type) tuple
  * \param[out] actual_unpack_bytes Actual number of bytes that were unpacked into the output buffer
+ * \param[in]  info              Hint object
  * \param[out] request           Request handle associated with the operation
  *                               (YAKSA_REQUEST__NULL if the request already completed)
  */

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -53,6 +53,11 @@ struct yaksi_request_s;
 
 #define YAKSI_TYPE_GET_OBJECT_ID(handle) \
     ((handle) << (64 - YAKSI_TYPE_OBJECT_ID_BITS) >> (64 - YAKSI_TYPE_OBJECT_ID_BITS))
+#define YAKSI_TYPE_SET_OBJECT_ID(handle, obj_id)                        \
+    do {                                                                \
+        assert((obj_id) < ((yaksa_type_t) 1 << YAKSI_TYPE_OBJECT_ID_BITS)); \
+        (handle) = (((handle) & ~((((yaksa_type_t) 1) << YAKSI_TYPE_OBJECT_ID_BITS) - 1)) + (obj_id)); \
+    } while (0)
 
 /*
  * The request handle is divided into the following parts:
@@ -252,8 +257,8 @@ int yaksi_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t i
 int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size);
 
 /* type pool */
-int yaksi_type_handle_alloc(yaksi_type_s * type, yaksu_handle_t * handle);
-int yaksi_type_handle_dealloc(yaksu_handle_t handle, yaksi_type_s ** type);
+int yaksi_type_handle_alloc(yaksi_type_s * type, yaksa_type_t * handle);
+int yaksi_type_handle_dealloc(yaksa_type_t handle, yaksi_type_s ** type);
 int yaksi_type_get(yaksa_type_t type, yaksi_type_s ** yaksi_type);
 
 /* request pool */

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -17,7 +17,7 @@
         YAKSU_ERR_CHKANDJUMP(!tmp_type_, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail); \
         yaksu_atomic_store(&tmp_type_->refcount, 1);                    \
                                                                         \
-        yaksu_handle_t id;                                              \
+        yaksa_type_t id;                                                \
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
@@ -32,7 +32,7 @@
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
         yaksu_atomic_incr(&tmp_type_->refcount);                        \
                                                                         \
-        yaksu_handle_t id;                                              \
+        yaksa_type_t id;                                                \
         rc = yaksi_type_handle_alloc(tmp_type_, &id);                   \
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -124,11 +124,8 @@ int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t 
     rc = yaksi_type_create_hindexed_block(count, blocklength, array_of_displs, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;
@@ -164,11 +161,8 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
                                           &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     if (real_array_of_displs)

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -78,11 +78,8 @@ int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
     rc = yaksi_type_create_contig(count, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;

--- a/src/frontend/types/yaksa_dup.c
+++ b/src/frontend/types/yaksa_dup.c
@@ -32,11 +32,8 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t 
     rc = yaksi_type_create_dup(intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -147,11 +147,8 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
                                     &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;
@@ -190,11 +187,8 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                                     &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     free(real_array_of_displs);

--- a/src/frontend/types/yaksa_resized.c
+++ b/src/frontend/types/yaksa_resized.c
@@ -72,11 +72,8 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, uintptr_t exten
     rc = yaksi_type_create_resized(intype, lb, extent, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -169,11 +169,9 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                                   &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    *newtype = (yaksa_type_t) id;
     free(array_of_intypes);
 
   fn_exit:

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -97,11 +97,8 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
     rc = yaksi_type_create_hvector(count, blocklength, stride, intype, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;
@@ -130,11 +127,8 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
                                    &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    yaksu_handle_t id;
-    rc = yaksi_type_handle_alloc(outtype, &id);
+    rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
-
-    *newtype = (yaksa_type_t) id;
 
   fn_exit:
     return rc;

--- a/src/frontend/types/yaksi_type.c
+++ b/src/frontend/types/yaksi_type.c
@@ -7,14 +7,16 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksi_type_handle_alloc(yaksi_type_s * type, yaksu_handle_t * handle)
+int yaksi_type_handle_alloc(yaksi_type_s * type, yaksa_type_t * handle)
 {
     int rc = YAKSA_SUCCESS;
+    yaksu_handle_t id;
 
-    rc = yaksu_handle_pool_elem_alloc(yaksi_global.type_handle_pool, handle, type);
+    rc = yaksu_handle_pool_elem_alloc(yaksi_global.type_handle_pool, &id, type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    assert(*handle < ((yaksa_type_t) 1 << YAKSI_TYPE_OBJECT_ID_BITS));
+    *handle = 0;
+    YAKSI_TYPE_SET_OBJECT_ID(*handle, id);
 
   fn_exit:
     return rc;
@@ -22,14 +24,15 @@ int yaksi_type_handle_alloc(yaksi_type_s * type, yaksu_handle_t * handle)
     goto fn_exit;
 }
 
-int yaksi_type_handle_dealloc(yaksu_handle_t handle, yaksi_type_s ** type)
+int yaksi_type_handle_dealloc(yaksa_type_t handle, yaksi_type_s ** type)
 {
     int rc = YAKSA_SUCCESS;
+    yaksu_handle_t id = YAKSI_TYPE_GET_OBJECT_ID(handle);
 
-    rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, handle, (const void **) type);
+    rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, id, (const void **) type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = yaksu_handle_pool_elem_free(yaksi_global.type_handle_pool, handle);
+    rc = yaksu_handle_pool_elem_free(yaksi_global.type_handle_pool, id);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -38,12 +41,12 @@ int yaksi_type_handle_dealloc(yaksu_handle_t handle, yaksi_type_s ** type)
     goto fn_exit;
 }
 
-int yaksi_type_get(yaksa_type_t type, struct yaksi_type_s **yaksi_type)
+int yaksi_type_get(yaksa_type_t handle, yaksi_type_s ** type)
 {
     int rc = YAKSA_SUCCESS;
-    yaksu_handle_t id = YAKSI_TYPE_GET_OBJECT_ID(type);
+    yaksu_handle_t id = YAKSI_TYPE_GET_OBJECT_ID(handle);
 
-    rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, id, (const void **) yaksi_type);
+    rc = yaksu_handle_pool_elem_get(yaksi_global.type_handle_pool, id, (const void **) type);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:

--- a/src/util/yaksu_buffer_pool.c
+++ b/src/util/yaksu_buffer_pool.c
@@ -60,6 +60,7 @@ typedef struct pool_head {
 
     yaksu_malloc_fn malloc_fn;
     yaksu_free_fn free_fn;
+    void *state;
 
     pthread_mutex_t mutex;
 
@@ -74,7 +75,7 @@ typedef struct pool_head {
 static pthread_mutex_t global_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int yaksu_buffer_pool_alloc(uintptr_t elemsize, unsigned int elems_in_chunk, unsigned int maxelems,
-                            yaksu_malloc_fn malloc_fn, yaksu_free_fn free_fn,
+                            yaksu_malloc_fn malloc_fn, yaksu_free_fn free_fn, void *state,
                             yaksu_buffer_pool_s * pool)
 {
     int rc = YAKSA_SUCCESS;
@@ -90,6 +91,7 @@ int yaksu_buffer_pool_alloc(uintptr_t elemsize, unsigned int elems_in_chunk, uns
 
     pool_head->malloc_fn = malloc_fn;
     pool_head->free_fn = free_fn;
+    pool_head->state = state;
 
     pthread_mutex_init(&pool_head->mutex, NULL);
 
@@ -130,7 +132,7 @@ int yaksu_buffer_pool_free(yaksu_buffer_pool_s pool)
     chunk_s *chunk, *tmp;
     DL_FOREACH_SAFE(pool_head->chunks, chunk, tmp) {
         DL_DELETE(pool_head->chunks, chunk);
-        pool_head->free_fn(chunk->slab);
+        pool_head->free_fn(chunk->slab, pool_head->state);
         free(chunk);
     }
 
@@ -162,7 +164,8 @@ int yaksu_buffer_pool_elem_alloc(yaksu_buffer_pool_s pool, void **elem)
         chunk = (chunk_s *) malloc(sizeof(chunk_s));
         YAKSU_ERR_CHKANDJUMP(!chunk, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail);
 
-        chunk->slab = pool_head->malloc_fn(pool_head->elems_in_chunk * pool_head->elemsize);
+        chunk->slab = pool_head->malloc_fn(pool_head->elems_in_chunk * pool_head->elemsize,
+                                           pool_head->state);
         YAKSU_ERR_CHKANDJUMP(!chunk->slab, rc, YAKSA_ERR__OUT_OF_MEM, fn_fail);
 
         /* keep track of the allocated chunk */

--- a/src/util/yaksu_buffer_pool.c
+++ b/src/util/yaksu_buffer_pool.c
@@ -149,6 +149,7 @@ int yaksu_buffer_pool_elem_alloc(yaksu_buffer_pool_s pool, void **elem)
 
     pthread_mutex_lock(&pool_head->mutex);
 
+    *elem = NULL;
     chunk_s *chunk = NULL;
     if (pool_head->free_elems == NULL) {
         /* no more free elements left; see if we can allocate more

--- a/src/util/yaksu_buffer_pool.h
+++ b/src/util/yaksu_buffer_pool.h
@@ -8,11 +8,11 @@
 
 typedef void *yaksu_buffer_pool_s;
 
-typedef void *(*yaksu_malloc_fn) (uintptr_t);
-typedef void (*yaksu_free_fn) (void *);
+typedef void *(*yaksu_malloc_fn) (uintptr_t size, void *state);
+typedef void (*yaksu_free_fn) (void *buf, void *state);
 
 int yaksu_buffer_pool_alloc(uintptr_t elemsize, unsigned int elems_in_chunk, unsigned int maxelems,
-                            yaksu_malloc_fn malloc_fn, yaksu_free_fn free_fn,
+                            yaksu_malloc_fn malloc_fn, yaksu_free_fn free_fn, void *state,
                             yaksu_buffer_pool_s * pool);
 int yaksu_buffer_pool_free(yaksu_buffer_pool_s pool);
 int yaksu_buffer_pool_elem_alloc(yaksu_buffer_pool_s pool, void **elem);


### PR DESCRIPTION
## Pull Request Description

This PR revamps the Yaksa progress engine to convert it to a cleaner state machine.  The event and buffer management are now completely hoisted up to the glue layer (the GPU drivers do not need to know anything about temporary buffers).  Different buffer types are managed as separate smaller functions to avoid code clutter.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
