### PR TITLE
frontend/backend: implement blocking pack/unpack and optimize fast-path

### DIFF
--- a/maint/gentests.py
+++ b/maint/gentests.py
@@ -135,6 +135,8 @@ if __name__ == '__main__':
     gen_pack_iov_tests("pack", "test/pack/testlist.gen", True)
     gen_pack_iov_tests("pack", "test/pack/testlist.threads.gen", True, \
                        " -num-threads 4")
+    gen_pack_iov_tests("pack", "test/pack/testlist.blocking.gen", True, \
+                       " -blocking")
 
     gen_pack_iov_tests("iov", "test/iov/testlist.gen", False)
     gen_pack_iov_tests("iov", "test/iov/testlist.threads.gen", False, " -num-threads 4")

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -190,6 +190,7 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
     (*hooks)->ipack = yaksuri_cudai_ipack;
     (*hooks)->iunpack = yaksuri_cudai_iunpack;
+    (*hooks)->synchronize = NULL;       /* unsupported */
     (*hooks)->flush_all = yaksuri_cudai_flush_all;
     (*hooks)->pup_is_supported = yaksuri_cudai_pup_is_supported;
     (*hooks)->host_malloc = cuda_host_malloc;

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -190,7 +190,7 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
     (*hooks)->ipack = yaksuri_cudai_ipack;
     (*hooks)->iunpack = yaksuri_cudai_iunpack;
-    (*hooks)->synchronize = NULL;       /* unsupported */
+    (*hooks)->synchronize = yaksuri_cudai_synchronize;
     (*hooks)->flush_all = yaksuri_cudai_flush_all;
     (*hooks)->pup_is_supported = yaksuri_cudai_pup_is_supported;
     (*hooks)->host_malloc = cuda_host_malloc;

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -84,6 +84,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
                         yaksi_info_s * info, yaksa_op_t op, int target);
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                           yaksi_info_s * info, yaksa_op_t op, int target);
+int yaksuri_cudai_synchronize(int target);
 int yaksuri_cudai_flush_all(void);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, yaksa_op_t op, bool * is_supported);
 uintptr_t yaksuri_cudai_get_iov_pack_threshold(yaksi_info_s * info);

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -210,6 +210,20 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
     goto fn_exit;
 }
 
+int yaksuri_cudai_synchronize(int target)
+{
+    int rc = YAKSA_SUCCESS;
+    cudaError_t cerr;
+
+    cerr = cudaStreamSynchronize(yaksuri_cudai_global.stream[target]);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
 int yaksuri_cudai_flush_all(void)
 {
     return YAKSA_SUCCESS;

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -66,6 +66,7 @@ typedef struct yaksur_gpudriver_hooks_s {
                   int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,
                     struct yaksi_info_s * info, yaksa_op_t op, int device);
+    int (*synchronize) (int device);    /* complete all outstanding tasks that are created by yaksa on the device */
     int (*flush_all) (void);
     int (*pup_is_supported) (struct yaksi_type_s * type, yaksa_op_t op, bool * is_supported);
 

--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -275,6 +275,7 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->finalize = finalize_hook;
     (*hooks)->ipack = yaksuri_zei_ipack;
     (*hooks)->iunpack = yaksuri_zei_iunpack;
+    (*hooks)->synchronize = NULL;       /* unsupported */
     (*hooks)->flush_all = yaksuri_zei_flush_all;
     (*hooks)->pup_is_supported = yaksuri_zei_pup_is_supported;
     (*hooks)->get_iov_pack_threshold = yaksuri_zei_get_iov_pack_threshold;

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -486,6 +486,23 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
                 yaksa_info_t info, yaksa_op_t op, yaksa_request_t * request);
 
 /*!
+ * \brief packs the data represented by the (incount, type) tuple into a contiguous buffer. Completes at return.
+ *
+ * \param[in]  inbuf             Input buffer from which data is being packed
+ * \param[in]  incount           Number of elements of the datatype representing the layout
+ * \param[in]  type              Datatype representing the layout
+ * \param[in]  inoffset          Number of bytes to skip from the layout represented by the
+ *                               (incount, type) tuple
+ * \param[out] outbuf            Output buffer into which data is being packed
+ * \param[in]  max_pack_bytes    Maximum number of bytes that can be packed in the output buffer
+ * \param[out] actual_pack_bytes Actual number of bytes that were packed into the output buffer
+ * \param[in]  info              Info hint to apply
+ */
+int yaksa_pack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
+               void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
+               yaksa_info_t info, yaksa_op_t op);
+
+/*!
  * \brief unpacks data from a contiguous buffer into a buffer represented by the (incount, type) tuple
  *
  * \param[in]  inbuf             Input buffer from which data is being unpacked
@@ -503,6 +520,23 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
 int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
                   yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
                   yaksa_info_t info, yaksa_op_t op, yaksa_request_t * request);
+
+/*!
+ * \brief unpacks data from a contiguous buffer into a buffer represented by the (incount, type) tuple. Completes at return.
+ *
+ * \param[in]  inbuf             Input buffer from which data is being unpacked
+ * \param[in]  insize            Number of bytes in the input buffer
+ * \param[out] outbuf            Output buffer into which data is being unpacked
+ * \param[in]  outcount          Number of elements of the datatype representing the layout
+ * \param[in]  type              Datatype representing the layout
+ * \param[in]  outoffset         Number of bytes to skip from the layout represented by the
+ *                               (outcount, type) tuple
+ * \param[out] actual_unpack_bytes Actual number of bytes that were unpacked into the output buffer
+ * \param[in]  info              Info hint to apply
+ */
+int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
+                 yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                 yaksa_info_t info, yaksa_op_t op);
 
 /*!
  * \brief gets the number of contiguous segments in the (count, type) tuple

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -148,6 +148,7 @@ typedef struct yaksi_type_s {
 typedef struct yaksi_request_s {
     yaksu_handle_t id;
     yaksu_atomic_int cc;        /* completion counter */
+    bool is_blocking;           /* ipack/iunpack are nonblocking; pack/unpack are blocking */
 
     /* give some private space for the backend to store content */
     yaksur_request_s backend;
@@ -264,7 +265,7 @@ int yaksi_type_handle_dealloc(yaksa_type_t handle, yaksi_type_s ** type);
 int yaksi_type_get(yaksa_type_t type, yaksi_type_s ** yaksi_type);
 
 /* request pool */
-int yaksi_request_create(yaksi_request_s ** request);
+int yaksi_request_create(yaksi_request_s ** request, bool is_blocking);
 int yaksi_request_free(yaksi_request_s * request);
 int yaksi_request_get(yaksa_request_t request, yaksi_request_s ** yaksi_request);
 

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -266,7 +266,7 @@ int yaksa_init(yaksa_info_t info)
 
     /* allocate the NULL request */
     struct yaksi_request_s *request;
-    rc = yaksi_request_create(&request);
+    rc = yaksi_request_create(&request, false /* is_blocking */);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     assert(request->id == YAKSA_REQUEST__NULL);

--- a/src/frontend/pup/Makefile.mk
+++ b/src/frontend/pup/Makefile.mk
@@ -7,7 +7,9 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/frontend/pup
 
 libyaksa_la_SOURCES += \
 	src/frontend/pup/yaksa_ipack.c \
+	src/frontend/pup/yaksa_pack.c \
 	src/frontend/pup/yaksa_iunpack.c \
+	src/frontend/pup/yaksa_unpack.c \
 	src/frontend/pup/yaksa_request.c \
 	src/frontend/pup/yaksi_ipack.c \
 	src/frontend/pup/yaksi_ipack_element.c \

--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -32,7 +32,7 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
     }
 
     yaksi_request_s *yaksi_request;
-    rc = yaksi_request_create(&yaksi_request);
+    rc = yaksi_request_create(&yaksi_request, false /* is_blocking */);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     yaksi_info_s *yaksi_info;

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -35,7 +35,7 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
 
     yaksi_request_s *yaksi_request;
     yaksi_request = NULL;
-    rc = yaksi_request_create(&yaksi_request);
+    rc = yaksi_request_create(&yaksi_request, false /* is_blocking */);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     yaksi_info_s *yaksi_info;

--- a/src/frontend/pup/yaksa_pack.c
+++ b/src/frontend/pup/yaksa_pack.c
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksi.h"
+#include "yaksu.h"
+#include <assert.h>
+
+int yaksa_pack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
+               void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
+               yaksa_info_t info, yaksa_op_t op)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    if (incount == 0) {
+        *actual_pack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_type_s *yaksi_type;
+    rc = yaksi_type_get(type, &yaksi_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *actual_pack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_request_s *yaksi_request;
+    yaksi_request = NULL;
+    rc = yaksi_request_create(&yaksi_request, true /* is_blocking */);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
+    rc = yaksi_ipack(inbuf, incount, yaksi_type, inoffset, outbuf, max_pack_bytes,
+                     actual_pack_bytes, yaksi_info, op, yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksu_atomic_load(&yaksi_request->cc)) {
+        rc = yaksur_request_wait(yaksi_request);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+    rc = yaksi_request_free(yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/frontend/pup/yaksa_unpack.c
+++ b/src/frontend/pup/yaksa_unpack.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksi.h"
+#include "yaksu.h"
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
+                 yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                 yaksa_info_t info, yaksa_op_t op)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    if (outcount == 0) {
+        *actual_unpack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_type_s *yaksi_type;
+    rc = yaksi_type_get(type, &yaksi_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *actual_unpack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_request_s *yaksi_request;
+    yaksi_request = NULL;
+    rc = yaksi_request_create(&yaksi_request, true /* is_blocking */);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
+    rc = yaksi_iunpack(inbuf, insize, outbuf, outcount, yaksi_type, outoffset, actual_unpack_bytes,
+                       yaksi_info, op, yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksu_atomic_load(&yaksi_request->cc)) {
+        rc = yaksur_request_wait(yaksi_request);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+
+    rc = yaksi_request_free(yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -7,7 +7,7 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksi_request_create(yaksi_request_s ** request)
+int yaksi_request_create(yaksi_request_s ** request, bool is_blocking)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_request_s *req;
@@ -21,6 +21,7 @@ int yaksi_request_create(yaksi_request_s ** request)
     assert(req->id < ((yaksa_request_t) 1 << YAKSI_REQUEST_OBJECT_ID_BITS));
 
     yaksu_atomic_store(&req->cc, 0);
+    req->is_blocking = is_blocking;
 
     rc = yaksur_request_create_hook(req);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/test/pack/Makefile.mk
+++ b/test/pack/Makefile.mk
@@ -7,7 +7,8 @@ pack_testlists = $(top_srcdir)/test/pack/testlist.gen \
 	$(top_srcdir)/test/pack/testlist.threads.gen
 
 EXTRA_DIST += $(top_srcdir)/test/pack/testlist.gen \
-	$(top_srcdir)/test/pack/testlist.threads.gen
+	$(top_srcdir)/test/pack/testlist.threads.gen     \
+	$(top_srcdir)/test/pack/testlist.blocking.gen
 
 EXTRA_PROGRAMS += \
 	test/pack/pack


### PR DESCRIPTION
## Pull Request Description

#### Background
Current API supports only nonblocking `ipack|iunpack` and `request_wait`. The user can use them to implement blocking pack|unpack, however, it causes suboptimal performance in fast-path copy. Performance study with CUDA showed that use of **event-creation-record-destroy** APIs in the current nonblocking approach introduce about **3us~** consistent overhead. Such an overhead is significant at the fast-path of d<->d, d<->m, d<->rh copy which usually takes latency only at 8~15us.

On the user side (e.g., in MPICH), yaksa APIs are often used in a blocking manner depends on the communication protocol or latency/message-rate preference. Thus, using the underlying nonblocking yaksa routines introduce unnecessary overhead. 

#### What is changed
This PR implements the blocking `pack|unpack` API. Thus, yaksa can optimize the blocking use case by skipping event creation. Instead, it uses the `synchronize` backend driver hook. In CUDA, it is `cudaStreamSynchronize`.

## Expected Impact
- For CUDA fast-path, it saves 3+us for blocking pack/unpack use case.
- For CUDA slow-paths, it creates event as of today and the event is blocking waited at end of frontend pack|unpack. Thus, no performance change compared to current version.
- For ZE backend, `synchronize` hook is not defined. Thus, Even fast-path will still create event, same performance as of today.

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->



## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
