### PR TITLE
backend/ze: fixes for multi-threading

### DIFF
--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -210,10 +210,9 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
         (yaksuri_zei_device_state_s *) calloc(yaksuri_zei_global.ndevices,
                                               sizeof(yaksuri_zei_device_state_s));
     yaksuri_zei_global.throttle_threshold = ZE_THROTTLE_THRESHOLD;
-    yaksuri_zei_global.ev_pool_cap = ZE_EVENT_POOL_CAP;
     ze_event_pool_desc_t pool_desc = { ZE_STRUCTURE_TYPE_EVENT_POOL_DESC };
     pool_desc.flags = 0;
-    pool_desc.count = yaksuri_zei_global.ev_pool_cap;
+    pool_desc.count = ZE_EVENT_POOL_CAP;
 
     for (int i = 0; i < yaksuri_zei_global.ndevices; i++) {
         yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + i;
@@ -223,7 +222,7 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
                                  &yaksuri_zei_global.device[i], &device_state->ep);
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
         device_state->events =
-            (ze_event_handle_t *) calloc(yaksuri_zei_global.ev_pool_cap, sizeof(ze_event_handle_t));
+            (ze_event_handle_t *) calloc(ZE_EVENT_POOL_CAP, sizeof(ze_event_handle_t));
         device_state->last_event_idx = -1;
         device_state->ev_lb = device_state->ev_ub = -1;
         device_state->cl_pool_size = ZE_CMD_LIST_INIT_POOL_SIZE;

--- a/src/backend/ze/md/yaksuri_zei_md.c
+++ b/src/backend/ze/md/yaksuri_zei_md.c
@@ -46,16 +46,33 @@ int yaksuri_zei_md_alloc(yaksi_type_s * type, int dev_id)
     if (ze->md && ze->md[dev_id]) {
         goto fn_exit;
     } else {
-        if (ze->md == NULL)
+        if (ze->md == NULL) {
             ze->md =
                 (yaksuri_zei_md_s **) calloc(yaksuri_zei_global.ndevices,
                                              sizeof(yaksuri_zei_md_s *));
+            assert(ze->md);
+        }
+#if ZE_MD_HOST
+        if (ze->md[0] == NULL) {
+            zerr =
+                zeMemAllocHost(yaksuri_zei_global.context, &host_desc,
+                               sizeof(yaksuri_zei_md_s), 1, (void **) &ze->md[0]);
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            ze->md[dev_id] = ze->md[0];
+        } else {
+            ze->md[dev_id] = ze->md[0];
+            goto fn_exit;
+        }
+#else
         zerr =
             zeMemAllocShared(yaksuri_zei_global.context, &device_desc, &host_desc,
                              sizeof(yaksuri_zei_md_s), 1, yaksuri_zei_global.device[dev_id],
                              (void **) &ze->md[dev_id]);
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+#endif
     }
+
+    yaksuri_zei_md_s *md = ze->md[dev_id];
 
     switch (type->kind) {
         case YAKSI_TYPE_KIND__BUILTIN:
@@ -64,89 +81,263 @@ int yaksuri_zei_md_alloc(yaksi_type_s * type, int dev_id)
         case YAKSI_TYPE_KIND__DUP:
             rc = yaksuri_zei_md_alloc(type->u.dup.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.dup.child = type_to_md(type->u.dup.child, dev_id);
+            md->u.dup.child = type_to_md(type->u.dup.child, dev_id);
             break;
 
         case YAKSI_TYPE_KIND__RESIZED:
             rc = yaksuri_zei_md_alloc(type->u.resized.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.resized.child = type_to_md(type->u.resized.child, dev_id);
+            md->u.resized.child = type_to_md(type->u.resized.child, dev_id);
             break;
 
         case YAKSI_TYPE_KIND__HVECTOR:
-            ze->md[dev_id]->u.hvector.count = type->u.hvector.count;
-            ze->md[dev_id]->u.hvector.blocklength = type->u.hvector.blocklength;
-            ze->md[dev_id]->u.hvector.stride = type->u.hvector.stride;
+            md->u.hvector.count = type->u.hvector.count;
+            md->u.hvector.blocklength = type->u.hvector.blocklength;
+            md->u.hvector.stride = type->u.hvector.stride;
 
             rc = yaksuri_zei_md_alloc(type->u.hvector.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.hvector.child = type_to_md(type->u.hvector.child, dev_id);
+            md->u.hvector.child = type_to_md(type->u.hvector.child, dev_id);
             break;
 
         case YAKSI_TYPE_KIND__BLKHINDX:
-            ze->md[dev_id]->u.blkhindx.count = type->u.blkhindx.count;
-            ze->md[dev_id]->u.blkhindx.blocklength = type->u.blkhindx.blocklength;
+            md->u.blkhindx.count = type->u.blkhindx.count;
+            md->u.blkhindx.blocklength = type->u.blkhindx.blocklength;
 
+#if ZE_MD_HOST
+            zerr = zeMemAllocHost(yaksuri_zei_global.context, &host_desc,
+                                  type->u.blkhindx.count * sizeof(intptr_t), 1,
+                                  (void **) &md->u.blkhindx.array_of_displs);
+#else
             zerr = zeMemAllocShared(yaksuri_zei_global.context, &device_desc, &host_desc,
                                     type->u.blkhindx.count * sizeof(intptr_t), 1,
                                     yaksuri_zei_global.device[dev_id],
-                                    (void **) &ze->md[dev_id]->u.blkhindx.array_of_displs);
+                                    (void **) &md->u.blkhindx.array_of_displs);
+#endif
             YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
 
-            memcpy(ze->md[dev_id]->u.blkhindx.array_of_displs, type->u.blkhindx.array_of_displs,
+            memcpy(md->u.blkhindx.array_of_displs, type->u.blkhindx.array_of_displs,
                    type->u.blkhindx.count * sizeof(intptr_t));
 
             rc = yaksuri_zei_md_alloc(type->u.blkhindx.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.blkhindx.child = type_to_md(type->u.blkhindx.child, dev_id);
+            md->u.blkhindx.child = type_to_md(type->u.blkhindx.child, dev_id);
             break;
 
         case YAKSI_TYPE_KIND__HINDEXED:
-            ze->md[dev_id]->u.hindexed.count = type->u.hindexed.count;
+            md->u.hindexed.count = type->u.hindexed.count;
 
+#if ZE_MD_HOST
+            zerr = zeMemAllocHost(yaksuri_zei_global.context, &host_desc,
+                                  type->u.hindexed.count * sizeof(intptr_t), 1,
+                                  (void **) &md->u.hindexed.array_of_displs);
+#else
             zerr = zeMemAllocShared(yaksuri_zei_global.context, &device_desc, &host_desc,
                                     type->u.hindexed.count * sizeof(intptr_t), 1,
                                     yaksuri_zei_global.device[dev_id],
-                                    (void **) &ze->md[dev_id]->u.hindexed.array_of_displs);
+                                    (void **) &md->u.hindexed.array_of_displs);
+#endif
             YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
 
-            memcpy(ze->md[dev_id]->u.hindexed.array_of_displs, type->u.hindexed.array_of_displs,
+            memcpy(md->u.hindexed.array_of_displs, type->u.hindexed.array_of_displs,
                    type->u.hindexed.count * sizeof(intptr_t));
 
+#if ZE_MD_HOST
+            zerr = zeMemAllocHost(yaksuri_zei_global.context, &host_desc,
+                                  type->u.hindexed.count * sizeof(int), 1,
+                                  (void **) &md->u.hindexed.array_of_blocklengths);
+#else
             zerr = zeMemAllocShared(yaksuri_zei_global.context, &device_desc, &host_desc,
                                     type->u.hindexed.count * sizeof(int), 1,
                                     yaksuri_zei_global.device[dev_id],
-                                    (void **) &ze->md[dev_id]->u.hindexed.array_of_blocklengths);
+                                    (void **) &md->u.hindexed.array_of_blocklengths);
+#endif
             YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
 
-            memcpy(ze->md[dev_id]->u.hindexed.array_of_blocklengths,
+            memcpy(md->u.hindexed.array_of_blocklengths,
                    type->u.hindexed.array_of_blocklengths, type->u.hindexed.count * sizeof(int));
 
             rc = yaksuri_zei_md_alloc(type->u.hindexed.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.hindexed.child = type_to_md(type->u.hindexed.child, dev_id);
+            md->u.hindexed.child = type_to_md(type->u.hindexed.child, dev_id);
             break;
 
         case YAKSI_TYPE_KIND__CONTIG:
-            ze->md[dev_id]->u.contig.count = type->u.contig.count;
-            ze->md[dev_id]->u.contig.stride = type->u.contig.child->extent;
+            md->u.contig.count = type->u.contig.count;
+            md->u.contig.stride = type->u.contig.child->extent;
 
             rc = yaksuri_zei_md_alloc(type->u.contig.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
-            ze->md[dev_id]->u.contig.child = type_to_md(type->u.contig.child, dev_id);
+            md->u.contig.child = type_to_md(type->u.contig.child, dev_id);
             break;
 
         default:
             assert(0);
     }
 
-    ze->md[dev_id]->extent = type->extent;
-    ze->md[dev_id]->num_elements = ze->num_elements;
-    ze->md[dev_id]->true_lb = type->true_lb;
+    md->extent = type->extent;
+    md->num_elements = ze->num_elements;
+    md->true_lb = type->true_lb;
 
   fn_exit:
     pthread_mutex_unlock(&ze->mdmutex);
     return rc;
   fn_fail:
+    goto fn_exit;
+}
+
+int yaksuri_zei_type_make_resident(yaksi_type_s * type, int dev_id)
+{
+    int rc = YAKSA_SUCCESS;
+    ze_result_t zerr;
+    ze_device_handle_t device = yaksuri_zei_global.device[dev_id];
+    yaksuri_zei_md_s *md = type_to_md(type, dev_id);
+
+    if (type->kind == YAKSI_TYPE_KIND__DUP) {
+        if (md->u.dup.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device, md->u.dup.child,
+                                            sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.dup.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__RESIZED) {
+        if (md->u.resized.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device, md->u.resized.child,
+                                            sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.resized.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__HVECTOR) {
+        if (md->u.hvector.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device, md->u.hvector.child,
+                                            sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.hvector.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__BLKHINDX) {
+        assert(md->u.blkhindx.array_of_displs);
+        zerr =
+            zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
+                                        md->u.blkhindx.array_of_displs,
+                                        md->u.blkhindx.count * sizeof(intptr_t));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        assert(md->u.blkhindx.child);
+        if (md->u.blkhindx.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
+                                            md->u.blkhindx.child, sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.blkhindx.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__HINDEXED) {
+        assert(md->u.hindexed.array_of_displs);
+        zerr =
+            zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
+                                        md->u.hindexed.array_of_displs,
+                                        md->u.hindexed.count * sizeof(intptr_t));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        assert(md->u.hindexed.array_of_blocklengths);
+        zerr =
+            zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
+                                        md->u.hindexed.array_of_blocklengths,
+                                        md->u.hindexed.count * sizeof(int));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        if (md->u.hindexed.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
+                                            md->u.hindexed.child, sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.hindexed.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__CONTIG) {
+        if (md->u.contig.child) {
+            zerr =
+                zeContextMakeMemoryResident(yaksuri_zei_global.context, device, md->u.contig.child,
+                                            sizeof(yaksuri_zei_md_s));
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+            yaksuri_zei_type_make_resident(type->u.contig.child, dev_id);
+        }
+    } else if (type->kind == YAKSI_TYPE_KIND__SUBARRAY) {
+        assert(0);
+    } else if (type->kind == YAKSI_TYPE_KIND__STRUCT) {
+        assert(0);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    assert(0);
+    goto fn_exit;
+}
+
+int yaksuri_zei_type_evict_resident(yaksi_type_s * type, int dev_id)
+{
+    int rc = YAKSA_SUCCESS;
+    ze_result_t zerr;
+    ze_device_handle_t device = yaksuri_zei_global.device[dev_id];
+    yaksuri_zei_md_s *md = type_to_md(type, dev_id);
+
+    if (type->kind == YAKSI_TYPE_KIND__DUP) {
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.dup.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__RESIZED) {
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.resized.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__HVECTOR) {
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.hvector.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__BLKHINDX) {
+        assert(md->u.blkhindx.array_of_displs);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.blkhindx.array_of_displs,
+                                 md->u.blkhindx.count * sizeof(intptr_t));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        assert(md->u.blkhindx.child);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.blkhindx.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__HINDEXED) {
+        assert(md->u.hindexed.array_of_displs);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.hindexed.array_of_displs,
+                                 md->u.hindexed.count * sizeof(intptr_t));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        assert(md->u.hindexed.array_of_blocklengths);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device,
+                                 md->u.hindexed.array_of_blocklengths,
+                                 md->u.hindexed.count * sizeof(int));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+        assert(md->u.hindexed.child);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.hindexed.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__CONTIG) {
+        assert(md->u.contig.child);
+        zerr =
+            zeContextEvictMemory(yaksuri_zei_global.context, device, md->u.contig.child,
+                                 sizeof(yaksuri_zei_md_s));
+        YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
+    } else if (type->kind == YAKSI_TYPE_KIND__SUBARRAY) {
+        assert(0);
+    } else if (type->kind == YAKSI_TYPE_KIND__STRUCT) {
+        assert(0);
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    assert(0);
     goto fn_exit;
 }

--- a/src/backend/ze/pup/yaksuri_zei_event.c
+++ b/src/backend/ze/pup/yaksuri_zei_event.c
@@ -15,10 +15,9 @@
 #define update_event_usage(device_state, event_idx)                     \
         if (event_idx == device_state->ev_ub)                           \
             device_state->ev_lb = device_state->ev_ub = -1;             \
-        else {                                                          \
+        else if (event_idx >= device_state->ev_lb && device_state->ev_lb != -1) {                           \
+            assert(event_idx < device_state->ev_ub);                    \
             device_state->ev_lb = event_idx + 1;                        \
-            if (device_state->ev_lb == yaksuri_zei_global.ev_pool_cap)  \
-                device_state->ev_lb = 0;                                \
         }
 
 int create_ze_event(int dev_id, ze_event_handle_t * ze_event, int *idx)
@@ -28,36 +27,34 @@ int create_ze_event(int dev_id, ze_event_handle_t * ze_event, int *idx)
     int ev_idx;
 
     yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + dev_id;
-    pthread_mutex_lock(&device_state->mutex);
     /* sanity check - abort when all events in the event pool are used up */
-    assert(device_state->ev_pool_idx != device_state->ev_lb);
+    assert(device_state->ev_ub - device_state->ev_lb < ZE_EVENT_POOL_CAP ||
+           device_state->ev_lb != -1);
     ev_idx = device_state->ev_pool_idx;
     if (idx)
         *idx = ev_idx;
     /* reset the event before using it again */
-    if (device_state->events[ev_idx]) {
-        zeEventHostReset(device_state->events[ev_idx]);
-        *ze_event = device_state->events[ev_idx];
+    int pool_idx = ZE_EVENT_POOL_INDEX(ev_idx);
+    if (device_state->events[pool_idx]) {
+        zeEventHostReset(device_state->events[pool_idx]);
+        *ze_event = device_state->events[pool_idx];
     } else {
         ze_event_desc_t event_desc = {
             .stype = ZE_STRUCTURE_TYPE_EVENT_DESC,
             .pNext = NULL,
-            .index = ev_idx,
+            .index = pool_idx,
             .signal = 0,
             .wait = ZE_EVENT_SCOPE_FLAG_HOST
         };
         zerr = zeEventCreate(device_state->ep, &event_desc, ze_event);
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
-        device_state->events[ev_idx] = *ze_event;
+        device_state->events[pool_idx] = *ze_event;
     }
     device_state->ev_pool_idx++;
-    if (device_state->ev_pool_idx == yaksuri_zei_global.ev_pool_cap)
-        device_state->ev_pool_idx = 0;
     /* update event bracket [ev_lb,ev_ub] */
     device_state->ev_ub = ev_idx;
     if (device_state->ev_lb == -1)
         device_state->ev_lb = device_state->ev_ub;
-    pthread_mutex_unlock(&device_state->mutex);
 
   fn_exit:
     return rc;
@@ -99,6 +96,8 @@ int yaksuri_zei_event_record(int device, void **event_)
 
     event = (yaksuri_zei_event_s *) malloc(sizeof(yaksuri_zei_event_s));
 
+    yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + device;
+    pthread_mutex_lock(&device_state->mutex);
     rc = create_ze_event(device, &ze_event, &idx);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -107,21 +106,19 @@ int yaksuri_zei_event_record(int device, void **event_)
     event->cl = NULL;
     event->idx = idx;
 
-    yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + device;
     if (device_state->num_cl) {
-        pthread_mutex_lock(&device_state->mutex);
         ze_command_list_handle_t cl = device_state->cl[device_state->num_cl - 1];
         assert(cl);
         zerr = zeCommandListAppendSignalEvent(cl, event->ze_event);
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
         event->cl = cl;
-        pthread_mutex_unlock(&device_state->mutex);
     }
     assert(event->cl);
 
     *event_ = event;
 
   fn_exit:
+    pthread_mutex_unlock(&device_state->mutex);
     return rc;
   fn_fail:
     goto fn_exit;
@@ -168,10 +165,9 @@ int yaksuri_zei_add_dependency(int device1, int device2)
     yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + device1;
     pthread_mutex_lock(&device_state->mutex);
     assert(device_state->last_event_idx >= 0);
-    last_event = device_state->events[device_state->last_event_idx];
+    last_event = device_state->events[ZE_EVENT_POOL_INDEX(device_state->last_event_idx)];
     assert(device_state->num_cl > 0);
     cl = device_state->cl[device_state->num_cl - 1];
-    pthread_mutex_unlock(&device_state->mutex);
     if (last_event) {
         int completed = 0;
         while (!completed) {
@@ -182,14 +178,13 @@ int yaksuri_zei_add_dependency(int device1, int device2)
                 YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
             }
         }
-        pthread_mutex_lock(&device_state->mutex);
         /* update event bracket [ev_lb, ev_ub] */
         update_event_usage(device_state, device_state->last_event_idx);
         free_to_marker(device_state, cl);
-        pthread_mutex_unlock(&device_state->mutex);
     }
 
   fn_exit:
+    pthread_mutex_unlock(&device_state->mutex);
     return rc;
   fn_fail:
     goto fn_exit;


### PR DESCRIPTION
Switched from indirect-access mode to finer-grained control of buffer
residency to avoid race condition in handling managed buffers.
Improved locking on events and kernel invocation.

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
