### PR TITLE
atomics: Remove return from void function

### DIFF
--- a/src/util/yaksu_atomics.h
+++ b/src/util/yaksu_atomics.h
@@ -32,7 +32,7 @@ static inline int yaksu_atomic_load(yaksu_atomic_int * val)
 
 static inline void yaksu_atomic_store(yaksu_atomic_int * val, int x)
 {
-    return atomic_store_explicit(val, x, memory_order_release);
+    atomic_store_explicit(val, x, memory_order_release);
 }
 
 #else


### PR DESCRIPTION
## Pull Request Description

Solaris compilers complain:

  "src/util/yaksu_atomics.h", line 35: void function cannot return value

Remove "return" so that the compiler knows nothing is returned to the caller.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix build on Solaris with suncc compiler.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
