### PR TITLE
backend: Fix Solaris build error

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -47,7 +47,8 @@ static void free_fn(void *buf, void *state)
             continue;
 
         if (state == &yaksuri_global.gpudriver[id].host) {
-            return yaksuri_global.gpudriver[id].hooks->host_free(buf);
+            yaksuri_global.gpudriver[id].hooks->host_free(buf);
+            return;
         } else {
             uintptr_t start = (uintptr_t) yaksuri_global.gpudriver[id].device;
             uintptr_t end =
@@ -55,7 +56,8 @@ static void free_fn(void *buf, void *state)
                                                                   gpudriver[id].ndevices - 1];
 
             if ((uintptr_t) state >= start && (uintptr_t) state <= end) {
-                return yaksuri_global.gpudriver[id].hooks->gpu_free(buf);
+                yaksuri_global.gpudriver[id].hooks->gpu_free(buf);
+                return;
             }
         }
     }


### PR DESCRIPTION
Solaris compilers are really picky about returning from void
functions. Separate the free function call from the return statement
to make the compiler happy.

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
