### PR TITLE
init: skip gpu initialization with infohint

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -65,13 +65,21 @@ static void free_fn(void *buf, void *state)
     assert(0);
 }
 
-int yaksur_init_hook(void)
+int yaksur_init_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id;
 
     rc = yaksuri_seq_init_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info) {
+        yaksuri_info_s *infopriv = info->backend.priv;
+        if (infopriv->gpudriver_id == YAKSURI_GPUDRIVER_ID__LAST) {
+            /* gpu disabled */
+            goto fn_exit;
+        }
+    }
 
     /* CUDA hooks */
     id = YAKSURI_GPUDRIVER_ID__CUDA;

--- a/src/backend/src/yaksur_post.h
+++ b/src/backend/src/yaksur_post.h
@@ -10,7 +10,7 @@
 #include "yaksuri_cuda_post.h"
 #include "yaksuri_ze_post.h"
 
-int yaksur_init_hook(void);
+int yaksur_init_hook(yaksi_info_s * info);
 int yaksur_finalize_hook(void);
 int yaksur_type_create_hook(yaksi_type_s * type);
 int yaksur_type_free_hook(yaksi_type_s * type);

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -158,7 +158,7 @@ int yaksa_init(yaksa_info_t info)
     /*************************************************************/
     /* initialize the backend */
     /*************************************************************/
-    rc = yaksur_init_hook();
+    rc = yaksur_init_hook((yaksi_info_s *) info);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
 


### PR DESCRIPTION
## Pull Request Description

Yaksa will query gpu devices during init. This query can have huge
latency especially when multiple processes are trying to query the device at
the same time. With CUDA, cudaGetDeviceCount and checking peer access
are the most suceptible operations.

This commit allows "nogpu" infohint to skip the gpu driver setup.

Skipping gpu driver setup leaves yaksuri_global.gpudriver[id].hooks
NULL, thus will skip driver finalize. If somehow there is access to gpu
driver during runtime, I guess it will simply segfault (due to NULL
hooks).

TODO: a better solution may be to allow lazy gpu initialization. This
can be helpful especially when not all process on the same node need
access GPU.



<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
