### PR TITLE
backend/ze: fix use of wrong SPIRV file name for inline generation

### DIFF
--- a/src/backend/ze/pup/Makefile.mk
+++ b/src/backend/ze/pup/Makefile.mk
@@ -30,6 +30,6 @@ else
 	echo "ocloc compile -file $< -device skl -spv_only -out_dir `dirname $@` -output_no_suffix -options \"-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0\""; \
 	ocloc compile -file $< -device skl -spv_only -out_dir `dirname $@` -output_no_suffix -options "-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0" && \
 	/bin/rm -f $(@:.c=.gen); \
-	$(top_srcdir)/src/backend/ze/pup/inline.py $< $@ $(top_srcdir) 0
+	$(top_srcdir)/src/backend/ze/pup/inline.py $(@:.c=.spv) $@ $(top_srcdir) 0
 
 endif


### PR DESCRIPTION
Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
