### PR TITLE
backend: fix fast-path conditions for reduce operations

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -89,20 +89,17 @@ static int get_num_devices(int *ndevices)
     return YAKSA_SUCCESS;
 }
 
-static int check_p2p_comm(int sdev, int ddev, bool * is_enabled)
+static bool check_p2p_comm(int sdev, int ddev)
 {
+    bool is_enabled = 0;
 #if CUDA_P2P == CUDA_P2P_ENABLED
-    *is_enabled = yaksuri_cudai_global.p2p[sdev][ddev];
+    is_enabled = yaksuri_cudai_global.p2p[sdev][ddev];
 #elif CUDA_P2P == CUDA_P2P_CLIQUES
-    if ((sdev + ddev) % 2)
-        *is_enabled = 0;
-    else
-        *is_enabled = yaksuri_cudai_global.p2p[sdev][ddev];
-#else
-    *is_enabled = 0;
+    if ((sdev + ddev) % 2 == 0)
+        is_enabled = yaksuri_cudai_global.p2p[sdev][ddev];
 #endif
 
-    return YAKSA_SUCCESS;
+    return is_enabled;
 }
 
 int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -51,7 +51,9 @@ typedef struct {
 typedef struct yaksur_gpudriver_hooks_s {
     /* miscellaneous */
     int (*get_num_devices) (int *ndevices);
-    int (*check_p2p_comm) (int sdev, int ddev, bool * is_enabled);
+    /* *INDENT-OFF* */
+    bool (*check_p2p_comm) (int sdev, int ddev);
+    /* *INDENT-ON* */
     int (*finalize) (void);
 
     /* pup functions */

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1137,10 +1137,7 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
     }
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
@@ -1320,10 +1317,7 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
     }
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t count,

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -123,17 +123,9 @@ static int iunpack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, u
     goto fn_exit;
 }
 
-static int check_p2p_comm(yaksuri_gpudriver_id_e id, int indev, int outdev, bool * is_enabled)
+static bool check_p2p_comm(yaksuri_gpudriver_id_e id, int indev, int outdev)
 {
-    int rc = YAKSA_SUCCESS;
-
-    rc = yaksuri_global.gpudriver[id].hooks->check_p2p_comm(indev, outdev, is_enabled);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
-  fn_exit:
-    return rc;
-  fn_fail:
-    goto fn_exit;
+    return yaksuri_global.gpudriver[id].hooks->check_p2p_comm(indev, outdev);
 }
 
 static int event_record(yaksuri_gpudriver_id_e id, int device, void **event)
@@ -1122,10 +1114,8 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
         subreq->u.multiple.release = simple_release;
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
     } else {
-        bool is_enabled;
-        rc = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
-                            reqpriv->request->backend.outattr.device, &is_enabled);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        bool is_enabled = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
+                                         reqpriv->request->backend.outattr.device);
 
         if (is_enabled) {
             subreq->u.multiple.acquire = pack_d2d_p2p_acquire;
@@ -1299,10 +1289,8 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
         subreq->u.multiple.release = simple_release;
         rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq);
     } else {
-        bool is_enabled;
-        rc = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
-                            reqpriv->request->backend.outattr.device, &is_enabled);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        bool is_enabled = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
+                                         reqpriv->request->backend.outattr.device);
 
         if (is_enabled) {
             subreq->u.multiple.acquire = unpack_d2d_p2p_acquire;

--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -107,20 +107,17 @@ static int get_num_devices(int *ndevices)
     return YAKSA_SUCCESS;
 }
 
-static int check_p2p_comm(int sdev, int ddev, bool * is_enabled)
+static bool check_p2p_comm(int sdev, int ddev)
 {
+    bool is_enabled = 0;
 #if ZE_P2P == ZE_P2P_ENABLED
-    *is_enabled = yaksuri_zei_global.p2p[sdev][ddev];
+    is_enabled = yaksuri_zei_global.p2p[sdev][ddev];
 #elif ZE_P2P == ZE_P2P_CLIQUES
-    if ((sdev + ddev) % 2)
-        *is_enabled = 0;
-    else
-        *is_enabled = yaksuri_zei_global.p2p[sdev][ddev];
-#else
-    *is_enabled = 0;
+    if ((sdev + ddev) % 2 == 0)
+        is_enabled = yaksuri_zei_global.p2p[sdev][ddev];
 #endif
 
-    return YAKSA_SUCCESS;
+    return is_enabled;
 }
 
 int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)


### PR DESCRIPTION
## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

This PR contains two major changes:
1.  Add p2p-enabled case for the fast-path of **REPLACE** operation

2. [c346933b](https://github.com/pmodels/yaksa/commit/c346933b5262809b433c322a2552dd1c06f2e683) missed the fast-path check for non-REPLACE reduce operations. Now we add it back. Below are the fast-path conditions for **non-REPLACE** operations:
    - d2d pack/unpack: same device and buffer is aligned
    - d2m or m2d pack/unpack: same device or device-host, and with aligned buffer

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
