### PR TITLE
config: allow --without-cuda to bypass cuda

### DIFF
--- a/m4/aclocal_libs.m4
+++ b/m4/aclocal_libs.m4
@@ -12,7 +12,7 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                                 [specify path where $1 include directory and lib directory can be found])],
 
                 [AS_CASE(["$withval"],
-                         [yes|no|''],
+                         [yes|''],
                          [AC_MSG_WARN([--with[out]-$1=PATH expects a valid PATH])
                           with_$1=""])],
                 [with_$1=$2])
@@ -37,6 +37,7 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     # Now append -I/-L args to CPPFLAGS/LDFLAGS, with more specific options
     # taking priority
 
+    if test "x$with_$1" != "xno" ; then
     AS_IF([test -n "${with_$1_include}"],
           [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
           [AS_IF([test -n "${with_$1}"],
@@ -49,6 +50,8 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                  dnl we are on a 32-bit host that happens to have both lib dirs available?
                  [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])
                   PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])])])
+
+    fi
 ])
 
 

--- a/m4/aclocal_libs.m4
+++ b/m4/aclocal_libs.m4
@@ -38,18 +38,18 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     # taking priority
 
     if test "x$with_$1" != "xno" ; then
-    AS_IF([test -n "${with_$1_include}"],
-          [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
-          [AS_IF([test -n "${with_$1}"],
-                 [PAC_APPEND_FLAG([-I${with_$1}/include],[CPPFLAGS])])])
+        AS_IF([test -n "${with_$1_include}"],
+            [PAC_APPEND_FLAG([-I${with_$1_include}],[CPPFLAGS])],
+            [AS_IF([test -n "${with_$1}"],
+                    [PAC_APPEND_FLAG([-I${with_$1}/include],[CPPFLAGS])])])
 
-    AS_IF([test -n "${with_$1_lib}"],
-          [PAC_APPEND_FLAG([-L${with_$1_lib}],[LDFLAGS])],
-          [AS_IF([test -n "${with_$1}"],
-                 dnl is adding lib64 by default really the right thing to do?  What if
-                 dnl we are on a 32-bit host that happens to have both lib dirs available?
-                 [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])
-                  PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])])])
+        AS_IF([test -n "${with_$1_lib}"],
+            [PAC_APPEND_FLAG([-L${with_$1_lib}],[LDFLAGS])],
+            [AS_IF([test -n "${with_$1}"],
+                    dnl is adding lib64 by default really the right thing to do?  What if
+                    dnl we are on a 32-bit host that happens to have both lib dirs available?
+                    [PAC_APPEND_FLAG([-L${with_$1}/lib64],[LDFLAGS])
+                    PAC_APPEND_FLAG([-L${with_$1}/lib],[LDFLAGS])])])
 
     fi
 ])

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -58,39 +58,39 @@ AC_ARG_WITH([cuda-sm],
 # --with-cuda
 PAC_SET_HEADER_LIB_PATH([cuda])
 if test "$with_cuda" != "no" ; then
-PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
-if test "${have_cuda}" = "yes" ; then
-    AC_MSG_CHECKING([whether nvcc works])
-    cat>conftest.cu<<EOF
-    __global__ void foo(int x) {}
+    PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
+    if test "${have_cuda}" = "yes" ; then
+        AC_MSG_CHECKING([whether nvcc works])
+        cat>conftest.cu<<EOF
+        __global__ void foo(int x) {}
 EOF
-    ${with_cuda}/bin/nvcc -c conftest.cu 2> /dev/null
-    if test "$?" = "0" ; then
-        AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
-        AS_IF([test -n "${with_cuda}"],[NVCC=${with_cuda}/bin/nvcc],[NVCC=nvcc])
-        AC_SUBST(NVCC)
-        # nvcc compiled applications need libstdc++ to be able to link
-        # with a C compiler
-        PAC_PUSH_FLAG([LIBS])
-        PAC_APPEND_FLAG([-lstdc++],[LIBS])
-        AC_LINK_IFELSE(
-            [AC_LANG_PROGRAM([int x = 5;],[x++;])],
-            [libstdcpp_works=yes],
-            [libstdcpp_works=no])
-        PAC_POP_FLAG([LIBS])
-        if test "${libstdcpp_works}" = "yes" ; then
+        ${with_cuda}/bin/nvcc -c conftest.cu 2> /dev/null
+        if test "$?" = "0" ; then
+            AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
+            AS_IF([test -n "${with_cuda}"],[NVCC=${with_cuda}/bin/nvcc],[NVCC=nvcc])
+            AC_SUBST(NVCC)
+            # nvcc compiled applications need libstdc++ to be able to link
+            # with a C compiler
+            PAC_PUSH_FLAG([LIBS])
             PAC_APPEND_FLAG([-lstdc++],[LIBS])
-            AC_MSG_RESULT([yes])
+            AC_LINK_IFELSE(
+                [AC_LANG_PROGRAM([int x = 5;],[x++;])],
+                [libstdcpp_works=yes],
+                [libstdcpp_works=no])
+            PAC_POP_FLAG([LIBS])
+            if test "${libstdcpp_works}" = "yes" ; then
+                PAC_APPEND_FLAG([-lstdc++],[LIBS])
+                AC_MSG_RESULT([yes])
+            else
+                have_cuda=no
+                AC_MSG_RESULT([no])
+            fi
         else
             have_cuda=no
             AC_MSG_RESULT([no])
         fi
-    else
-        have_cuda=no
-        AC_MSG_RESULT([no])
+        rm -f conftest.*
     fi
-    rm -f conftest.*
-fi
 fi
 AM_CONDITIONAL([BUILD_CUDA_BACKEND], [test x${have_cuda} = xyes])
 AM_CONDITIONAL([BUILD_CUDA_TESTS], [test x${have_cuda} = xyes])

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -55,8 +55,9 @@ AC_ARG_WITH([cuda-sm],
             [with_cuda_sm=all])
 
 
-# --with=cuda
+# --with-cuda
 PAC_SET_HEADER_LIB_PATH([cuda])
+if test "$with_cuda" != "no" ; then
 PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
 if test "${have_cuda}" = "yes" ; then
     AC_MSG_CHECKING([whether nvcc works])
@@ -89,6 +90,7 @@ EOF
         AC_MSG_RESULT([no])
     fi
     rm -f conftest.*
+fi
 fi
 AM_CONDITIONAL([BUILD_CUDA_BACKEND], [test x${have_cuda} = xyes])
 AM_CONDITIONAL([BUILD_CUDA_TESTS], [test x${have_cuda} = xyes])

--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -8,8 +8,9 @@
 ##### capture user arguments
 ##########################################################################
 
-# --with=ze
+# --with-ze
 PAC_SET_HEADER_LIB_PATH([ze])
+if test "$with_ze" != "no" ; then
 if test x"${with_ze}" != x ; then
     PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeCommandQueueCreate],[have_ze=yes],[have_ze=no])
     AC_MSG_CHECKING([whether ocloc is installed])
@@ -42,6 +43,7 @@ typedef struct _ze_ipc_mem_handle_t ze_ipc_mem_handle_t;
 fi
 if test "${have_ze}" = "yes" ; then
     AC_DEFINE([HAVE_ZE],[1],[Define is ZE is available])
+fi
 fi
 AM_CONDITIONAL([BUILD_ZE_BACKEND], [test x${have_ze} = xyes])
 AM_CONDITIONAL([BUILD_ZE_TESTS], [test x${have_ze} = xyes])

--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -11,39 +11,39 @@
 # --with-ze
 PAC_SET_HEADER_LIB_PATH([ze])
 if test "$with_ze" != "no" ; then
-if test x"${with_ze}" != x ; then
-    PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeCommandQueueCreate],[have_ze=yes],[have_ze=no])
-    AC_MSG_CHECKING([whether ocloc is installed])
-    if ! command -v ocloc &> /dev/null; then
-        AC_MSG_ERROR([ocloc not found; either install it or disable ze support])
-    else
-        AC_MSG_RESULT([yes])
-    fi
-fi
-# ze_api.h relies on support for c11
-if test "${have_ze}" = "yes" ; then
-    PAC_PUSH_FLAG([CFLAGS])
-    CFLAGS="$CFLAGS -Werror"
-    AC_CACHE_CHECK([for -Werror],ac_cv_werror,[
-    AC_TRY_COMPILE([],[],ac_cv_werror=yes,ac_cv_werror=no)])
-    if test "${ac_cv_werror}" = "yes" ; then
-        AC_CACHE_CHECK([for c11 support],ac_cv_support_c11,[
-        AC_TRY_COMPILE([
-typedef struct _ze_ipc_mem_handle_t
-{
-    int data;
-} ze_ipc_mem_handle_t;
-typedef struct _ze_ipc_mem_handle_t ze_ipc_mem_handle_t;
-        ],[],ac_cv_support_c11=yes,ac_cv_support_c11=no)])
-        if test "${ac_cv_support_c11}" = "no" ; then
-            have_ze=no
+    if test x"${with_ze}" != x ; then
+        PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeCommandQueueCreate],[have_ze=yes],[have_ze=no])
+        AC_MSG_CHECKING([whether ocloc is installed])
+        if ! command -v ocloc &> /dev/null; then
+            AC_MSG_ERROR([ocloc not found; either install it or disable ze support])
+        else
+            AC_MSG_RESULT([yes])
         fi
     fi
-    PAC_POP_FLAG([CFLAGS])
-fi
-if test "${have_ze}" = "yes" ; then
-    AC_DEFINE([HAVE_ZE],[1],[Define is ZE is available])
-fi
+    # ze_api.h relies on support for c11
+    if test "${have_ze}" = "yes" ; then
+        PAC_PUSH_FLAG([CFLAGS])
+        CFLAGS="$CFLAGS -Werror"
+        AC_CACHE_CHECK([for -Werror],ac_cv_werror,[
+        AC_TRY_COMPILE([],[],ac_cv_werror=yes,ac_cv_werror=no)])
+        if test "${ac_cv_werror}" = "yes" ; then
+            AC_CACHE_CHECK([for c11 support],ac_cv_support_c11,[
+            AC_TRY_COMPILE([
+    typedef struct _ze_ipc_mem_handle_t
+    {
+        int data;
+    } ze_ipc_mem_handle_t;
+    typedef struct _ze_ipc_mem_handle_t ze_ipc_mem_handle_t;
+            ],[],ac_cv_support_c11=yes,ac_cv_support_c11=no)])
+            if test "${ac_cv_support_c11}" = "no" ; then
+                have_ze=no
+            fi
+        fi
+        PAC_POP_FLAG([CFLAGS])
+    fi
+    if test "${have_ze}" = "yes" ; then
+        AC_DEFINE([HAVE_ZE],[1],[Define is ZE is available])
+    fi
 fi
 AM_CONDITIONAL([BUILD_ZE_BACKEND], [test x${have_ze} = xyes])
 AM_CONDITIONAL([BUILD_ZE_TESTS], [test x${have_ze} = xyes])


### PR DESCRIPTION
## Pull Request Description

The previous macros will set "no" to the library path if `--without-cuda` is passed in. This PR makes it to work.
<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
