### PR TITLE
type: change the type creation API to use intptr_t

### DIFF
--- a/examples/fuf.c
+++ b/examples/fuf.c
@@ -17,7 +17,7 @@ int main()
     int pack_buf[SIZE];
     int unpack_buf[SIZE];
     yaksa_type_t indexed_block;
-    int array_of_displacements[ROWS] = {
+    intptr_t array_of_displacements[ROWS] = {
         4, 12, 20, 28,
         32, 40, 48, 56
     };

--- a/examples/hindexed.c
+++ b/examples/hindexed.c
@@ -14,7 +14,7 @@ int main()
     int pack_buf[SIZE];
     int unpack_buf[SIZE];
     yaksa_type_t hindexed;
-    int array_of_blocklengths[ROWS - 1] = {
+    intptr_t array_of_blocklengths[ROWS - 1] = {
         1, 2, 2, 4, 4, 4, 4
     };
     intptr_t array_of_displacements[ROWS - 1] = {

--- a/examples/indexed.c
+++ b/examples/indexed.c
@@ -14,10 +14,10 @@ int main()
     int pack_buf[SIZE];
     int unpack_buf[SIZE];
     yaksa_type_t indexed;
-    int array_of_blocklengths[ROWS - 1] = {
+    intptr_t array_of_blocklengths[ROWS - 1] = {
         1, 2, 2, 4, 4, 4, 4
     };
-    int array_of_displacements[ROWS - 1] = {
+    intptr_t array_of_displacements[ROWS - 1] = {
         9,
         18, 26,
         36, 44, 52, 60

--- a/examples/indexed_block.c
+++ b/examples/indexed_block.c
@@ -17,7 +17,7 @@ int main()
     int pack_buf[SIZE];
     int unpack_buf[SIZE];
     yaksa_type_t indexed_block;
-    int array_of_displacements[ROWS] = {
+    intptr_t array_of_displacements[ROWS] = {
         4, 12, 20, 28,
         32, 40, 48, 56
     };

--- a/examples/iov.c
+++ b/examples/iov.c
@@ -17,7 +17,7 @@ int main()
     int pack_buf[SIZE];
     int unpack_buf[SIZE];
     yaksa_type_t indexed_block;
-    int array_of_displacements[ROWS] = {
+    intptr_t array_of_displacements[ROWS] = {
         4, 12, 20, 28,
         32, 40, 48, 56
     };

--- a/examples/subarray.c
+++ b/examples/subarray.c
@@ -16,9 +16,9 @@ int main()
     int unpack_buf[SIZE];
     yaksa_type_t subarray;
     int ndims = 2;
-    int array_of_sizes[2] = { ROWS, COLS };
-    int array_of_subsizes[2] = { 4, 4 };
-    int array_of_starts[2] = { 4, 4 };
+    intptr_t array_of_sizes[2] = { ROWS, COLS };
+    intptr_t array_of_subsizes[2] = { 4, 4 };
+    intptr_t array_of_starts[2] = { 4, 4 };
     yaksa_subarray_order_e order = YAKSA_SUBARRAY_ORDER__C;
 
     yaksa_init(NULL);   /* before any yaksa API is called the library

--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -149,7 +149,7 @@ def generate_kernels(b, darray, op):
                 yutils.display(OUTFILE, "inner_elements /= %s->u.%s.blocklength;\n" % (md, d))
             elif (d == "hindexed"):
                 yutils.display(OUTFILE, "uintptr_t x%d;\n" % idx)
-                yutils.display(OUTFILE, "for (int i = 0; i < %s->u.%s.count; i++) {\n" % (md, d))
+                yutils.display(OUTFILE, "for (intptr_t i = 0; i < %s->u.%s.count; i++) {\n" % (md, d))
                 yutils.display(OUTFILE, "    uintptr_t in_elems = %s->u.%s.array_of_blocklengths[i] *\n" % (md, d))
                 yutils.display(OUTFILE, "                         %s->u.%s.child->num_elements;\n" % (md, d))
                 yutils.display(OUTFILE, "    if (res < in_elems) {\n")

--- a/src/backend/cuda/include/yaksuri_cudai_base.h
+++ b/src/backend/cuda/include/yaksuri_cudai_base.h
@@ -28,7 +28,7 @@ extern yaksuri_cudai_global_s yaksuri_cudai_global;
 typedef struct yaksuri_cudai_md_s {
     union {
         struct {
-            int count;
+            intptr_t count;
             intptr_t stride;
             struct yaksuri_cudai_md_s *child;
         } contig;
@@ -36,20 +36,20 @@ typedef struct yaksuri_cudai_md_s {
             struct yaksuri_cudai_md_s *child;
         } resized;
         struct {
-            int count;
-            int blocklength;
+            intptr_t count;
+            intptr_t blocklength;
             intptr_t stride;
             struct yaksuri_cudai_md_s *child;
         } hvector;
         struct {
-            int count;
-            int blocklength;
+            intptr_t count;
+            intptr_t blocklength;
             intptr_t *array_of_displs;
             struct yaksuri_cudai_md_s *child;
         } blkhindx;
         struct {
-            int count;
-            int *array_of_blocklengths;
+            intptr_t count;
+            intptr_t *array_of_blocklengths;
             intptr_t *array_of_displs;
             struct yaksuri_cudai_md_s *child;
         } hindexed;

--- a/src/backend/cuda/md/yaksuri_cudai_md.c
+++ b/src/backend/cuda/md/yaksuri_cudai_md.c
@@ -89,11 +89,13 @@ int yaksuri_cudai_md_alloc(yaksi_type_s * type)
                    type->u.hindexed.count * sizeof(intptr_t));
 
             cerr = cudaMallocManaged((void **) &cuda->md->u.hindexed.array_of_blocklengths,
-                                     type->u.hindexed.count * sizeof(int), cudaMemAttachGlobal);
+                                     type->u.hindexed.count * sizeof(intptr_t),
+                                     cudaMemAttachGlobal);
             YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
             memcpy(cuda->md->u.hindexed.array_of_blocklengths,
-                   type->u.hindexed.array_of_blocklengths, type->u.hindexed.count * sizeof(int));
+                   type->u.hindexed.array_of_blocklengths,
+                   type->u.hindexed.count * sizeof(intptr_t));
 
             rc = yaksuri_cudai_md_alloc(type->u.hindexed.child);
             YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -31,19 +31,19 @@ builtin_maps = { }
 
 ## hvector routines
 def hvector_decl(nesting, dtp, b):
-    yutils.display(OUTFILE, "int count%d = %s->u.hvector.count;\n" % (nesting, dtp))
-    yutils.display(OUTFILE, "int blocklength%d ATTRIBUTE((unused)) = %s->u.hvector.blocklength;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t count%d = %s->u.hvector.count;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t blocklength%d ATTRIBUTE((unused)) = %s->u.hvector.blocklength;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "intptr_t stride%d = %s->u.hvector.stride;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "uintptr_t extent%d ATTRIBUTE((unused)) = %s->extent;\n" % (nesting, dtp))
 
 def hvector(suffix, b, blklen, last):
     global num_paren_open
     num_paren_open += 2
-    yutils.display(OUTFILE, "for (int j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
+    yutils.display(OUTFILE, "for (intptr_t j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
     if (blklen == "generic"):
-        yutils.display(OUTFILE, "for (int k%d = 0; k%d < blocklength%d; k%d++) {\n" % (suffix, suffix, suffix, suffix))
+        yutils.display(OUTFILE, "for (intptr_t k%d = 0; k%d < blocklength%d; k%d++) {\n" % (suffix, suffix, suffix, suffix))
     else:
-        yutils.display(OUTFILE, "for (int k%d = 0; k%d < %s; k%d++) {\n" % (suffix, suffix, blklen, suffix))
+        yutils.display(OUTFILE, "for (intptr_t k%d = 0; k%d < %s; k%d++) {\n" % (suffix, suffix, blklen, suffix))
     global s
     if (last != 1):
         s += " + j%d * stride%d + k%d * extent%d" % (suffix, suffix, suffix, suffix + 1)
@@ -52,19 +52,19 @@ def hvector(suffix, b, blklen, last):
 
 ## blkhindx routines
 def blkhindx_decl(nesting, dtp, b):
-    yutils.display(OUTFILE, "int count%d = %s->u.blkhindx.count;\n" % (nesting, dtp))
-    yutils.display(OUTFILE, "int blocklength%d ATTRIBUTE((unused)) = %s->u.blkhindx.blocklength;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t count%d = %s->u.blkhindx.count;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t blocklength%d ATTRIBUTE((unused)) = %s->u.blkhindx.blocklength;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "intptr_t *restrict array_of_displs%d = %s->u.blkhindx.array_of_displs;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "uintptr_t extent%d ATTRIBUTE((unused)) = %s->extent;\n" % (nesting, dtp))
 
 def blkhindx(suffix, b, blklen, last):
     global num_paren_open
     num_paren_open += 2
-    yutils.display(OUTFILE, "for (int j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
+    yutils.display(OUTFILE, "for (intptr_t j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
     if (blklen == "generic"):
-        yutils.display(OUTFILE, "for (int k%d = 0; k%d < blocklength%d; k%d++) {\n" % (suffix, suffix, suffix, suffix))
+        yutils.display(OUTFILE, "for (intptr_t k%d = 0; k%d < blocklength%d; k%d++) {\n" % (suffix, suffix, suffix, suffix))
     else:
-        yutils.display(OUTFILE, "for (int k%d = 0; k%d < %s; k%d++) {\n" % (suffix, suffix, blklen, suffix))
+        yutils.display(OUTFILE, "for (intptr_t k%d = 0; k%d < %s; k%d++) {\n" % (suffix, suffix, blklen, suffix))
     global s
     if (last != 1):
         s += " + array_of_displs%d[j%d] + k%d * extent%d" % \
@@ -74,16 +74,16 @@ def blkhindx(suffix, b, blklen, last):
 
 ## hindexed routines
 def hindexed_decl(nesting, dtp, b):
-    yutils.display(OUTFILE, "int count%d = %s->u.hindexed.count;\n" % (nesting, dtp))
-    yutils.display(OUTFILE, "int *restrict array_of_blocklengths%d = %s->u.hindexed.array_of_blocklengths;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t count%d = %s->u.hindexed.count;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t *restrict array_of_blocklengths%d = %s->u.hindexed.array_of_blocklengths;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "intptr_t *restrict array_of_displs%d = %s->u.hindexed.array_of_displs;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "uintptr_t extent%d ATTRIBUTE((unused)) = %s->extent;\n" % (nesting, dtp))
 
 def hindexed(suffix, b, blklen, last):
     global num_paren_open
     num_paren_open += 2
-    yutils.display(OUTFILE, "for (int j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
-    yutils.display(OUTFILE, "for (int k%d = 0; k%d < array_of_blocklengths%d[j%d]; k%d++) {\n" % \
+    yutils.display(OUTFILE, "for (intptr_t j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
+    yutils.display(OUTFILE, "for (intptr_t k%d = 0; k%d < array_of_blocklengths%d[j%d]; k%d++) {\n" % \
             (suffix, suffix, suffix, suffix, suffix))
     global s
     if (last != 1):
@@ -94,14 +94,14 @@ def hindexed(suffix, b, blklen, last):
 
 ## contig routines
 def contig_decl(nesting, dtp, b):
-    yutils.display(OUTFILE, "int count%d = %s->u.contig.count;\n" % (nesting, dtp))
+    yutils.display(OUTFILE, "intptr_t count%d = %s->u.contig.count;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "intptr_t stride%d = %s->u.contig.child->extent;\n" % (nesting, dtp))
     yutils.display(OUTFILE, "uintptr_t extent%d ATTRIBUTE((unused)) = %s->extent;\n" % (nesting, dtp))
 
 def contig(suffix, b, blklen, last):
     global num_paren_open
     num_paren_open += 1
-    yutils.display(OUTFILE, "for (int j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
+    yutils.display(OUTFILE, "for (intptr_t j%d = 0; j%d < count%d; j%d++) {\n" % (suffix, suffix, suffix, suffix))
     global s
     s += " + j%d * stride%d" % (suffix, suffix)
 
@@ -162,7 +162,7 @@ def generate_kernels(b, darray, blklen):
             yutils.display(OUTFILE, "case YAKSA_OP__%s:\n" % op)
             yutils.display(OUTFILE, "{\n")
 
-            yutils.display(OUTFILE, "for (int i = 0; i < count; i++) {\n")
+            yutils.display(OUTFILE, "for (intptr_t i = 0; i < count; i++) {\n")
             num_paren_open += 1
             s = "i * extent"
             for x in range(len(darray)):

--- a/src/backend/ze/genpup.py
+++ b/src/backend/ze/genpup.py
@@ -170,7 +170,7 @@ def generate_kernels(b, darray, op):
                 yutils.display(OUTFILE, "inner_elements /= %s->u.%s.blocklength;\n" % (md, d))
             elif (d == "hindexed"):
                 yutils.display(OUTFILE, "uintptr_t x%d;\n" % idx)
-                yutils.display(OUTFILE, "for (int i = 0; i < %s->u.%s.count; i++) {\n" % (md, d))
+                yutils.display(OUTFILE, "for (intptr_t i = 0; i < %s->u.%s.count; i++) {\n" % (md, d))
                 yutils.display(OUTFILE, "    uintptr_t in_elems = %s->u.%s.array_of_blocklengths[i] *\n" % (md, d))
                 yutils.display(OUTFILE, "                         %s->u.%s.child->num_elements;\n" % (md, d))
                 yutils.display(OUTFILE, "    if (res < in_elems) {\n")

--- a/src/backend/ze/include/yaksuri_zei_md.h
+++ b/src/backend/ze/include/yaksuri_zei_md.h
@@ -9,7 +9,7 @@
 typedef struct yaksuri_zei_md_s {
     union {
         struct {
-            int count;
+            long count;
             long stride;
             struct yaksuri_zei_md_s *child;
         } contig;
@@ -20,20 +20,20 @@ typedef struct yaksuri_zei_md_s {
             struct yaksuri_zei_md_s *child;
         } resized;
         struct {
-            int count;
-            int blocklength;
+            long count;
+            long blocklength;
             long stride;
             struct yaksuri_zei_md_s *child;
         } hvector;
         struct {
-            int count;
-            int blocklength;
+            long count;
+            long blocklength;
             long *array_of_displs;
             struct yaksuri_zei_md_s *child;
         } blkhindx;
         struct {
-            int count;
-            int *array_of_blocklengths;
+            long count;
+            long *array_of_blocklengths;
             long *array_of_displs;
             struct yaksuri_zei_md_s *child;
         } hindexed;

--- a/src/backend/ze/md/yaksuri_zei_md.c
+++ b/src/backend/ze/md/yaksuri_zei_md.c
@@ -147,18 +147,19 @@ int yaksuri_zei_md_alloc(yaksi_type_s * type, int dev_id)
 
 #if ZE_MD_HOST
             zerr = zeMemAllocHost(yaksuri_zei_global.context, &host_desc,
-                                  type->u.hindexed.count * sizeof(int), 1,
+                                  type->u.hindexed.count * sizeof(intptr_t), 1,
                                   (void **) &md->u.hindexed.array_of_blocklengths);
 #else
             zerr = zeMemAllocShared(yaksuri_zei_global.context, &device_desc, &host_desc,
-                                    type->u.hindexed.count * sizeof(int), 1,
+                                    type->u.hindexed.count * sizeof(intptr_t), 1,
                                     yaksuri_zei_global.device[dev_id],
                                     (void **) &md->u.hindexed.array_of_blocklengths);
 #endif
             YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
 
             memcpy(md->u.hindexed.array_of_blocklengths,
-                   type->u.hindexed.array_of_blocklengths, type->u.hindexed.count * sizeof(int));
+                   type->u.hindexed.array_of_blocklengths,
+                   type->u.hindexed.count * sizeof(intptr_t));
 
             rc = yaksuri_zei_md_alloc(type->u.hindexed.child, dev_id);
             YAKSU_ERR_CHECK(rc, fn_fail);
@@ -246,7 +247,7 @@ int yaksuri_zei_type_make_resident(yaksi_type_s * type, int dev_id)
         zerr =
             zeContextMakeMemoryResident(yaksuri_zei_global.context, device,
                                         md->u.hindexed.array_of_blocklengths,
-                                        md->u.hindexed.count * sizeof(int));
+                                        md->u.hindexed.count * sizeof(intptr_t));
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
         if (md->u.hindexed.child) {
             zerr =
@@ -319,7 +320,7 @@ int yaksuri_zei_type_evict_resident(yaksi_type_s * type, int dev_id)
         zerr =
             zeContextEvictMemory(yaksuri_zei_global.context, device,
                                  md->u.hindexed.array_of_blocklengths,
-                                 md->u.hindexed.count * sizeof(int));
+                                 md->u.hindexed.count * sizeof(intptr_t));
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
         assert(md->u.hindexed.child);
         zerr =

--- a/src/frontend/flatten/yaksa_flatten.c
+++ b/src/frontend/flatten/yaksa_flatten.c
@@ -64,13 +64,14 @@ static int flatten(yaksi_type_s * type, void *flattened_type)
             break;
 
         case YAKSI_TYPE_KIND__STRUCT:
-            memcpy(flatbuf, type->u.str.array_of_blocklengths, type->u.str.count * sizeof(int));
-            flatbuf += type->u.str.count * sizeof(int);
+            memcpy(flatbuf, type->u.str.array_of_blocklengths,
+                   type->u.str.count * sizeof(intptr_t));
+            flatbuf += type->u.str.count * sizeof(intptr_t);
 
             memcpy(flatbuf, type->u.str.array_of_displs, type->u.str.count * sizeof(intptr_t));
             flatbuf += type->u.str.count * sizeof(intptr_t);
 
-            for (int i = 0; i < type->u.str.count; i++) {
+            for (intptr_t i = 0; i < type->u.str.count; i++) {
                 rc = flatten(type->u.str.array_of_types[i], flatbuf);
                 YAKSU_ERR_CHECK(rc, fn_fail);
 

--- a/src/frontend/flatten/yaksa_flatten.c
+++ b/src/frontend/flatten/yaksa_flatten.c
@@ -52,8 +52,8 @@ static int flatten(yaksi_type_s * type, void *flattened_type)
 
         case YAKSI_TYPE_KIND__HINDEXED:
             memcpy(flatbuf, type->u.hindexed.array_of_blocklengths,
-                   type->u.hindexed.count * sizeof(int));
-            flatbuf += type->u.hindexed.count * sizeof(int);
+                   type->u.hindexed.count * sizeof(intptr_t));
+            flatbuf += type->u.hindexed.count * sizeof(intptr_t);
 
             memcpy(flatbuf, type->u.hindexed.array_of_displs,
                    type->u.hindexed.count * sizeof(intptr_t));

--- a/src/frontend/flatten/yaksa_flatten_size.c
+++ b/src/frontend/flatten/yaksa_flatten_size.c
@@ -53,7 +53,7 @@ int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size)
 
         case YAKSI_TYPE_KIND__HINDEXED:
             /* add space for array_of_blocklengths */
-            *flattened_type_size += type->u.hindexed.count * sizeof(int);
+            *flattened_type_size += type->u.hindexed.count * sizeof(intptr_t);
             /* add space for array_of_displs */
             *flattened_type_size += type->u.hindexed.count * sizeof(intptr_t);
 

--- a/src/frontend/flatten/yaksa_flatten_size.c
+++ b/src/frontend/flatten/yaksa_flatten_size.c
@@ -64,7 +64,7 @@ int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size)
 
         case YAKSI_TYPE_KIND__STRUCT:
             /* add space for array_of_blocklengths */
-            *flattened_type_size += type->u.str.count * sizeof(int);
+            *flattened_type_size += type->u.str.count * sizeof(intptr_t);
             /* add space for array_of_displs */
             *flattened_type_size += type->u.str.count * sizeof(intptr_t);
 

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -67,10 +67,10 @@ static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
 
         case YAKSI_TYPE_KIND__HINDEXED:
             newtype->u.hindexed.array_of_blocklengths =
-                (int *) malloc(newtype->u.hindexed.count * sizeof(int));
+                (intptr_t *) malloc(newtype->u.hindexed.count * sizeof(intptr_t));
             memcpy(newtype->u.hindexed.array_of_blocklengths, flatbuf,
-                   newtype->u.hindexed.count * sizeof(int));
-            flatbuf += newtype->u.hindexed.count * sizeof(int);
+                   newtype->u.hindexed.count * sizeof(intptr_t));
+            flatbuf += newtype->u.hindexed.count * sizeof(intptr_t);
 
             newtype->u.hindexed.array_of_displs =
                 (intptr_t *) malloc(newtype->u.hindexed.count * sizeof(intptr_t));

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -84,10 +84,10 @@ static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
 
         case YAKSI_TYPE_KIND__STRUCT:
             newtype->u.str.array_of_blocklengths =
-                (int *) malloc(newtype->u.str.count * sizeof(int));
+                (intptr_t *) malloc(newtype->u.str.count * sizeof(intptr_t));
             memcpy(newtype->u.str.array_of_blocklengths, flatbuf,
-                   newtype->u.str.count * sizeof(int));
-            flatbuf += newtype->u.str.count * sizeof(int);
+                   newtype->u.str.count * sizeof(intptr_t));
+            flatbuf += newtype->u.str.count * sizeof(intptr_t);
 
             newtype->u.str.array_of_displs =
                 (intptr_t *) malloc(newtype->u.str.count * sizeof(intptr_t));

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -263,6 +263,8 @@ int yaksa_finalize(void);
  */
 int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
                              yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hvector layout
@@ -277,6 +279,8 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
  */
 int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
                               yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
+                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a contig layout

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -404,6 +404,10 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                              const intptr_t * array_of_displacements,
                              const yaksa_type_t * array_of_types, yaksa_info_t info,
                              yaksa_type_t * newtype);
+int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                               const intptr_t * array_of_displacements,
+                               const yaksa_type_t * array_of_types, yaksa_info_t info,
+                               yaksa_type_t * newtype);
 
 /*!
  * \brief creates a subarray layout

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -355,6 +355,9 @@ int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
 int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                               const int *array_of_displacements, yaksa_type_t oldtype,
                               yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_indexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                                const intptr_t * array_of_displacements, yaksa_type_t oldtype,
+                                yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hindexed layout
@@ -370,6 +373,9 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
 int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksa_type_t oldtype,
                                yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_hindexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                                 const intptr_t * array_of_displacements, yaksa_type_t oldtype,
+                                 yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a resized layout with updated lower and extent

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -318,6 +318,9 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t 
 int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
                                     yaksa_type_t oldtype, yaksa_info_t info,
                                     yaksa_type_t * newtype);
+int yaksa_type_create_indexed_block_x(intptr_t count, intptr_t blocklength,
+                                      const intptr_t * array_of_displacements, yaksa_type_t oldtype,
+                                      yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a block-hindexed layout
@@ -333,6 +336,10 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
 int yaksa_type_create_hindexed_block(int count, int blocklength,
                                      const intptr_t * array_of_displacements, yaksa_type_t oldtype,
                                      yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
+                                       const intptr_t * array_of_displacements,
+                                       yaksa_type_t oldtype, yaksa_info_t info,
+                                       yaksa_type_t * newtype);
 
 /*!
  * \brief creates a indexed layout

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -288,6 +288,8 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
  */
 int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
                              yaksa_type_t * newtype);
+int yaksa_type_create_contig_x(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
+                               yaksa_type_t * newtype);
 
 /*!
  * \brief creates a copy of the oldtype

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -261,10 +261,8 @@ int yaksa_finalize(void);
  * \param[in]  info         Info hint to apply
  * \param[out] newtype      Final generated type
  */
-int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
-                             yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
-                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_vector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                             yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hvector layout
@@ -277,10 +275,8 @@ int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t st
  * \param[in]  info         Info hint to apply
  * \param[out] newtype      Final generated type
  */
-int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
-                              yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
-                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                              yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a contig layout
@@ -290,10 +286,8 @@ int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t s
  * \param[in]  info         Info hint to apply
  * \param[out] newtype      Final generated type
  */
-int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
+int yaksa_type_create_contig(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
                              yaksa_type_t * newtype);
-int yaksa_type_create_contig_x(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
-                               yaksa_type_t * newtype);
 
 /*!
  * \brief creates a copy of the oldtype
@@ -315,12 +309,9 @@ int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t 
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displacements,
-                                    yaksa_type_t oldtype, yaksa_info_t info,
-                                    yaksa_type_t * newtype);
-int yaksa_type_create_indexed_block_x(intptr_t count, intptr_t blocklength,
-                                      const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                                      yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_indexed_block(intptr_t count, intptr_t blocklength,
+                                    const intptr_t * array_of_displacements, yaksa_type_t oldtype,
+                                    yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a block-hindexed layout
@@ -333,13 +324,10 @@ int yaksa_type_create_indexed_block_x(intptr_t count, intptr_t blocklength,
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_hindexed_block(int count, int blocklength,
-                                     const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                                     yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
-                                       const intptr_t * array_of_displacements,
-                                       yaksa_type_t oldtype, yaksa_info_t info,
-                                       yaksa_type_t * newtype);
+int yaksa_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
+                                     const intptr_t * array_of_displacements,
+                                     yaksa_type_t oldtype, yaksa_info_t info,
+                                     yaksa_type_t * newtype);
 
 /*!
  * \brief creates a indexed layout
@@ -352,12 +340,9 @@ int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
-                              const int *array_of_displacements, yaksa_type_t oldtype,
+int yaksa_type_create_indexed(intptr_t count, const intptr_t * array_of_blocklengths,
+                              const intptr_t * array_of_displacements, yaksa_type_t oldtype,
                               yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_indexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                                const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                                yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a hindexed layout
@@ -370,12 +355,9 @@ int yaksa_type_create_indexed_x(intptr_t count, const intptr_t * array_of_blockl
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
+int yaksa_type_create_hindexed(intptr_t count, const intptr_t * array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksa_type_t oldtype,
                                yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_hindexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                                 const intptr_t * array_of_displacements, yaksa_type_t oldtype,
-                                 yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief creates a resized layout with updated lower and extent
@@ -400,14 +382,10 @@ int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, intptr_t extent
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
+int yaksa_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
                              const intptr_t * array_of_displacements,
                              const yaksa_type_t * array_of_types, yaksa_info_t info,
                              yaksa_type_t * newtype);
-int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                               const intptr_t * array_of_displacements,
-                               const yaksa_type_t * array_of_types, yaksa_info_t info,
-                               yaksa_type_t * newtype);
 
 /*!
  * \brief creates a subarray layout
@@ -421,13 +399,10 @@ int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blockle
  * \param[in]  info                   Info hint to apply
  * \param[out] newtype                Final generated type
  */
-int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                               const int *array_of_starts, yaksa_subarray_order_e order,
+int yaksa_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
+                               const intptr_t * array_of_subsizes,
+                               const intptr_t * array_of_starts, yaksa_subarray_order_e order,
                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
-int yaksa_type_create_subarray_x(int ndims, const intptr_t * array_of_sizes,
-                                 const intptr_t * array_of_subsizes,
-                                 const intptr_t * array_of_starts, yaksa_subarray_order_e order,
-                                 yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief gets the size of (number of bytes in) the datatype

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -424,6 +424,10 @@ int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blockle
 int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
                                const int *array_of_starts, yaksa_subarray_order_e order,
                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
+int yaksa_type_create_subarray_x(int ndims, const intptr_t * array_of_sizes,
+                                 const intptr_t * array_of_subsizes,
+                                 const intptr_t * array_of_starts, yaksa_subarray_order_e order,
+                                 yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype);
 
 /*!
  * \brief gets the size of (number of bytes in) the datatype

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -105,8 +105,8 @@ typedef struct yaksi_type_s {
             struct yaksi_type_s *child;
         } hvector;
         struct {
-            int count;
-            int blocklength;
+            intptr_t count;
+            intptr_t blocklength;
             intptr_t *array_of_displs;
             struct yaksi_type_s *child;
         } blkhindx;
@@ -220,7 +220,7 @@ int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksi_type_s * intype,
                                yaksi_type_s ** outtype);
-int yaksi_type_create_hindexed_block(int count, int blocklength,
+int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
                                      const intptr_t * array_of_displacements, yaksi_type_s * intype,
                                      yaksi_type_s ** outtype);
 int yaksi_type_create_resized(yaksi_type_s * intype, intptr_t lb, intptr_t extent,

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -228,9 +228,10 @@ int yaksi_type_create_resized(yaksi_type_s * intype, intptr_t lb, intptr_t exten
 int yaksi_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
                              const intptr_t * array_of_displacements,
                              yaksi_type_s ** array_of_intypes, yaksi_type_s ** outtype);
-int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                               const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksi_type_s * intype, yaksi_type_s ** outtype);
+int yaksi_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
+                               const intptr_t * array_of_subsizes, const intptr_t * array_of_starts,
+                               yaksa_subarray_order_e order, yaksi_type_s * intype,
+                               yaksi_type_s ** outtype);
 int yaksi_type_free(yaksi_type_s * type);
 
 int yaksi_ipack(const void *inbuf, uintptr_t incount, yaksi_type_s * type, uintptr_t inoffset,

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -126,7 +126,7 @@ typedef struct yaksi_type_s {
             struct yaksi_type_s *child;
         } resized;
         struct {
-            int count;
+            intptr_t count;
             struct yaksi_type_s *child;
         } contig;
         struct {
@@ -215,7 +215,7 @@ typedef struct {
 /* function declarations come at the very end */
 int yaksi_type_create_hvector(int count, int blocklength, intptr_t stride, yaksi_type_s * intype,
                               yaksi_type_s ** outtype);
-int yaksi_type_create_contig(int count, yaksi_type_s * intype, yaksi_type_s ** outtype);
+int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksi_type_s * intype,

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -99,8 +99,8 @@ typedef struct yaksi_type_s {
 
     union {
         struct {
-            int count;
-            int blocklength;
+            intptr_t count;
+            intptr_t blocklength;
             intptr_t stride;
             struct yaksi_type_s *child;
         } hvector;
@@ -213,8 +213,8 @@ typedef struct {
 
 
 /* function declarations come at the very end */
-int yaksi_type_create_hvector(int count, int blocklength, intptr_t stride, yaksi_type_s * intype,
-                              yaksi_type_s ** outtype);
+int yaksi_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                              yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -111,8 +111,8 @@ typedef struct yaksi_type_s {
             struct yaksi_type_s *child;
         } blkhindx;
         struct {
-            int count;
-            int *array_of_blocklengths;
+            intptr_t count;
+            intptr_t *array_of_blocklengths;
             intptr_t *array_of_displs;
             struct yaksi_type_s *child;
         } hindexed;
@@ -217,7 +217,7 @@ int yaksi_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t str
                               yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s ** outtype);
 int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** outtype);
-int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
+int yaksi_type_create_hindexed(intptr_t count, const intptr_t * array_of_blocklengths,
                                const intptr_t * array_of_displacements, yaksi_type_s * intype,
                                yaksi_type_s ** outtype);
 int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -117,8 +117,8 @@ typedef struct yaksi_type_s {
             struct yaksi_type_s *child;
         } hindexed;
         struct {
-            int count;
-            int *array_of_blocklengths;
+            intptr_t count;
+            intptr_t *array_of_blocklengths;
             intptr_t *array_of_displs;
             struct yaksi_type_s **array_of_types;
         } str;
@@ -225,7 +225,7 @@ int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
                                      yaksi_type_s ** outtype);
 int yaksi_type_create_resized(yaksi_type_s * intype, intptr_t lb, intptr_t extent,
                               yaksi_type_s ** outtype);
-int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
+int yaksi_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
                              const intptr_t * array_of_displacements,
                              yaksi_type_s ** array_of_intypes, yaksi_type_s ** outtype);
 int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -108,10 +108,10 @@ int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
-                                       const intptr_t * array_of_displs,
-                                       yaksa_type_t oldtype, yaksa_info_t info,
-                                       yaksa_type_t * newtype)
+int yaksa_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
+                                     const intptr_t * array_of_displs,
+                                     yaksa_type_t oldtype, yaksa_info_t info,
+                                     yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -139,56 +139,8 @@ int yaksa_type_create_hindexed_block_x(intptr_t count, intptr_t blocklength,
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed_block(int count, int blocklength, const intptr_t * array_of_displs,
-                                     yaksa_type_t oldtype, yaksa_info_t info,
-                                     yaksa_type_t * newtype)
-{
-    return yaksa_type_create_hindexed_block_x(count, blocklength, array_of_displs, oldtype, info,
-                                              newtype);
-}
-
-int yaksa_type_create_indexed_block_x(intptr_t count, intptr_t blocklength,
-                                      const intptr_t * array_of_displs,
-                                      yaksa_type_t oldtype, yaksa_info_t info,
-                                      yaksa_type_t * newtype)
-{
-    intptr_t *real_array_of_displs = NULL;
-    int rc = YAKSA_SUCCESS;
-
-    assert(yaksu_atomic_load(&yaksi_is_initialized));
-
-    yaksi_type_s *intype;
-    rc = yaksi_type_get(oldtype, &intype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    if (count * intype->size == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-    assert(count > 0);
-
-    real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
-
-    for (intptr_t i = 0; i < count; i++)
-        real_array_of_displs[i] = array_of_displs[i] * intype->extent;
-
-    yaksi_type_s *outtype;
-    rc = yaksi_type_create_hindexed_block(count, blocklength, real_array_of_displs, intype,
-                                          &outtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    rc = yaksi_type_handle_alloc(outtype, newtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-  fn_exit:
-    if (real_array_of_displs)
-        free(real_array_of_displs);
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksa_type_create_indexed_block(int count, int blocklength, const int *array_of_displs,
+int yaksa_type_create_indexed_block(intptr_t count, intptr_t blocklength,
+                                    const intptr_t * array_of_displs,
                                     yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     intptr_t *real_array_of_displs = NULL;
@@ -208,7 +160,7 @@ int yaksa_type_create_indexed_block(int count, int blocklength, const int *array
 
     real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
 
-    for (int i = 0; i < count; i++)
+    for (intptr_t i = 0; i < count; i++)
         real_array_of_displs[i] = array_of_displs[i] * intype->extent;
 
     yaksi_type_s *outtype;

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-int yaksi_type_create_contig(int count, yaksi_type_s * intype, yaksi_type_s ** newtype)
+int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s ** newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -64,8 +64,8 @@ int yaksi_type_create_contig(int count, yaksi_type_s * intype, yaksi_type_s ** n
     goto fn_exit;
 }
 
-int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
-                             yaksa_type_t * newtype)
+int yaksa_type_create_contig_x(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
+                               yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -91,4 +91,10 @@ int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
     return rc;
   fn_fail:
     goto fn_exit;
+}
+
+int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
+                             yaksa_type_t * newtype)
+{
+    return yaksa_type_create_contig_x(count, oldtype, info, newtype);
 }

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -64,8 +64,8 @@ int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s
     goto fn_exit;
 }
 
-int yaksa_type_create_contig_x(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
-                               yaksa_type_t * newtype)
+int yaksa_type_create_contig(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
+                             yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -91,10 +91,4 @@ int yaksa_type_create_contig_x(intptr_t count, yaksa_type_t oldtype, yaksa_info_
     return rc;
   fn_fail:
     goto fn_exit;
-}
-
-int yaksa_type_create_contig(int count, yaksa_type_t oldtype, yaksa_info_t info,
-                             yaksa_type_t * newtype)
-{
-    return yaksa_type_create_contig_x(count, oldtype, info, newtype);
 }

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -138,9 +138,9 @@ int yaksi_type_create_hindexed(intptr_t count, const intptr_t * array_of_blockle
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                                 const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                                 yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_hindexed(intptr_t count, const intptr_t * array_of_blocklengths,
+                               const intptr_t * array_of_displs, yaksa_type_t oldtype,
+                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -174,72 +174,8 @@ int yaksa_type_create_hindexed_x(intptr_t count, const intptr_t * array_of_block
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
-                               const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                               yaksa_info_t info, yaksa_type_t * newtype)
-{
-    int rc = YAKSA_SUCCESS;
-
-    intptr_t *real_array_of_blkl = NULL;
-    real_array_of_blkl = (intptr_t *) malloc(count * sizeof(intptr_t));
-
-    for (int i = 0; i < count; i++)
-        real_array_of_blkl[i] = array_of_blocklengths[i];
-
-    rc = yaksa_type_create_hindexed_x(count, real_array_of_blkl, array_of_displs,
-                                      oldtype, info, newtype);
-    free(real_array_of_blkl);
-
-    return rc;
-}
-
-int yaksa_type_create_indexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                                const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                                yaksa_info_t info, yaksa_type_t * newtype)
-{
-    int rc = YAKSA_SUCCESS;
-    intptr_t *real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
-    intptr_t *real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
-
-    assert(yaksu_atomic_load(&yaksi_is_initialized));
-
-    yaksi_type_s *intype;
-    rc = yaksi_type_get(oldtype, &intype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    uintptr_t total_size;
-    total_size = 0;
-    for (intptr_t i = 0; i < count; i++) {
-        total_size += intype->size * array_of_blocklengths[i];
-    }
-    if (total_size == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
-    for (intptr_t i = 0; i < count; i++) {
-        real_array_of_blocklengths[i] = array_of_blocklengths[i];
-        real_array_of_displs[i] = array_of_displs[i] * intype->extent;
-    }
-
-    yaksi_type_s *outtype;
-    rc = yaksi_type_create_hindexed(count, real_array_of_blocklengths, real_array_of_displs, intype,
-                                    &outtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    rc = yaksi_type_handle_alloc(outtype, newtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-  fn_exit:
-    free(real_array_of_blocklengths);
-    free(real_array_of_displs);
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
-                              const int *array_of_displs, yaksa_type_t oldtype,
+int yaksa_type_create_indexed(intptr_t count, const intptr_t * array_of_blocklengths,
+                              const intptr_t * array_of_displs, yaksa_type_t oldtype,
                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
@@ -254,7 +190,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
 
     uintptr_t total_size;
     total_size = 0;
-    for (int i = 0; i < count; i++) {
+    for (intptr_t i = 0; i < count; i++) {
         total_size += intype->size * array_of_blocklengths[i];
     }
     if (total_size == 0) {
@@ -262,7 +198,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
         goto fn_exit;
     }
 
-    for (int i = 0; i < count; i++) {
+    for (intptr_t i = 0; i < count; i++) {
         real_array_of_blocklengths[i] = array_of_blocklengths[i];
         real_array_of_displs[i] = array_of_displs[i] * intype->extent;
     }

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
+int yaksi_type_create_hindexed(intptr_t count, const intptr_t * array_of_blocklengths,
                                const intptr_t * array_of_displs, yaksi_type_s * intype,
                                yaksi_type_s ** newtype)
 {
@@ -16,7 +16,7 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
 
     /* shortcut for hindexed_block types */
     bool is_hindexed_block = true;
-    for (int i = 1; i < count; i++) {
+    for (intptr_t i = 1; i < count; i++) {
         if (array_of_blocklengths[i] != array_of_blocklengths[i - 1])
             is_hindexed_block = false;
     }
@@ -39,13 +39,13 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
     outtype->tree_depth = intype->tree_depth + 1;
 
     outtype->size = 0;
-    for (int i = 0; i < count; i++)
+    for (intptr_t i = 0; i < count; i++)
         outtype->size += intype->size * array_of_blocklengths[i];
     outtype->alignment = intype->alignment;
 
     int is_set;
     is_set = 0;
-    for (int idx = 0; idx < count; idx++) {
+    for (intptr_t idx = 0; idx < count; idx++) {
         if (array_of_blocklengths[idx] == 0)
             continue;
 
@@ -81,7 +81,7 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
     outtype->extent = outtype->ub - outtype->lb;
 
     outtype->u.hindexed.count = count;
-    outtype->u.hindexed.array_of_blocklengths = (int *) malloc(count * sizeof(intptr_t));
+    outtype->u.hindexed.array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
     outtype->u.hindexed.array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
     for (int i = 0; i < count; i++) {
         outtype->u.hindexed.array_of_blocklengths[i] = array_of_blocklengths[i];
@@ -138,9 +138,9 @@ int yaksi_type_create_hindexed(int count, const int *array_of_blocklengths,
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
-                               const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                               yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_hindexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                                 const intptr_t * array_of_displs, yaksa_type_t oldtype,
+                                 yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -152,7 +152,7 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
 
     uintptr_t total_size;
     total_size = 0;
-    for (int i = 0; i < count; i++) {
+    for (intptr_t i = 0; i < count; i++) {
         total_size += intype->size * array_of_blocklengths[i];
     }
     if (total_size == 0) {
@@ -174,11 +174,76 @@ int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
     goto fn_exit;
 }
 
+int yaksa_type_create_hindexed(int count, const int *array_of_blocklengths,
+                               const intptr_t * array_of_displs, yaksa_type_t oldtype,
+                               yaksa_info_t info, yaksa_type_t * newtype)
+{
+    int rc = YAKSA_SUCCESS;
+
+    intptr_t *real_array_of_blkl = NULL;
+    real_array_of_blkl = (intptr_t *) malloc(count * sizeof(intptr_t));
+
+    for (int i = 0; i < count; i++)
+        real_array_of_blkl[i] = array_of_blocklengths[i];
+
+    rc = yaksa_type_create_hindexed_x(count, real_array_of_blkl, array_of_displs,
+                                      oldtype, info, newtype);
+    free(real_array_of_blkl);
+
+    return rc;
+}
+
+int yaksa_type_create_indexed_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                                const intptr_t * array_of_displs, yaksa_type_t oldtype,
+                                yaksa_info_t info, yaksa_type_t * newtype)
+{
+    int rc = YAKSA_SUCCESS;
+    intptr_t *real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
+    intptr_t *real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    yaksi_type_s *intype;
+    rc = yaksi_type_get(oldtype, &intype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    uintptr_t total_size;
+    total_size = 0;
+    for (intptr_t i = 0; i < count; i++) {
+        total_size += intype->size * array_of_blocklengths[i];
+    }
+    if (total_size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
+
+    for (intptr_t i = 0; i < count; i++) {
+        real_array_of_blocklengths[i] = array_of_blocklengths[i];
+        real_array_of_displs[i] = array_of_displs[i] * intype->extent;
+    }
+
+    yaksi_type_s *outtype;
+    rc = yaksi_type_create_hindexed(count, real_array_of_blocklengths, real_array_of_displs, intype,
+                                    &outtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksi_type_handle_alloc(outtype, newtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    free(real_array_of_blocklengths);
+    free(real_array_of_displs);
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
 int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
                               const int *array_of_displs, yaksa_type_t oldtype,
                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
+    intptr_t *real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
     intptr_t *real_array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
 
     assert(yaksu_atomic_load(&yaksi_is_initialized));
@@ -197,11 +262,13 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
         goto fn_exit;
     }
 
-    for (int i = 0; i < count; i++)
+    for (int i = 0; i < count; i++) {
+        real_array_of_blocklengths[i] = array_of_blocklengths[i];
         real_array_of_displs[i] = array_of_displs[i] * intype->extent;
+    }
 
     yaksi_type_s *outtype;
-    rc = yaksi_type_create_hindexed(count, array_of_blocklengths, real_array_of_displs, intype,
+    rc = yaksi_type_create_hindexed(count, real_array_of_blocklengths, real_array_of_displs, intype,
                                     &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
@@ -209,6 +276,7 @@ int yaksa_type_create_indexed(int count, const int *array_of_blocklengths,
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
+    free(real_array_of_blocklengths);
     free(real_array_of_displs);
     return rc;
   fn_fail:

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -157,10 +157,10 @@ int yaksi_type_create_struct(intptr_t count, const intptr_t * array_of_blockleng
     goto fn_exit;
 }
 
-int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blocklengths,
-                               const intptr_t * array_of_displs,
-                               const yaksa_type_t * array_of_types, yaksa_info_t info,
-                               yaksa_type_t * newtype)
+int yaksa_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
+                             const intptr_t * array_of_displs,
+                             const yaksa_type_t * array_of_types, yaksa_info_t info,
+                             yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -200,57 +200,6 @@ int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blockle
     free(array_of_intypes);
 
   fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
-                             const intptr_t * array_of_displs, const yaksa_type_t * array_of_types,
-                             yaksa_info_t info, yaksa_type_t * newtype)
-{
-    int rc = YAKSA_SUCCESS;
-    intptr_t *real_array_of_blocklengths = NULL;
-    yaksi_type_s **array_of_intypes = NULL;
-
-    assert(yaksu_atomic_load(&yaksi_is_initialized));
-
-    uintptr_t total_size;
-    total_size = 0;
-    for (int i = 0; i < count; i++) {
-        yaksi_type_s *type;
-        rc = yaksi_type_get(array_of_types[i], &type);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        total_size += type->size * array_of_blocklengths[i];
-    }
-    if (total_size == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
-    assert(count > 0);
-
-    real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
-    array_of_intypes = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
-
-    for (int i = 0; i < count; i++) {
-        real_array_of_blocklengths[i] = array_of_blocklengths[i];
-        rc = yaksi_type_get(array_of_types[i], &array_of_intypes[i]);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-    }
-
-    yaksi_type_s *outtype;
-    rc = yaksi_type_create_struct(count, real_array_of_blocklengths, array_of_displs,
-                                  array_of_intypes, &outtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    rc = yaksi_type_handle_alloc(outtype, newtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-  fn_exit:
-    free(real_array_of_blocklengths);
-    free(array_of_intypes);
     return rc;
   fn_fail:
     goto fn_exit;

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
-int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
+int yaksi_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
                              const intptr_t * array_of_displs, yaksi_type_s ** array_of_intypes,
                              yaksi_type_s ** newtype)
 {
@@ -16,7 +16,7 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
 
     /* shortcut for hindexed types */
     bool is_hindexed = true;
-    for (int i = 1; i < count; i++) {
+    for (intptr_t i = 1; i < count; i++) {
         if (array_of_intypes[i] != array_of_intypes[i - 1])
             is_hindexed = false;
     }
@@ -36,7 +36,7 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     outtype->kind = YAKSI_TYPE_KIND__STRUCT;
 
     outtype->size = 0;
-    for (int i = 0; i < count; i++) {
+    for (intptr_t i = 0; i < count; i++) {
         outtype->size += array_of_intypes[i]->size * array_of_blocklengths[i];
         yaksu_atomic_incr(&array_of_intypes[i]->refcount);
     }
@@ -44,7 +44,7 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     int is_set;
     is_set = 0;
     outtype->alignment = 0;
-    for (int idx = 0; idx < count; idx++) {
+    for (intptr_t idx = 0; idx < count; idx++) {
         if (array_of_blocklengths[idx] == 0)
             continue;
 
@@ -97,17 +97,17 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     if ((outtype->ub - outtype->lb) == outtype->size) {
         outtype->is_contig = true;
 
-        for (int i = 0; i < count; i++) {
+        for (intptr_t i = 0; i < count; i++) {
             if (array_of_intypes[i]->is_contig == false) {
                 outtype->is_contig = false;
                 break;
             }
         }
 
-        int left = 0;
+        intptr_t left = 0;
         while (array_of_blocklengths[left] == 0)
             left++;
-        int right = left + 1;
+        intptr_t right = left + 1;
         while (right < count && array_of_blocklengths[right] == 0)
             right++;
         while (right < count) {
@@ -129,7 +129,7 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
         outtype->num_contig = 1;
     } else {
         outtype->num_contig = 0;
-        for (int i = 0; i < count; i++) {
+        for (intptr_t i = 0; i < count; i++) {
             if (array_of_intypes[i]->is_contig && array_of_blocklengths[i]) {
                 outtype->num_contig++;
             } else {
@@ -139,10 +139,10 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     }
 
     outtype->u.str.count = count;
-    outtype->u.str.array_of_blocklengths = (int *) malloc(count * sizeof(intptr_t));
+    outtype->u.str.array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
     outtype->u.str.array_of_displs = (intptr_t *) malloc(count * sizeof(intptr_t));
     outtype->u.str.array_of_types = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
-    for (int i = 0; i < count; i++) {
+    for (intptr_t i = 0; i < count; i++) {
         outtype->u.str.array_of_blocklengths[i] = array_of_blocklengths[i];
         outtype->u.str.array_of_displs[i] = array_of_displs[i];
         outtype->u.str.array_of_types[i] = array_of_intypes[i];
@@ -157,11 +157,61 @@ int yaksi_type_create_struct(int count, const int *array_of_blocklengths,
     goto fn_exit;
 }
 
+int yaksa_type_create_struct_x(intptr_t count, const intptr_t * array_of_blocklengths,
+                               const intptr_t * array_of_displs,
+                               const yaksa_type_t * array_of_types, yaksa_info_t info,
+                               yaksa_type_t * newtype)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    uintptr_t total_size;
+    total_size = 0;
+    for (intptr_t i = 0; i < count; i++) {
+        yaksi_type_s *type;
+        rc = yaksi_type_get(array_of_types[i], &type);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        total_size += type->size * array_of_blocklengths[i];
+    }
+    if (total_size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
+
+    assert(count > 0);
+    yaksi_type_s **array_of_intypes;
+    array_of_intypes = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
+
+    for (intptr_t i = 0; i < count; i++) {
+        rc = yaksi_type_get(array_of_types[i], &array_of_intypes[i]);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+    yaksi_type_s *outtype;
+    rc = yaksi_type_create_struct(count, array_of_blocklengths, array_of_displs, array_of_intypes,
+                                  &outtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksi_type_handle_alloc(outtype, newtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    free(array_of_intypes);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
 int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
                              const intptr_t * array_of_displs, const yaksa_type_t * array_of_types,
                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
+    intptr_t *real_array_of_blocklengths = NULL;
+    yaksi_type_s **array_of_intypes = NULL;
 
     assert(yaksu_atomic_load(&yaksi_is_initialized));
 
@@ -180,25 +230,27 @@ int yaksa_type_create_struct(int count, const int *array_of_blocklengths,
     }
 
     assert(count > 0);
-    yaksi_type_s **array_of_intypes;
+
+    real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));
     array_of_intypes = (yaksi_type_s **) malloc(count * sizeof(yaksi_type_s *));
 
     for (int i = 0; i < count; i++) {
+        real_array_of_blocklengths[i] = array_of_blocklengths[i];
         rc = yaksi_type_get(array_of_types[i], &array_of_intypes[i]);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
 
     yaksi_type_s *outtype;
-    rc = yaksi_type_create_struct(count, array_of_blocklengths, array_of_displs, array_of_intypes,
-                                  &outtype);
+    rc = yaksi_type_create_struct(count, real_array_of_blocklengths, array_of_displs,
+                                  array_of_intypes, &outtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = yaksi_type_handle_alloc(outtype, newtype);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    free(array_of_intypes);
-
   fn_exit:
+    free(real_array_of_blocklengths);
+    free(array_of_intypes);
     return rc;
   fn_fail:
     goto fn_exit;

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -127,10 +127,10 @@ int yaksi_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
     goto fn_exit;
 }
 
-int yaksa_type_create_subarray_x(int ndims, const intptr_t * array_of_sizes,
-                                 const intptr_t * array_of_subsizes,
-                                 const intptr_t * array_of_starts, yaksa_subarray_order_e order,
-                                 yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
+                               const intptr_t * array_of_subsizes,
+                               const intptr_t * array_of_starts, yaksa_subarray_order_e order,
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -154,49 +154,6 @@ int yaksa_type_create_subarray_x(int ndims, const intptr_t * array_of_sizes,
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
-}
-
-int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                               const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
-{
-    int rc = YAKSA_SUCCESS;
-
-    assert(yaksu_atomic_load(&yaksi_is_initialized));
-
-    intptr_t *real_array_of_sizes = malloc(ndims * sizeof(intptr_t));
-    intptr_t *real_array_of_subsizes = malloc(ndims * sizeof(intptr_t));
-    intptr_t *real_array_of_starts = malloc(ndims * sizeof(intptr_t));
-
-    yaksi_type_s *intype;
-    rc = yaksi_type_get(oldtype, &intype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    if (ndims * intype->size == 0) {
-        *newtype = YAKSA_TYPE__NULL;
-        goto fn_exit;
-    }
-
-    for (int i = 0; i < ndims; i++) {
-        real_array_of_sizes[i] = array_of_sizes[i];
-        real_array_of_subsizes[i] = array_of_subsizes[i];
-        real_array_of_starts[i] = array_of_starts[i];
-    }
-    yaksi_type_s *outtype;
-    rc = yaksi_type_create_subarray(ndims, real_array_of_sizes, real_array_of_subsizes,
-                                    real_array_of_starts, order, intype, &outtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-    rc = yaksi_type_handle_alloc(outtype, newtype);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-  fn_exit:
-    free(real_array_of_sizes);
-    free(real_array_of_subsizes);
-    free(real_array_of_starts);
     return rc;
   fn_fail:
     goto fn_exit;

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -8,9 +8,10 @@
 #include <stdlib.h>
 #include <assert.h>
 
-int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                               const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksi_type_s * intype, yaksi_type_s ** newtype)
+int yaksi_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
+                               const intptr_t * array_of_subsizes, const intptr_t * array_of_starts,
+                               yaksa_subarray_order_e order, yaksi_type_s * intype,
+                               yaksi_type_s ** newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -126,9 +127,10 @@ int yaksi_type_create_subarray(int ndims, const int *array_of_sizes, const int *
     goto fn_exit;
 }
 
-int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
-                               const int *array_of_starts, yaksa_subarray_order_e order,
-                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_subarray_x(int ndims, const intptr_t * array_of_sizes,
+                                 const intptr_t * array_of_subsizes,
+                                 const intptr_t * array_of_starts, yaksa_subarray_order_e order,
+                                 yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -152,6 +154,49 @@ int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+int yaksa_type_create_subarray(int ndims, const int *array_of_sizes, const int *array_of_subsizes,
+                               const int *array_of_starts, yaksa_subarray_order_e order,
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    intptr_t *real_array_of_sizes = malloc(ndims * sizeof(intptr_t));
+    intptr_t *real_array_of_subsizes = malloc(ndims * sizeof(intptr_t));
+    intptr_t *real_array_of_starts = malloc(ndims * sizeof(intptr_t));
+
+    yaksi_type_s *intype;
+    rc = yaksi_type_get(oldtype, &intype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (ndims * intype->size == 0) {
+        *newtype = YAKSA_TYPE__NULL;
+        goto fn_exit;
+    }
+
+    for (int i = 0; i < ndims; i++) {
+        real_array_of_sizes[i] = array_of_sizes[i];
+        real_array_of_subsizes[i] = array_of_subsizes[i];
+        real_array_of_starts[i] = array_of_starts[i];
+    }
+    yaksi_type_s *outtype;
+    rc = yaksi_type_create_subarray(ndims, real_array_of_sizes, real_array_of_subsizes,
+                                    real_array_of_starts, order, intype, &outtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksi_type_handle_alloc(outtype, newtype);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    free(real_array_of_sizes);
+    free(real_array_of_subsizes);
+    free(real_array_of_starts);
     return rc;
   fn_fail:
     goto fn_exit;

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -81,8 +81,8 @@ int yaksi_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t str
     goto fn_exit;
 }
 
-int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
-                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                              yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -110,14 +110,8 @@ int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t s
     goto fn_exit;
 }
 
-int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
-                              yaksa_info_t info, yaksa_type_t * newtype)
-{
-    return yaksa_type_create_hvector_x(count, blocklength, stride, oldtype, info, newtype);
-}
-
-int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
-                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_vector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                             yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -144,10 +138,4 @@ int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t st
     return rc;
   fn_fail:
     goto fn_exit;
-}
-
-int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
-                             yaksa_info_t info, yaksa_type_t * newtype)
-{
-    return yaksa_type_create_vector_x(count, blocklength, stride, oldtype, info, newtype);
 }

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 #include <assert.h>
 
-int yaksi_type_create_hvector(int count, int blocklength, intptr_t stride, yaksi_type_s * intype,
-                              yaksi_type_s ** newtype)
+int yaksi_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                              yaksi_type_s * intype, yaksi_type_s ** newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -81,8 +81,8 @@ int yaksi_type_create_hvector(int count, int blocklength, intptr_t stride, yaksi
     goto fn_exit;
 }
 
-int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
-                              yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_hvector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
+                                yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -110,8 +110,14 @@ int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa
     goto fn_exit;
 }
 
-int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
-                             yaksa_info_t info, yaksa_type_t * newtype)
+int yaksa_type_create_hvector(int count, int blocklength, intptr_t stride, yaksa_type_t oldtype,
+                              yaksa_info_t info, yaksa_type_t * newtype)
+{
+    return yaksa_type_create_hvector_x(count, blocklength, stride, oldtype, info, newtype);
+}
+
+int yaksa_type_create_vector_x(intptr_t count, intptr_t blocklength, intptr_t stride,
+                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -138,4 +144,10 @@ int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_
     return rc;
   fn_fail:
     goto fn_exit;
+}
+
+int yaksa_type_create_vector(int count, int blocklength, int stride, yaksa_type_t oldtype,
+                             yaksa_info_t info, yaksa_type_t * newtype)
+{
+    return yaksa_type_create_vector_x(count, blocklength, stride, oldtype, info, newtype);
 }

--- a/test/dtpools/src/dtpools_attr.c
+++ b/test/dtpools/src/dtpools_attr.c
@@ -259,13 +259,13 @@ static int construct_vector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
         }
         if (!VALUE_FITS_IN_INT(stride))
             goto retry;
-        attr->u.vector.stride = (int) stride;
+        attr->u.vector.stride = (intptr_t) stride;
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.vector.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.vector.numblks; i++) {
             if (max_displ_idx == -1)
                 max_displ_idx = i;
             else if (attr->u.vector.stride > 0)
@@ -377,9 +377,9 @@ static int construct_hvector(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.hvector.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.hvector.numblks; i++) {
             if (max_displ_idx == -1)
                 max_displ_idx = i;
             else if (attr->u.hvector.stride > 0)
@@ -473,44 +473,44 @@ static int construct_blkindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
         count /= attr->u.blkindx.blklen;
 
-        DTPI_ALLOC_OR_FAIL(attr->u.blkindx.array_of_displs, attr->u.blkindx.numblks * sizeof(int),
-                           rc);
+        DTPI_ALLOC_OR_FAIL(attr->u.blkindx.array_of_displs,
+                           attr->u.blkindx.numblks * sizeof(intptr_t), rc);
 
         uint64_t total_displ = 0;
         int displs_attr = DTPI_rand(dtpi) % DTPI_ATTR_BLKINDX_DISPLS__LAST;
         if (displs_attr == DTPI_ATTR_BLKINDX_DISPLS__SMALL) {
-            for (int i = 0; i < attr->u.blkindx.numblks; i++) {
-                attr->u.blkindx.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
+                attr->u.blkindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.blkindx.blklen + 1;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKINDX_DISPLS__LARGE) {
-            for (int i = 0; i < attr->u.blkindx.numblks; i++) {
-                attr->u.blkindx.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
+                attr->u.blkindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.blkindx.blklen * 4;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKINDX_DISPLS__REDUCING) {
-            for (int i = 0; i < attr->u.blkindx.numblks; i++) {
-                int idx = attr->u.blkindx.numblks - i - 1;
-                attr->u.blkindx.array_of_displs[idx] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
+                intptr_t idx = attr->u.blkindx.numblks - i - 1;
+                attr->u.blkindx.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->u.blkindx.blklen + 1;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKINDX_DISPLS__REVERSE) {
-            for (int i = 0; i < attr->u.blkindx.numblks; i++) {
-                int idx = attr->u.blkindx.numblks - i - 1;
-                attr->u.blkindx.array_of_displs[idx] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
+                intptr_t idx = attr->u.blkindx.numblks - i - 1;
+                attr->u.blkindx.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->u.blkindx.blklen;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKINDX_DISPLS__UNEVEN) {
-            for (int i = 0; i < attr->u.blkindx.numblks; i++) {
-                attr->u.blkindx.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
+                attr->u.blkindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.blkindx.blklen + i;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
@@ -521,9 +521,9 @@ static int construct_blkindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.blkindx.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
             if (max_displ_idx == -1)
                 max_displ_idx = i;
             else if (attr->u.blkindx.array_of_displs[i] >
@@ -626,37 +626,37 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
         uint64_t total_displ = 8;
         int displs_attr = DTPI_rand(dtpi) % DTPI_ATTR_BLKHINDX_DISPLS__LAST;
         if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__SMALL) {
-            for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + 1) * attr->child_type_extent;
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__LARGE) {
-            for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen * 4) * attr->child_type_extent;
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__REDUCING) {
-            for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
-                int idx = attr->u.blkhindx.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
+                intptr_t idx = attr->u.blkhindx.numblks - i - 1;
                 attr->u.blkhindx.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + 1) * attr->child_type_extent;
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__REVERSE) {
-            for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
-                int idx = attr->u.blkhindx.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
+                intptr_t idx = attr->u.blkhindx.numblks - i - 1;
                 attr->u.blkhindx.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->u.blkhindx.blklen * attr->child_type_extent;
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_BLKHINDX_DISPLS__UNEVEN) {
-            for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
                 attr->u.blkhindx.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += (attr->u.blkhindx.blklen + i) * attr->child_type_extent;
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
@@ -668,9 +668,9 @@ static int construct_blkhindx(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
             if (max_displ_idx == -1)
                 max_displ_idx = i;
             else if (attr->u.blkhindx.array_of_displs[i] >
@@ -756,28 +756,28 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
         count /= attr->u.indexed.numblks;
 
-        DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_blklens, attr->u.indexed.numblks * sizeof(int),
-                           rc);
+        DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_blklens,
+                           attr->u.indexed.numblks * sizeof(intptr_t), rc);
 
-        int total_blklen = 0;
-        int blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_INDEXED_BLKLEN__LAST;
+        intptr_t total_blklen = 0;
+        intptr_t blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_INDEXED_BLKLEN__LAST;
         if (blklen_attr == DTPI_ATTR_INDEXED_BLKLEN__ONE) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
                 attr->u.indexed.array_of_blklens[i] = 1;
                 total_blklen += attr->u.indexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_INDEXED_BLKLEN__SMALL) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
                 attr->u.indexed.array_of_blklens[i] = DTPI_low_count(count);
                 total_blklen += attr->u.indexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_INDEXED_BLKLEN__LARGE) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
                 attr->u.indexed.array_of_blklens[i] = DTPI_high_count(count);
                 total_blklen += attr->u.indexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_INDEXED_BLKLEN__UNEVEN) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
                 if (i % 2 == 0)
                     attr->u.indexed.array_of_blklens[i] = DTPI_low_count(count) + 1;
                 else
@@ -786,7 +786,7 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
             }
             if (attr->u.indexed.numblks % 2) {
                 /* if we have an odd number of blocks, adjust the counts */
-                int idx = attr->u.indexed.numblks - 1;
+                intptr_t idx = attr->u.indexed.numblks - 1;
                 attr->u.indexed.array_of_blklens[idx]--;
                 total_blklen--;
             }
@@ -797,44 +797,44 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
         count *= attr->u.indexed.numblks;
         count /= total_blklen;
 
-        DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_displs, attr->u.indexed.numblks * sizeof(int),
-                           rc);
+        DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_displs,
+                           attr->u.indexed.numblks * sizeof(intptr_t), rc);
 
         uint64_t total_displ = 0;
         int displs_attr = DTPI_rand(dtpi) % DTPI_ATTR_INDEXED_DISPLS__LAST;
         if (displs_attr == DTPI_ATTR_INDEXED_DISPLS__SMALL) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
-                attr->u.indexed.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
+                attr->u.indexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.indexed.array_of_blklens[i] + 1;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_INDEXED_DISPLS__LARGE) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
-                attr->u.indexed.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
+                attr->u.indexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.indexed.array_of_blklens[i] * 4;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_INDEXED_DISPLS__REDUCING) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
-                int idx = attr->u.indexed.numblks - i - 1;
-                attr->u.indexed.array_of_displs[idx] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
+                intptr_t idx = attr->u.indexed.numblks - i - 1;
+                attr->u.indexed.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->u.indexed.array_of_blklens[idx] + 1;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_INDEXED_DISPLS__REVERSE) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
-                int idx = attr->u.indexed.numblks - i - 1;
-                attr->u.indexed.array_of_displs[idx] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
+                intptr_t idx = attr->u.indexed.numblks - i - 1;
+                attr->u.indexed.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->u.indexed.array_of_blklens[idx];
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_INDEXED_DISPLS__UNEVEN) {
-            for (int i = 0; i < attr->u.indexed.numblks; i++) {
-                attr->u.indexed.array_of_displs[i] = (int) total_displ;
+            for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
+                attr->u.indexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->u.indexed.array_of_blklens[i] + i;
                 if (!VALUE_FITS_IN_INT(total_displ))
                     goto retry;
@@ -845,9 +845,9 @@ static int construct_indexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * 
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
             if (attr->u.indexed.array_of_blklens[i]) {
                 if (max_displ_idx == -1)
                     max_displ_idx = i;
@@ -936,27 +936,27 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
         count /= attr->u.hindexed.numblks;
 
         DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_blklens,
-                           attr->u.hindexed.numblks * sizeof(int), rc);
+                           attr->u.hindexed.numblks * sizeof(intptr_t), rc);
 
-        int total_blklen = 0;
-        int blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_HINDEXED_BLKLEN__LAST;
+        intptr_t total_blklen = 0;
+        intptr_t blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_HINDEXED_BLKLEN__LAST;
         if (blklen_attr == DTPI_ATTR_HINDEXED_BLKLEN__ONE) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_blklens[i] = 1;
                 total_blklen += attr->u.hindexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_HINDEXED_BLKLEN__SMALL) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_blklens[i] = DTPI_low_count(count);
                 total_blklen += attr->u.hindexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_HINDEXED_BLKLEN__LARGE) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_blklens[i] = DTPI_high_count(count);
                 total_blklen += attr->u.hindexed.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_HINDEXED_BLKLEN__UNEVEN) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 if (i % 2 == 0)
                     attr->u.hindexed.array_of_blklens[i] = DTPI_low_count(count) + 1;
                 else
@@ -965,7 +965,7 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
             }
             if (attr->u.hindexed.numblks % 2) {
                 /* if we have an odd number of blocks, adjust the counts */
-                int idx = attr->u.hindexed.numblks - 1;
+                intptr_t idx = attr->u.hindexed.numblks - 1;
                 attr->u.hindexed.array_of_blklens[idx]--;
                 total_blklen--;
             }
@@ -985,22 +985,22 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
         uint64_t total_displ = 8;
         int displs_attr = DTPI_rand(dtpi) % DTPI_ATTR_HINDEXED_DISPLS__LAST;
         if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__SMALL) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] + 1);
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__LARGE) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] * 4);
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__REDUCING) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
-                int idx = attr->u.hindexed.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
+                intptr_t idx = attr->u.hindexed.numblks - i - 1;
                 attr->u.hindexed.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.hindexed.array_of_blklens[idx] + 1);
@@ -1008,15 +1008,15 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__REVERSE) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
-                int idx = attr->u.hindexed.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
+                intptr_t idx = attr->u.hindexed.numblks - i - 1;
                 attr->u.hindexed.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * attr->u.hindexed.array_of_blklens[idx];
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_HINDEXED_DISPLS__UNEVEN) {
-            for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                 attr->u.hindexed.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * (attr->u.hindexed.array_of_blklens[i] + i);
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
@@ -1028,9 +1028,9 @@ static int construct_hindexed(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
             if (attr->u.hindexed.array_of_blklens[i]) {
                 if (max_displ_idx == -1)
                     max_displ_idx = i;
@@ -1100,10 +1100,12 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
         DTPI_ERR_ASSERT(0, rc);
     }
 
-    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_sizes, attr->u.subarray.ndims * sizeof(int), rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_sizes, attr->u.subarray.ndims * sizeof(intptr_t),
+                       rc);
     DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_subsizes,
-                       attr->u.subarray.ndims * sizeof(int), rc);
-    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_starts, attr->u.subarray.ndims * sizeof(int), rc);
+                       attr->u.subarray.ndims * sizeof(intptr_t), rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_starts, attr->u.subarray.ndims * sizeof(intptr_t),
+                       rc);
 
     uintptr_t tmp_count = count;
     while (1) {
@@ -1115,17 +1117,17 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
         int subsizes_attr = DTPI_rand(dtpi) % DTPI_ATTR_SUBARRAY_SUBSIZES__LAST;
         if (subsizes_attr == DTPI_ATTR_SUBARRAY_SUBSIZES__ONE) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_subsizes[i] = 1;
                 count /= attr->u.subarray.array_of_subsizes[i];
             }
         } else if (subsizes_attr == DTPI_ATTR_SUBARRAY_SUBSIZES__SMALL) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_subsizes[i] = DTPI_low_count(count);
                 count /= attr->u.subarray.array_of_subsizes[i];
             }
         } else if (subsizes_attr == DTPI_ATTR_SUBARRAY_SUBSIZES__LARGE) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_subsizes[i] = DTPI_high_count(count);
                 count /= attr->u.subarray.array_of_subsizes[i];
             }
@@ -1135,19 +1137,19 @@ static int construct_subarray(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s *
 
         int sizes_attr = DTPI_rand(dtpi) % DTPI_ATTR_SUBARRAY_SIZES__LAST;
         if (sizes_attr == DTPI_ATTR_SUBARRAY_SIZES__ONE) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_sizes[i] = attr->u.subarray.array_of_subsizes[i];
                 attr->u.subarray.array_of_starts[i] = 0;
                 extent *= attr->u.subarray.array_of_sizes[i];
             }
         } else if (sizes_attr == DTPI_ATTR_SUBARRAY_SIZES__SMALL) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_sizes[i] = attr->u.subarray.array_of_subsizes[i] + 1;
                 attr->u.subarray.array_of_starts[i] = 1;
                 extent *= attr->u.subarray.array_of_sizes[i];
             }
         } else if (sizes_attr == DTPI_ATTR_SUBARRAY_SIZES__LARGE) {
-            for (int i = 0; i < attr->u.subarray.ndims; i++) {
+            for (intptr_t i = 0; i < attr->u.subarray.ndims; i++) {
                 attr->u.subarray.array_of_sizes[i] = attr->u.subarray.array_of_subsizes[i] * 4;
                 attr->u.subarray.array_of_starts[i] = attr->u.subarray.array_of_subsizes[i];
                 extent *= attr->u.subarray.array_of_sizes[i];
@@ -1236,27 +1238,27 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
         count /= attr->u.structure.numblks;
 
         DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_blklens,
-                           attr->u.structure.numblks * sizeof(int), rc);
+                           attr->u.structure.numblks * sizeof(intptr_t), rc);
 
-        int total_blklen = 0;
-        int blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_STRUCTURE_BLKLEN__LAST;
+        intptr_t total_blklen = 0;
+        intptr_t blklen_attr = DTPI_rand(dtpi) % DTPI_ATTR_STRUCTURE_BLKLEN__LAST;
         if (blklen_attr == DTPI_ATTR_STRUCTURE_BLKLEN__ONE) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_blklens[i] = 1;
                 total_blklen += attr->u.structure.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_STRUCTURE_BLKLEN__SMALL) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_blklens[i] = DTPI_low_count(count);
                 total_blklen += attr->u.structure.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_STRUCTURE_BLKLEN__LARGE) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_blklens[i] = DTPI_high_count(count);
                 total_blklen += attr->u.structure.array_of_blklens[i];
             }
         } else if (blklen_attr == DTPI_ATTR_STRUCTURE_BLKLEN__UNEVEN) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 if (i % 2 == 0)
                     attr->u.structure.array_of_blklens[i] = DTPI_low_count(count) + 1;
                 else
@@ -1265,7 +1267,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
             }
             if (attr->u.structure.numblks % 2) {
                 /* if we have an odd number of blocks, adjust the counts */
-                int idx = attr->u.structure.numblks - 1;
+                intptr_t idx = attr->u.structure.numblks - 1;
                 attr->u.structure.array_of_blklens[idx]--;
                 total_blklen--;
             }
@@ -1285,7 +1287,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
         uint64_t total_displ = 8;
         int displs_attr = DTPI_rand(dtpi) % DTPI_ATTR_STRUCTURE_DISPLS__LAST;
         if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__SMALL) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] + 1);
@@ -1293,7 +1295,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__LARGE) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] * 4);
@@ -1301,8 +1303,8 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__REDUCING) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
-                int idx = attr->u.structure.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
+                intptr_t idx = attr->u.structure.numblks - i - 1;
                 attr->u.structure.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[idx] + 1);
@@ -1310,15 +1312,15 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__REVERSE) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
-                int idx = attr->u.structure.numblks - i - 1;
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
+                intptr_t idx = attr->u.structure.numblks - i - 1;
                 attr->u.structure.array_of_displs[idx] = (intptr_t) total_displ;
                 total_displ += attr->child_type_extent * attr->u.structure.array_of_blklens[idx];
                 if (!VALUE_FITS_IN_INTPTR_T(total_displ))
                     goto retry;
             }
         } else if (displs_attr == DTPI_ATTR_STRUCTURE_DISPLS__UNEVEN) {
-            for (int i = 0; i < attr->u.structure.numblks; i++) {
+            for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                 attr->u.structure.array_of_displs[i] = (intptr_t) total_displ;
                 total_displ +=
                     attr->child_type_extent * (attr->u.structure.array_of_blklens[i] + i);
@@ -1331,9 +1333,9 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
 
         /* calculate the extent for our datatype, to decide whether we
          * want to use this or try again */
-        int max_displ_idx = -1;
-        int min_displ_idx = -1;
-        for (int i = 0; i < attr->u.structure.numblks; i++) {
+        intptr_t max_displ_idx = -1;
+        intptr_t min_displ_idx = -1;
+        for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
             if (attr->u.structure.array_of_blklens[i]) {
                 if (max_displ_idx == -1)
                     max_displ_idx = i;
@@ -1362,7 +1364,7 @@ static int construct_struct(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s * a
         yaksa_type_t *array_of_types;
 
         DTPI_ALLOC_OR_FAIL(array_of_types, attr->u.structure.numblks * sizeof(yaksa_type_t), rc);
-        for (int i = 0; i < attr->u.structure.numblks; i++)
+        for (intptr_t i = 0; i < attr->u.structure.numblks; i++)
             array_of_types[i] = type;
 
         rc = yaksa_type_create_struct(attr->u.structure.numblks,

--- a/test/dtpools/src/dtpools_init_verify.c
+++ b/test/dtpools/src/dtpools_init_verify.c
@@ -299,7 +299,7 @@ static int init_verify_base_type(DTP_pool_s dtp, DTP_obj_s obj, void *buf_,
     DTPI_FUNC_ENTER();
 
     if (dtpi->base_type_is_struct) {
-        for (int i = 0; i < dtpi->base_type_attrs.numblks; i++) {
+        for (intptr_t i = 0; i < dtpi->base_type_attrs.numblks; i++) {
             intptr_t offset = dtpi->base_type_attrs.array_of_displs[i];
             for (int j = 0; j < dtpi->base_type_attrs.array_of_blklens[i]; j++) {
                 rc = init_verify_basic_datatype(dtpi->base_type_attrs.array_of_types[i],
@@ -353,7 +353,7 @@ static int init_verify_subarray(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_A
         base_offset *= attr->child_type_extent;
 
         uintptr_t offset = buf_offset + base_offset * attr->u.subarray.array_of_starts[dims_offset];
-        for (int i = 0; i < attr->u.subarray.array_of_subsizes[dims_offset]; i++) {
+        for (intptr_t i = 0; i < attr->u.subarray.array_of_subsizes[dims_offset]; i++) {
             rc = init_verify_subarray(dtp, obj, buf, attr, ndims - 1, offset, val_start,
                                       val_stride, rem_val_count, verify);
             DTPI_ERR_CHK_RC(rc);
@@ -366,7 +366,7 @@ static int init_verify_subarray(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_A
         base_offset *= attr->child_type_extent;
 
         uintptr_t offset = buf_offset + base_offset * attr->u.subarray.array_of_starts[ndims - 1];
-        for (int i = 0; i < attr->u.subarray.array_of_subsizes[ndims - 1]; i++) {
+        for (intptr_t i = 0; i < attr->u.subarray.array_of_subsizes[ndims - 1]; i++) {
             rc = init_verify_subarray(dtp, obj, buf, attr, ndims - 1, offset, val_start,
                                       val_stride, rem_val_count, verify);
             DTPI_ERR_CHK_RC(rc);
@@ -407,7 +407,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__CONTIG:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.contig.blklen; i++) {
+                for (intptr_t i = 0; i < attr->u.contig.blklen; i++) {
                     rc = DTPI_init_verify(dtp, obj, buf, attr->child, offset, val_start,
                                           val_stride, rem_val_count, verify);
                     DTPI_ERR_CHK_RC(rc);
@@ -432,7 +432,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__VECTOR:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.vector.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.vector.numblks; i++) {
                     uintptr_t base_offset = offset;
                     for (int j = 0; j < attr->u.vector.blklen; j++) {
                         rc = DTPI_init_verify(dtp, obj, buf, attr->child, offset, val_start,
@@ -447,7 +447,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__HVECTOR:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.hvector.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.hvector.numblks; i++) {
                     uintptr_t base_offset = offset;
                     for (int j = 0; j < attr->u.hvector.blklen; j++) {
                         rc = DTPI_init_verify(dtp, obj, buf, attr->child, offset, val_start,
@@ -462,7 +462,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__BLKINDX:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.blkindx.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.blkindx.numblks; i++) {
                     uintptr_t base_offset = offset;
                     offset += attr->u.blkindx.array_of_displs[i] * attr->child_type_extent;
                     for (int j = 0; j < attr->u.blkindx.blklen; j++) {
@@ -478,7 +478,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__BLKHINDX:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.blkhindx.numblks; i++) {
                     uintptr_t base_offset = offset;
                     offset += attr->u.blkhindx.array_of_displs[i];
                     for (int j = 0; j < attr->u.blkhindx.blklen; j++) {
@@ -494,7 +494,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__INDEXED:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.indexed.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.indexed.numblks; i++) {
                     uintptr_t base_offset = offset;
                     offset += attr->u.indexed.array_of_displs[i] * attr->child_type_extent;
                     for (int j = 0; j < attr->u.indexed.array_of_blklens[i]; j++) {
@@ -510,7 +510,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__HINDEXED:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.hindexed.numblks; i++) {
                     uintptr_t base_offset = offset;
                     offset += attr->u.hindexed.array_of_displs[i];
                     for (int j = 0; j < attr->u.hindexed.array_of_blklens[i]; j++) {
@@ -532,7 +532,7 @@ int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * att
         case DTPI_DATATYPE_KIND__STRUCT:
             {
                 uintptr_t offset = buf_offset;
-                for (int i = 0; i < attr->u.structure.numblks; i++) {
+                for (intptr_t i = 0; i < attr->u.structure.numblks; i++) {
                     uintptr_t base_offset = offset;
                     offset += attr->u.structure.array_of_displs[i];
                     for (int j = 0; j < attr->u.structure.array_of_blklens[i]; j++) {

--- a/test/dtpools/src/dtpools_internal.h
+++ b/test/dtpools/src/dtpools_internal.h
@@ -122,8 +122,8 @@ typedef struct {
     /* in case the base type is a struct */
     int base_type_is_struct;
     struct {
-        int numblks;
-        int *array_of_blklens;
+        intptr_t numblks;
+        intptr_t *array_of_blklens;
         intptr_t *array_of_displs;
         yaksa_type_t *array_of_types;
     } base_type_attrs;
@@ -371,7 +371,7 @@ typedef struct DTPI_Attr {
 
     union {
         struct {
-            int blklen;
+            intptr_t blklen;
         } contig;
 
         struct {
@@ -380,52 +380,52 @@ typedef struct DTPI_Attr {
         } resized;
 
         struct {
-            int numblks;
-            int blklen;
-            int stride;
+            intptr_t numblks;
+            intptr_t blklen;
+            intptr_t stride;
         } vector;
 
         struct {
-            int numblks;
-            int blklen;
+            intptr_t numblks;
+            intptr_t blklen;
             intptr_t stride;
         } hvector;
 
         struct {
-            int numblks;
-            int blklen;
-            int *array_of_displs;
+            intptr_t numblks;
+            intptr_t blklen;
+            intptr_t *array_of_displs;
         } blkindx;
 
         struct {
-            int numblks;
-            int blklen;
+            intptr_t numblks;
+            intptr_t blklen;
             intptr_t *array_of_displs;
         } blkhindx;
 
         struct {
-            int numblks;
-            int *array_of_blklens;
-            int *array_of_displs;
+            intptr_t numblks;
+            intptr_t *array_of_blklens;
+            intptr_t *array_of_displs;
         } indexed;
 
         struct {
-            int numblks;
-            int *array_of_blklens;
+            intptr_t numblks;
+            intptr_t *array_of_blklens;
             intptr_t *array_of_displs;
         } hindexed;
 
         struct {
-            int ndims;
-            int *array_of_sizes;
-            int *array_of_subsizes;
-            int *array_of_starts;
+            intptr_t ndims;
+            intptr_t *array_of_sizes;
+            intptr_t *array_of_subsizes;
+            intptr_t *array_of_starts;
             int order;
         } subarray;
 
         struct {
-            int numblks;
-            int *array_of_blklens;
+            intptr_t numblks;
+            intptr_t *array_of_blklens;
             intptr_t *array_of_displs;
         } structure;
     } u;

--- a/test/dtpools/src/dtpools_misc.c
+++ b/test/dtpools/src/dtpools_misc.c
@@ -253,7 +253,7 @@ static yaksa_type_t name_to_type(const char *name)
 int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str)
 {
     yaksa_type_t *array_of_types = NULL;
-    int *array_of_blklens = NULL;
+    intptr_t *array_of_blklens = NULL;
     char **typestr = NULL;
     char **countstr = NULL;
     int num_types = 0;
@@ -301,7 +301,7 @@ int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str)
     DTPI_ERR_ASSERT(num_types < MAX_TYPES, rc);
 
     DTPI_ALLOC_OR_FAIL(array_of_types, num_types * sizeof(yaksa_type_t), rc);
-    DTPI_ALLOC_OR_FAIL(array_of_blklens, num_types * sizeof(int), rc);
+    DTPI_ALLOC_OR_FAIL(array_of_blklens, num_types * sizeof(intptr_t), rc);
 
     for (i = 0; i < num_types; i++) {
         array_of_types[i] = name_to_type(typestr[i]);


### PR DESCRIPTION
## Pull Request Description

Modify all yaksa type creation function, e.g.  `yaksa_type_create_contig_x`, `yaksa_type_create_vector_x`, etc. to use `intptr_t` typed arguments in stead of `int`. This really only affects:
* `yaksa_type_create_indexed_block`
* `yaksa_type_create_indexed`
* `yaksa_type_create_hindexed`
* `yaksa_type_create_struct`
* `yaksa_type_create_subarray`
, because they now use `intptr_t` arrays rather than `int` array. For all scalar parameters, it should be automatically converted to the larger integer type gracefully by the compiler.


<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
