### PR TITLE
backend: added a new flush_all function to flush kernels

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -193,6 +193,7 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
     (*hooks)->ipack = yaksuri_cudai_ipack;
     (*hooks)->iunpack = yaksuri_cudai_iunpack;
+    (*hooks)->flush_all = yaksuri_cudai_flush_all;
     (*hooks)->pup_is_supported = yaksuri_cudai_pup_is_supported;
     (*hooks)->host_malloc = cuda_host_malloc;
     (*hooks)->host_free = cuda_host_free;

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -82,6 +82,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
                         yaksi_info_s * info, int target);
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                           yaksi_info_s * info, int target);
+int yaksuri_cudai_flush_all(void);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, bool * is_supported);
 uintptr_t yaksuri_cudai_get_iov_pack_threshold(yaksi_info_s * info);
 uintptr_t yaksuri_cudai_get_iov_unpack_threshold(yaksi_info_s * info);

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -209,3 +209,8 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
   fn_fail:
     goto fn_exit;
 }
+
+int yaksuri_cudai_flush_all(void)
+{
+    return YAKSA_SUCCESS;
+}

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -62,6 +62,7 @@ typedef struct yaksur_gpudriver_hooks_s {
                   struct yaksi_type_s * type, struct yaksi_info_s * info, int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,
                     struct yaksi_info_s * info, int device);
+    int (*flush_all) (void);
     int (*pup_is_supported) (struct yaksi_type_s * type, bool * is_supported);
 
     /* memory management */

--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -274,6 +274,7 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->finalize = finalize_hook;
     (*hooks)->ipack = yaksuri_zei_ipack;
     (*hooks)->iunpack = yaksuri_zei_iunpack;
+    (*hooks)->flush_all = yaksuri_zei_flush_all;
     (*hooks)->pup_is_supported = yaksuri_zei_pup_is_supported;
     (*hooks)->get_iov_pack_threshold = yaksuri_zei_get_iov_pack_threshold;
     (*hooks)->get_iov_unpack_threshold = yaksuri_zei_get_iov_unpack_threshold;

--- a/src/backend/ze/include/yaksuri_zei.h
+++ b/src/backend/ze/include/yaksuri_zei.h
@@ -145,6 +145,7 @@ int yaksuri_zei_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_ty
                       yaksi_info_s * info, int target);
 int yaksuri_zei_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                         yaksi_info_s * info, int target);
+int yaksuri_zei_flush_all(void);
 int yaksuri_zei_pup_is_supported(yaksi_type_s * type, bool * is_supported);
 uintptr_t yaksuri_zei_get_iov_pack_threshold(yaksi_info_s * info);
 uintptr_t yaksuri_zei_get_iov_unpack_threshold(yaksi_info_s * info);

--- a/src/backend/ze/pup/yaksuri_zei_pup.c
+++ b/src/backend/ze/pup/yaksuri_zei_pup.c
@@ -412,3 +412,8 @@ int yaksuri_zei_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     pthread_mutex_unlock(&device_state->mutex);
     goto fn_exit;
 }
+
+int yaksuri_zei_flush_all(void)
+{
+    return YAKSA_SUCCESS;
+}


### PR DESCRIPTION
## Pull Request Description

While CUDA does not need this functionality, Ze can take advantage of
it to chain a bunch of kernels and then issue them all during the
flush operation.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
