### PR TITLE
backend/cuda: add libstdc++ dependency for CUDA

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -68,7 +68,22 @@ EOF
         AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
         AS_IF([test -n "${with_cuda}"],[NVCC=${with_cuda}/bin/nvcc],[NVCC=nvcc])
         AC_SUBST(NVCC)
-        AC_MSG_RESULT([yes])
+        # nvcc compiled applications need libstdc++ to be able to link
+        # with a C compiler
+        PAC_PUSH_FLAG([LIBS])
+        PAC_APPEND_FLAG([-lstdc++],[LIBS])
+        AC_LINK_IFELSE(
+            [AC_LANG_PROGRAM([int x = 5;],[x++;])],
+            [libstdcpp_works=yes],
+            [libstdcpp_works=no])
+        PAC_POP_FLAG([LIBS])
+        if test "${libstdcpp_works}" = "yes" ; then
+            PAC_APPEND_FLAG([-lstdc++],[LIBS])
+            AC_MSG_RESULT([yes])
+        else
+            have_cuda=no
+            AC_MSG_RESULT([no])
+        fi
     else
         have_cuda=no
         AC_MSG_RESULT([no])


### PR DESCRIPTION
## Pull Request Description

libcudart requires libstdc++, but it does not seem to have an explicit dependency on it.  Try to add it in the build, if it is available.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
