### PR TITLE
info: fix info usage before yaksa_init

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -234,8 +234,20 @@ int yaksur_info_create_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
 
+    info->backend.pre_init = !yaksu_atomic_load(&yaksi_is_initialized);
+
+    info->backend.priv = (yaksuri_info_s *) malloc(sizeof(yaksuri_info_s));
+
+    yaksuri_info_s *infopriv;
+    infopriv = (yaksuri_info_s *) info->backend.priv;
+    infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
+
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info->backend.pre_init) {
+        goto fn_exit;
+    }
 
     for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
@@ -245,12 +257,6 @@ int yaksur_info_create_hook(yaksi_info_s * info)
         rc = yaksuri_global.gpudriver[id].hooks->info_create(info);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
-
-    info->backend.priv = (yaksuri_info_s *) malloc(sizeof(yaksuri_info_s));
-
-    yaksuri_info_s *infopriv;
-    infopriv = (yaksuri_info_s *) info->backend.priv;
-    infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
 
   fn_exit:
     return rc;
@@ -266,6 +272,10 @@ int yaksur_info_free_hook(yaksi_info_s * info)
 
     rc = yaksuri_seq_info_free_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info->backend.pre_init) {
+        goto fn_exit;
+    }
 
     for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -41,6 +41,7 @@ typedef struct {
 } yaksur_request_s;
 
 typedef struct {
+    bool pre_init;              /* set to true for info created before yaksa_init */
     yaksuri_seq_info_s seq;
     yaksuri_cuda_info_s cuda;
     yaksuri_ze_info_s ze;


### PR DESCRIPTION
## Pull Request Description
In order to pass info hint to yaksa_init, it is necessary to create info
before yaksa_init. But some facility, such as gpu driver hooks are not
inplace yet before init. This patch adds a pre_init flag to guard
against such inconsistencies. Currently, this simply prevents gpu driver
hooks to ever executed for such pre_init infos.



<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
