### PR TITLE
backend/glue: distinguish UNSET vs. LAST GPU driver ID

### DIFF
--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -51,10 +51,10 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
     }
 
     if (id == YAKSURI_GPUDRIVER_ID__LAST)
-        reqpriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
+        reqpriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__LAST;
 
     /* if this can be handled by the CPU, wrap it up */
-    if (reqpriv->gpudriver_id == YAKSURI_GPUDRIVER_ID__UNSET) {
+    if (reqpriv->gpudriver_id == YAKSURI_GPUDRIVER_ID__LAST) {
         bool is_supported;
         rc = yaksuri_seq_pup_is_supported(type, &is_supported);
         YAKSU_ERR_CHECK(rc, fn_fail);
@@ -70,15 +70,10 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
                 YAKSU_ERR_CHECK(rc, fn_fail);
             }
         }
-        goto fn_exit;
+    } else {
+        rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request);
+        YAKSU_ERR_CHECK(rc, fn_fail);
     }
-
-    /* if this cannot be handled by the CPU, queue it up for the GPU
-     * to handle */
-    assert(reqpriv->gpudriver_id != YAKSURI_GPUDRIVER_ID__UNSET);
-
-    rc = yaksuri_progress_enqueue(inbuf, outbuf, count, type, info, request);
-    YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
     return rc;


### PR DESCRIPTION
## Pull Request Description

Use UNSET for the case where the GPU driver ID is not queried yet.
LAST is used when the query is done, but no GPU driver claimed the
buffers.

Without this, we were always repeating the query for each subreq, when
no GPU driver claimed the buffers.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
