### PR TITLE
backend/ze: set memory property descriptor to zero

### DIFF
--- a/src/backend/ze/pup/yaksuri_zei_get_ptr_attr.c
+++ b/src/backend/ze/pup/yaksuri_zei_get_ptr_attr.c
@@ -40,7 +40,13 @@ int yaksuri_zei_get_ptr_attr(const void *inbuf, void *outbuf, yaksi_info_s * inf
     int rc = YAKSA_SUCCESS;
     ze_result_t zerr;
     yaksuri_zei_info_s *infopriv = NULL;
-    ze_memory_allocation_properties_t prop;
+    ze_memory_allocation_properties_t prop = {
+        .stype = ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES,
+        .pNext = NULL,
+        .type = 0,
+        .id = 0,
+        .pageSize = 0,
+    };
     ze_device_handle_t device;
 
     if (info) {

--- a/test/pack/pack-ze.c
+++ b/test/pack/pack-ze.c
@@ -189,6 +189,7 @@ void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info)
         assert(rc == YAKSA_SUCCESS);
 
         ze_alloc_attr_t attr;
+        memset(&attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
         zerr = zeMemGetAllocProperties(ze_context, inbuf, &attr.prop, &attr.device);
         assert(zerr == ZE_RESULT_SUCCESS);
         rc = yaksa_info_keyval_append(*info, "yaksa_ze_inbuf_ptr_attr", &attr, sizeof(attr));
@@ -213,6 +214,8 @@ void pack_ze_copy_content(const void *sbuf, void *dbuf, size_t size, mem_type_e 
             ze_memory_allocation_properties_t prop;
             ze_device_handle_t device;
         } s_attr, d_attr;
+        memset(&s_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
+        memset(&d_attr.prop, 0, sizeof(ze_memory_allocation_properties_t));
         ret = zeMemGetAllocProperties(ze_context, sbuf, &s_attr.prop, &s_attr.device);
         assert(ret == ZE_RESULT_SUCCESS);
         ret = zeMemGetAllocProperties(ze_context, dbuf, &d_attr.prop, &d_attr.device);


### PR DESCRIPTION
Latest L0 requires the property descriptor to be set zero

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
