### PR TITLE
backend/cuda: Fix bashism in shell script

### DIFF
--- a/src/backend/cuda/cudalt.sh
+++ b/src/backend/cuda/cudalt.sh
@@ -14,6 +14,7 @@ fi
 
 LO_FILEPATH="$1"
 O_FILEPATH="${LO_FILEPATH%%.lo}.o"
+shift # handle the rest of the arguments together with ${@}
 
 LO_DIR=$(dirname $O_FILEPATH)
 O_FILENAME=$(basename $O_FILEPATH)
@@ -32,11 +33,11 @@ if test ! -d "$PIC_DIR" ; then
     mkdir -p "$PIC_DIR"
 fi
 
-CMD="${@:2} -Xcompiler -fPIC -o $PIC_FILEPATH"
+CMD="${@} -Xcompiler -fPIC -o $PIC_FILEPATH"
 if test "$verbose" ; then echo "$CMD" ; fi
 eval "$CMD"
 
-CMD="${@:2} -o $NPIC_FILEPATH"
+CMD="${@} -o $NPIC_FILEPATH"
 if test "$verbose" ; then echo "$CMD" ; fi
 eval "$CMD"
 


### PR DESCRIPTION
## Pull Request Description

Use shift instead of array slicing syntax. Fixes a build issue on
systems with dash as /bin/sh, e.g. Ubuntu. Closes #180.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Fix build issue on Ubuntu.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
