### PR TITLE
Fix c_complex type in reduction

### DIFF
--- a/src/backend/ze/genpup.py
+++ b/src/backend/ze/genpup.py
@@ -32,7 +32,6 @@ builtin_maps = {
     "YAKSA_TYPE__UINT16_T": "int16_t",
     "YAKSA_TYPE__UINT32_T": "int32_t",
     "YAKSA_TYPE__UINT64_T": "int64_t",
-    "YAKSA_TYPE__C_COMPLEX": "float",
     "YAKSA_TYPE__BYTE": "int8_t"
 }
 

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -126,6 +126,13 @@
         yaksur_type_create_hook(tmp_type_);                             \
     } while (0)
 
+#define INIT_BUILTIN_PAIRTYPE_CONTIG(BASE_TYPE, TYPE, rc, fn_fail)      \
+    do {                                                                \
+        yaksa_type_t id;                                                \
+        yaksa_type_create_contig(2, YAKSA_TYPE__##BASE_TYPE, NULL, &id);\
+        assert(YAKSA_TYPE__##TYPE == id);                               \
+    } while (0)
+
 #define FINALIZE_BUILTIN_TYPE(TYPE, rc, fn_fail)                        \
     do {                                                                \
         yaksu_handle_t id = (yaksu_handle_t) YAKSA_TYPE__##TYPE;        \
@@ -244,15 +251,14 @@ int yaksa_init(yaksa_info_t info)
     INIT_BUILTIN_TYPE(double, DOUBLE, rc, fn_fail);
     INIT_BUILTIN_TYPE(long double, LONG_DOUBLE, rc, fn_fail);
 
-    INIT_BUILTIN_PAIRTYPE(float, float, yaksi_c_complex_s, C_COMPLEX, rc, fn_fail);
-    INIT_BUILTIN_PAIRTYPE(double, double, yaksi_c_double_complex_s, C_DOUBLE_COMPLEX, rc, fn_fail);
-    INIT_BUILTIN_PAIRTYPE(long double, long double, yaksi_c_long_double_complex_s,
-                          C_LONG_DOUBLE_COMPLEX, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE_CONTIG(FLOAT, C_COMPLEX, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE_CONTIG(DOUBLE, C_DOUBLE_COMPLEX, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE_CONTIG(LONG_DOUBLE, C_LONG_DOUBLE_COMPLEX, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(float, int, yaksi_float_int_s, FLOAT_INT, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(double, int, yaksi_double_int_s, DOUBLE_INT, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(long, int, yaksi_long_int_s, LONG_INT, rc, fn_fail);
     /* *INDENT-OFF* */
-    INIT_BUILTIN_PAIRTYPE(int, int, yaksi_2int_s, 2INT, rc, fn_fail);
+    INIT_BUILTIN_PAIRTYPE_CONTIG(INT, 2INT, rc, fn_fail);
     /* *INDENT-ON* */
     INIT_BUILTIN_PAIRTYPE(short, int, yaksi_short_int_s, SHORT_INT, rc, fn_fail);
     INIT_BUILTIN_PAIRTYPE(long double, int, yaksi_long_double_int_s, LONG_DOUBLE_INT, rc, fn_fail);


### PR DESCRIPTION
datatype such as C_complex are treated as a contiguous array of floats for reduction computation. 

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
