### PR TITLE
backend/cuda: refactoring complex pack/unpack protocol switch in progress enqueue and minor bug fix

### DIFF
--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1105,7 +1105,7 @@ static int singlechunk_unpack(yaksuri_gpudriver_id_e id, int device, const void 
 static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                               uintptr_t threshold, yaksuri_subreq_s * subreq)
+                               yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1146,7 +1146,7 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
 static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                               uintptr_t threshold, yaksuri_subreq_s * subreq)
+                               yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1177,10 +1177,11 @@ static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
 static int set_subreq_pack_d2rh(const void *inbuf, void *outbuf, uintptr_t count,
                                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                 yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    uintptr_t threshold = yaksuri_global.gpudriver[id].hooks->get_iov_pack_threshold(info);
 
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
@@ -1200,22 +1201,22 @@ static int set_subreq_pack_d2rh(const void *inbuf, void *outbuf, uintptr_t count
 static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_t count,
                                        yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                        yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                       uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                       yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
 
     switch (request->backend.outattr.type) {
         case YAKSUR_PTR_TYPE__GPU:
             rc = set_subreq_pack_d2d(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                     threshold, subreq);
+                                     subreq);
             break;
         case YAKSUR_PTR_TYPE__MANAGED:
             rc = set_subreq_pack_d2m(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                     threshold, subreq);
+                                     subreq);
             break;
         case YAKSUR_PTR_TYPE__REGISTERED_HOST:
             rc = set_subreq_pack_d2rh(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                      threshold, subreq);
+                                      subreq);
             break;
         case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
         default:
@@ -1230,7 +1231,7 @@ static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_
 static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr_t count,
                                         yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                         yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                        uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                        yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1256,10 +1257,11 @@ static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr
 static int set_subreq_pack_from_rhost(const void *inbuf, void *outbuf, uintptr_t count,
                                       yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                       yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                      uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                      yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    uintptr_t threshold = yaksuri_global.gpudriver[id].hooks->get_iov_pack_threshold(info);
 
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
@@ -1280,7 +1282,7 @@ static int set_subreq_pack_from_rhost(const void *inbuf, void *outbuf, uintptr_t
 static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
                                  yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                  yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                 uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                 yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1321,7 +1323,7 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
 static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
                                  yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                  yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                 uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                 yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1346,10 +1348,11 @@ static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t coun
 static int set_subreq_unpack_d2rh(const void *inbuf, void *outbuf, uintptr_t count,
                                   yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                   yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                  uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                  yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    uintptr_t threshold = yaksuri_global.gpudriver[id].hooks->get_iov_unpack_threshold(info);
 
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
@@ -1369,22 +1372,22 @@ static int set_subreq_unpack_d2rh(const void *inbuf, void *outbuf, uintptr_t cou
 static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintptr_t count,
                                          yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                          yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                         uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                         yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
 
     switch (request->backend.outattr.type) {
         case YAKSUR_PTR_TYPE__GPU:
             rc = set_subreq_unpack_d2d(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                       threshold, subreq);
+                                       subreq);
             break;
         case YAKSUR_PTR_TYPE__MANAGED:
             rc = set_subreq_unpack_d2m(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                       threshold, subreq);
+                                       subreq);
             break;
         case YAKSUR_PTR_TYPE__REGISTERED_HOST:
             rc = set_subreq_unpack_d2rh(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                        threshold, subreq);
+                                        subreq);
             break;
         case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
         default:
@@ -1399,7 +1402,7 @@ static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintpt
 static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintptr_t count,
                                           yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                           yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                          uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                          yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1425,10 +1428,11 @@ static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintp
 static int set_subreq_unpack_from_rhost(const void *inbuf, void *outbuf, uintptr_t count,
                                         yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                         yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                        uintptr_t threshold, yaksuri_subreq_s * subreq)
+                                        yaksuri_subreq_s * subreq)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    uintptr_t threshold = yaksuri_global.gpudriver[id].hooks->get_iov_unpack_threshold(info);
 
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
@@ -1470,22 +1474,20 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
     }
 
     subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
-    uintptr_t threshold;
 
     if (reqpriv->optype == YAKSURI_OPTYPE__PACK) {
-        threshold = yaksuri_global.gpudriver[id].hooks->get_iov_pack_threshold(info);
         switch (request->backend.inattr.type) {
             case YAKSUR_PTR_TYPE__GPU:
                 rc = set_subreq_pack_from_device(inbuf, outbuf, count, type, info, op, request,
-                                                 reqpriv, threshold, subreq);
+                                                 reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__MANAGED:
                 rc = set_subreq_pack_from_managed(inbuf, outbuf, count, type, info, op, request,
-                                                  reqpriv, threshold, subreq);
+                                                  reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__REGISTERED_HOST:
                 rc = set_subreq_pack_from_rhost(inbuf, outbuf, count, type, info, op, request,
-                                                reqpriv, threshold, subreq);
+                                                reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
             default:
@@ -1495,19 +1497,18 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
                 break;
         }
     } else {
-        threshold = yaksuri_global.gpudriver[id].hooks->get_iov_unpack_threshold(info);
         switch (request->backend.inattr.type) {
             case YAKSUR_PTR_TYPE__GPU:
                 rc = set_subreq_unpack_from_device(inbuf, outbuf, count, type, info, op, request,
-                                                   reqpriv, threshold, subreq);
+                                                   reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__MANAGED:
                 rc = set_subreq_unpack_from_managed(inbuf, outbuf, count, type, info, op, request,
-                                                    reqpriv, threshold, subreq);
+                                                    reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__REGISTERED_HOST:
                 rc = set_subreq_unpack_from_rhost(inbuf, outbuf, count, type, info, op, request,
-                                                  reqpriv, threshold, subreq);
+                                                  reqpriv, subreq);
                 break;
             case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
             default:

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1111,7 +1111,7 @@ static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
 
     if (request->backend.outattr.type == YAKSUR_PTR_TYPE__GPU) {
-        if (!buf_is_aligned(outbuf, type) && op != YAKSA_OP__REPLACE) {
+        if (!buf_is_aligned(outbuf, type) || op != YAKSA_OP__REPLACE) {
             if (request->backend.inattr.device == request->backend.outattr.device) {
                 subreq->u.multiple.acquire = pack_d2d_unaligned_acquire;
                 subreq->u.multiple.release = simple_release;
@@ -1154,7 +1154,7 @@ static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_
             YAKSU_ERR_CHECK(rc, fn_fail);
         }
     } else if (request->backend.outattr.type == YAKSUR_PTR_TYPE__MANAGED) {
-        if (!buf_is_aligned(outbuf, type) && op != YAKSA_OP__REPLACE) {
+        if (!buf_is_aligned(outbuf, type) || op != YAKSA_OP__REPLACE) {
             if (request->backend.outattr.device == -1 ||
                 request->backend.inattr.device == request->backend.outattr.device) {
                 subreq->u.multiple.acquire = pack_d2d_unaligned_acquire;
@@ -1215,7 +1215,7 @@ static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
 
-    if (!buf_is_aligned(outbuf, type) && op != YAKSA_OP__REPLACE) {
+    if (!buf_is_aligned(outbuf, type) || op != YAKSA_OP__REPLACE) {
         subreq->u.multiple.acquire = pack_h2d_acquire;
         subreq->u.multiple.release = simple_release;
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
@@ -1280,7 +1280,7 @@ static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintpt
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
 
     if (request->backend.outattr.type == YAKSUR_PTR_TYPE__GPU) {
-        if (!buf_is_aligned(inbuf, type) && op != YAKSA_OP__REPLACE) {
+        if (!buf_is_aligned(inbuf, type) || op != YAKSA_OP__REPLACE) {
             if (request->backend.inattr.device == request->backend.outattr.device) {
                 subreq->u.multiple.acquire = unpack_d2d_unaligned_acquire;
                 subreq->u.multiple.release = simple_release;
@@ -1323,7 +1323,7 @@ static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintpt
             YAKSU_ERR_CHECK(rc, fn_fail);
         }
     } else if (request->backend.outattr.type == YAKSUR_PTR_TYPE__MANAGED) {
-        if (!buf_is_aligned(inbuf, type) && op != YAKSA_OP__REPLACE) {
+        if (!buf_is_aligned(inbuf, type) || op != YAKSA_OP__REPLACE) {
             subreq->u.multiple.acquire = unpack_d2h_acquire;
             subreq->u.multiple.release = unpack_d2h_release;
             rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
@@ -1378,7 +1378,7 @@ static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintp
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
 
-    if (!buf_is_aligned(inbuf, type) && op != YAKSA_OP__REPLACE) {
+    if (!buf_is_aligned(inbuf, type) || op != YAKSA_OP__REPLACE) {
         subreq->u.multiple.acquire = unpack_urh2d_acquire;
         subreq->u.multiple.release = simple_release;
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1437,6 +1437,7 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
                              yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request)
 {
     int rc = YAKSA_SUCCESS;
+    yaksuri_subreq_s *subreq = NULL;
     yaksuri_request_s *reqpriv = (yaksuri_request_s *) request->backend.priv;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
 
@@ -1456,7 +1457,7 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
         goto fn_exit;
     }
 
-    yaksuri_subreq_s *subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
+    subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
     uintptr_t threshold;
 
     if (reqpriv->optype == YAKSURI_OPTYPE__PACK) {
@@ -1504,14 +1505,6 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
                 break;
         }
     }
-
-    /* Unsupported multichunk subreq */
-    if (rc == YAKSA_ERR__NOT_SUPPORTED) {
-        free(subreq);
-        goto fn_exit;
-    }
-
-    /* Other error handling */
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     pthread_mutex_lock(&progress_mutex);
@@ -1532,6 +1525,7 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
   fn_exit:
     return rc;
   fn_fail:
+    free(subreq);
     goto fn_exit;
 }
 


### PR DESCRIPTION
## Pull Request Description
The current pack/unpack protocol switch code in `yaksuri_progress_enqueue` is complex and not easy to read. This patch refactors the long if-else based switch logic. The basic approach is to separate each situation (e.g., d2d_pack, d2rh_pack...) into subroutines so that later developers can easily find the place to optimize.

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
