### PR TITLE
frontend/unpack: bug-fix for unpack_element

### DIFF
--- a/src/frontend/pup/yaksi_iunpack_element.c
+++ b/src/frontend/pup/yaksi_iunpack_element.c
@@ -66,8 +66,11 @@ static int unpack_sub_hvector(const void *inbuf, uintptr_t insize, void *outbuf,
         rem_unpack_bytes -= tmp_actual_unpack_bytes;
         *actual_unpack_bytes += tmp_actual_unpack_bytes;
 
-        if (rem_unpack_bytes == 0 || tmp_actual_unpack_bytes == 0) {
-            /* if we are out of unpack buffer space, return */
+        if (rem_unpack_bytes == 0 ||
+            tmp_actual_unpack_bytes <
+            type->u.hvector.child->size * type->u.hvector.blocklength - remoffset) {
+            /* if we are out of unpack buffer space or if we could not
+             * unpack fully, return */
             goto fn_exit;
         }
 
@@ -155,8 +158,11 @@ static int unpack_sub_blkhindx(const void *inbuf, uintptr_t insize, void *outbuf
         rem_unpack_bytes -= tmp_actual_unpack_bytes;
         *actual_unpack_bytes += tmp_actual_unpack_bytes;
 
-        if (rem_unpack_bytes == 0 || tmp_actual_unpack_bytes == 0) {
-            /* if we are out of unpack buffer space, return */
+        if (rem_unpack_bytes == 0 ||
+            tmp_actual_unpack_bytes <
+            type->u.blkhindx.child->size * type->u.blkhindx.blocklength - remoffset) {
+            /* if we are out of unpack buffer space or if we could not
+             * unpack fully, return */
             goto fn_exit;
         }
 
@@ -253,8 +259,11 @@ static int unpack_sub_hindexed(const void *inbuf, uintptr_t insize, void *outbuf
         rem_unpack_bytes -= tmp_actual_unpack_bytes;
         *actual_unpack_bytes += tmp_actual_unpack_bytes;
 
-        if (rem_unpack_bytes == 0 || tmp_actual_unpack_bytes == 0) {
-            /* if we are out of unpack buffer space, return */
+        if (rem_unpack_bytes == 0 ||
+            tmp_actual_unpack_bytes < type->u.hindexed.child->size *
+            type->u.hindexed.array_of_blocklengths[blockid] - remoffset) {
+            /* if we are out of unpack buffer space or if we could not
+             * unpack fully, return */
             goto fn_exit;
         }
 
@@ -373,8 +382,11 @@ static int unpack_sub_struct(const void *inbuf, uintptr_t insize, void *outbuf, 
         rem_unpack_bytes -= tmp_actual_unpack_bytes;
         *actual_unpack_bytes += tmp_actual_unpack_bytes;
 
-        if (rem_unpack_bytes == 0 || tmp_actual_unpack_bytes == 0) {
-            /* if we are out of unpack buffer space, return */
+        if (rem_unpack_bytes == 0 ||
+            tmp_actual_unpack_bytes < type->u.str.array_of_types[blockid]->size *
+            type->u.str.array_of_blocklengths[blockid] - remoffset) {
+            /* if we are out of unpack buffer space or if we could not
+             * unpack fully, return */
             goto fn_exit;
         }
 


### PR DESCRIPTION
## Pull Request Description

If a partial pack returned without packing the entire block, it means
that we have hit a type boundary.  In that case, simply return.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
