### PR TITLE
frontend: free built-in types before calling finalize_hook

### DIFF
--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -288,11 +288,6 @@ int yaksa_finalize(void)
         goto fn_exit;
     }
 
-    /* finalize the backend */
-    rc = yaksur_finalize_hook();
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-
     /* free the builtin datatypes */
     FINALIZE_BUILTIN_TYPE(NULL, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(_BOOL, rc, fn_fail);
@@ -362,6 +357,10 @@ int yaksa_finalize(void)
     /* *INDENT-ON* */
     FINALIZE_BUILTIN_TYPE(SHORT_INT, rc, fn_fail);
     FINALIZE_BUILTIN_TYPE(LONG_DOUBLE_INT, rc, fn_fail);
+
+    /* finalize the backend */
+    rc = yaksur_finalize_hook();
+    YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = yaksu_handle_pool_free(yaksi_global.type_handle_pool);
     YAKSU_ERR_CHECK(rc, fn_fail);


### PR DESCRIPTION
Freeing built-in types may require accessing backend devices, it needs to
be called before devices are freed in the finalize_hook.

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
