### PR TITLE
infohint: add nogpu as a gpudriver_id hint

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -285,6 +285,8 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
             infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__CUDA;
         } else if (!strncmp(val, "ze", vallen)) {
             infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__ZE;
+        } else if (!strncmp(val, "nogpu", vallen)) {
+            infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__LAST;
         } else {
             assert(0);
         }

--- a/src/frontend/info/yaksa_info.c
+++ b/src/frontend/info/yaksa_info.c
@@ -34,7 +34,7 @@ int yaksa_info_free(yaksa_info_t info)
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
 
-    if (yaksu_atomic_decr(&yaksi_info->refcount) > 0)
+    if (yaksu_atomic_decr(&yaksi_info->refcount) > 1)
         goto fn_exit;
 
     rc = yaksur_info_free_hook(yaksi_info);

--- a/test/pack/pack-common.c
+++ b/test/pack/pack-common.c
@@ -78,12 +78,12 @@ void pack_free_mem(mem_type_e type, void *hostbuf, void *devicebuf)
     }
 }
 
-void pack_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info)
+void pack_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter)
 {
 #ifdef HAVE_CUDA
-    pack_cuda_get_ptr_attr(inbuf, outbuf, info);
+    pack_cuda_get_ptr_attr(inbuf, outbuf, info, iter);
 #elif defined(HAVE_ZE)
-    pack_ze_get_ptr_attr(inbuf, outbuf, info);
+    pack_ze_get_ptr_attr(inbuf, outbuf, info, iter);
 #else
     *info = NULL;
 #endif

--- a/test/pack/pack-common.h
+++ b/test/pack/pack-common.h
@@ -34,7 +34,7 @@ void pack_init_devices(void);
 void pack_finalize_devices(void);
 void pack_alloc_mem(int device_id, size_t size, mem_type_e type, void **hostbuf, void **devicebuf);
 void pack_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
-void pack_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info);
+void pack_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_copy_content(const void *sbuf, void *dbuf, size_t size, mem_type_e type);
 
 #ifdef HAVE_CUDA
@@ -44,7 +44,7 @@ void pack_cuda_finalize_devices(void);
 void pack_cuda_alloc_mem(int device_id, size_t size, mem_type_e type, void **hostbuf,
                          void **devicebuf);
 void pack_cuda_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
-void pack_cuda_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info);
+void pack_cuda_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_cuda_copy_content(const void *sbuf, void *dbuf, size_t size, mem_type_e type);
 #endif
 
@@ -55,7 +55,7 @@ void pack_ze_finalize_devices(void);
 void pack_ze_alloc_mem(int device_id, size_t size, mem_type_e type, void **hostbuf,
                        void **devicebuf);
 void pack_ze_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
-void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info);
+void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_ze_copy_content(const void *sbuf, void *dbuf, size_t size, mem_type_e type);
 #endif
 

--- a/test/pack/pack-cuda.c
+++ b/test/pack/pack-cuda.c
@@ -70,10 +70,9 @@ void pack_cuda_free_mem(mem_type_e type, void *hostbuf, void *devicebuf)
     }
 }
 
-void pack_cuda_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info)
+void pack_cuda_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter)
 {
-    static int count = 0;
-    if ((++count) % 2 == 0) {
+    if (iter % 2 == 0) {
         int rc;
 
         rc = yaksa_info_create(info);

--- a/test/pack/pack-ze.c
+++ b/test/pack/pack-ze.c
@@ -171,10 +171,9 @@ void pack_ze_free_mem(mem_type_e type, void *hostbuf, void *devicebuf)
     }
 }
 
-void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info)
+void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter)
 {
-    static int count = 0;
-    if ((++count) % 2 == 0) {
+    if (iter % 2 == 0) {
         int rc;
         ze_result_t zerr;
         typedef struct {

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -49,10 +49,9 @@ static void swap_segments(uintptr_t * starts, uintptr_t * lengths, int x, int y)
     lengths[y] = tmp;
 }
 
-static void host_only_get_ptr_attr(yaksa_info_t * info)
+static void host_only_get_ptr_attr(yaksa_info_t * info, int iter)
 {
-    static int count = 0;
-    if ((++count) % 2 == 0) {
+    if (iter % 2 == 0) {
         int rc;
 
         rc = yaksa_info_create(info);
@@ -245,14 +244,14 @@ void *runtest(void *arg)
 
         yaksa_info_t pack_info, unpack_info;
         if (sbuf_memtype != MEM_TYPE__DEVICE && tbuf_memtype != MEM_TYPE__DEVICE) {
-            host_only_get_ptr_attr(&pack_info);
+            host_only_get_ptr_attr(&pack_info, i);
         } else {
-            pack_get_ptr_attr(sbuf_d + sobj.DTP_buf_offset, tbuf_d, &pack_info);
+            pack_get_ptr_attr(sbuf_d + sobj.DTP_buf_offset, tbuf_d, &pack_info, i);
         }
         if (tbuf_memtype != MEM_TYPE__DEVICE && dbuf_memtype != MEM_TYPE__DEVICE) {
-            host_only_get_ptr_attr(&unpack_info);
+            host_only_get_ptr_attr(&unpack_info, i);
         } else {
-            pack_get_ptr_attr(tbuf_d, dbuf_d + dobj.DTP_buf_offset, &unpack_info);
+            pack_get_ptr_attr(tbuf_d, dbuf_d + dobj.DTP_buf_offset, &unpack_info, i);
         }
 
         for (int j = 0; j < segments; j++) {


### PR DESCRIPTION
## Pull Request Description

The purpose of this PR is add a way to tell yaksa the both `in_buf` and `out_buf` is cpu host memory. This is useful when yaksa is configured with GPU support but the application doesn't use gpu memory or the application knows when their buffer is entirely from CPU and thus doesn't need to pay the pointer attribute query overhead.
<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fixes #168 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
