### PR TITLE
backend: use YAKSURI_KERNEL_NULL for uninitialized kernels

### DIFF
--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -23,6 +23,8 @@ extern "C" {
 
 #include <yaksuri_cudai_base.h>
 
+#define YAKSURI_KERNEL_NULL  NULL
+
 #define YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail)            \
     do {                                                                \
         if (cerr != cudaSuccess) {                                      \

--- a/src/backend/gencomm.py
+++ b/src/backend/gencomm.py
@@ -112,8 +112,8 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
     yutils.display(OUTFILE, "yaksuri_%si_type_s *%s = (yaksuri_%si_type_s *) type->backend.%s.priv;\n" \
                    % (backend, backend, backend, backend))
     yutils.display(OUTFILE, "\n")
-    yutils.display(OUTFILE, "%s->pack = NULL;\n" % backend)
-    yutils.display(OUTFILE, "%s->unpack = NULL;\n" % backend)
+    yutils.display(OUTFILE, "%s->pack = YAKSURI_KERNEL_NULL;\n" % backend)
+    yutils.display(OUTFILE, "%s->unpack = YAKSURI_KERNEL_NULL;\n" % backend)
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "switch (type->kind) {\n")
     for dtype1 in derived_types:

--- a/src/backend/seq/include/yaksuri_seqi.h
+++ b/src/backend/seq/include/yaksuri_seqi.h
@@ -8,6 +8,8 @@
 
 #include "yaksi.h"
 
+#define YAKSURI_KERNEL_NULL   NULL
+
 typedef struct yaksuri_seqi_type_s {
     int (*pack) (const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *);
     int (*unpack) (const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *);


### PR DESCRIPTION
Each backend defines YAKSURI_KERNEL_NULL to be the right value for
uninitialized kernels.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
