### PR TITLE
test: fix runtest script to always print failure in the summary

### DIFF
--- a/test/runtests.py
+++ b/test/runtests.py
@@ -129,9 +129,12 @@ def create_summary(summary_file):
 
     for x in range(len(testnames)):
         fh.write("    <testcase name=\"%s\" time=\"%f\">\n" % (testnames[x].strip(), testtimes[x]))
-        if (testretvals[x] != 0 and testoutputs[x]):
+        if (testretvals[x] != 0):
             fh.write("      <failure><![CDATA[\n")
-            fh.write(testoutputs[x] + "\n")
+            if (testoutputs[x]):
+                fh.write(testoutputs[x] + "\n")
+            else:
+                fh.write("test failed\n")
             fh.write("      ]]></failure>\n")
         fh.write("    </testcase>\n")
 


### PR DESCRIPTION
Always print failure in the summary file even though there is no error output.
Also add a "make testing-pack" to run test "pack" only

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
