### PR TITLE
build: improve --enable-fast configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -126,12 +126,23 @@ if test "${enable_debug}" != "no" ; then
 fi
 
 # --enable-fast
-AC_ARG_ENABLE([fast],AS_HELP_STRING([--enable-fast=O<opt>],[adds -O<opt> to CFLAGS]),,[enable_fast=yes])
-if test "`echo ${enable_fast} | cut -c1`" = "O" ; then
-    PAC_APPEND_FLAG([-${enable_fast}],[CFLAGS])
-elif test "${enable_fast}" != "no" ; then
-    PAC_APPEND_FLAG([-O2],[CFLAGS])
-fi
+AC_ARG_ENABLE([fast],AS_HELP_STRING([--enable-fast=O<opt>],[adds -O<opt> to CFLAGS]),,[enable_fast=O2])
+PAC_PUSH_FLAG(IFS)
+IFS=","
+for option in ${enable_fast} ; do
+    case "$option" in
+        O*)
+            PAC_APPEND_FLAG([-${option}],[CFLAGS])
+	    ;;
+	ndebug)
+	    PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
+	    ;;
+	*)
+	    # ignore unknown options
+	    ;;
+    esac
+done
+PAC_POP_FLAG(IFS)
 
 
 dnl ----------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Description

Allow for ndebug to be passed as an option, and ignore options that we
do not recognize.  This allows yaksa to be used in embedded mode,
where we might not recognize all options passed to us.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
