### PR TITLE
type_create: fix checking for contig

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -24,6 +24,7 @@ error() {
 ########################################################################
 
 genpup_args=
+gentests_args=
 
 if test -n "$YAKSA_AUTOGEN_PUP_NESTING" ; then
     genpup_args=$YAKSA_AUTOGEN_PUP_NESTING
@@ -34,7 +35,9 @@ for arg in "$@" ; do
         -pup-max-nesting=*|--pup-max-nesting=*)
             genpup_args="$genpup_args $arg"
             ;;
-
+        -skip-test-complex)
+            gentests_args="$gentests_args $arg"
+            ;;
         *)
             error "unknown argument $arg"
             ;;
@@ -58,7 +61,7 @@ for x in seq cuda ze ; do
 done
 
 # tests
-./maint/gentests.py
+./maint/gentests.py ${gentests_args}
 if test "$?" != "0" ; then
     echo "test generation failed"
     exit 1

--- a/maint/gentests.py
+++ b/maint/gentests.py
@@ -7,6 +7,10 @@
 import sys
 import os
 
+skip_test_complex = False
+for a in sys.argv[1:]:
+    if a == "-skip-test-complex":
+        skip_test_complex = True
 
 ##### global settings
 counts = [ 17, 1075, 65536 ]
@@ -15,7 +19,10 @@ iters = {
     1075: 128,
     65536: 32,
 }
-types = [ "int", "short_int", "int:3+float:2", "int:3+double:2", "c_complex", "c_double_complex" ]
+types = [ "int", "short_int", "int:3+float:2", "int:3+double:2"]
+if not skip_test_complex:
+    types.extend(["c_complex", "c_double_complex"])
+
 oplist = {
     "int": "int",
     "short_int": "int",

--- a/maint/gentests.py
+++ b/maint/gentests.py
@@ -41,6 +41,7 @@ def gen_simple_tests(testlist):
     outfile.write(os.path.join(prefix, "simple_test") + "\n")
     outfile.write(os.path.join(prefix, "threaded_test") + "\n")
     outfile.write(os.path.join(prefix, "lbub") + "\n")
+    outfile.write(os.path.join(prefix, "test_contig") + "\n")
     outfile.close()
     sys.stdout.write("done\n")
 

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -75,7 +75,7 @@ int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
     if (intype->is_contig && ((outtype->ub - outtype->lb) == outtype->size)) {
         outtype->is_contig = true;
         for (int i = 1; i < count; i++) {
-            if (array_of_displs[i] <= array_of_displs[i - 1]) {
+            if (array_of_displs[i] != array_of_displs[i - 1] + intype->extent * blocklength) {
                 outtype->is_contig = false;
                 break;
             }

--- a/test/simple/Makefile.mk
+++ b/test/simple/Makefile.mk
@@ -9,10 +9,12 @@ EXTRA_DIST += $(top_srcdir)/test/simple/testlist.gen
 EXTRA_PROGRAMS += \
 	test/simple/simple_test \
         test/simple/lbub \
+	test/simple/test_contig \
 	test/simple/threaded_test
 
 test_simple_simple_test_CPPFLAGS = $(test_cppflags)
 test_simple_lbub_CPPFLAGS = $(test_cppflags)
+test_simple_test_contig_CPPFLAGS = $(test_cppflags)
 test_simple_threaded_test_CPPFLAGS = $(test_cppflags)
 
 test-simple:

--- a/test/simple/test_contig.c
+++ b/test/simple/test_contig.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksa.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+int main(int argc, char **argv)
+{
+    int errs = 0;
+    yaksa_type_t type;
+    uintptr_t iov_len;
+
+    yaksa_init(NULL);
+
+    {
+        yaksa_type_create_vector(5, 2, 2, YAKSA_TYPE__INT, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len != 1) {
+            printf("Test vector with consecutive blocks, got iov_len = %ld, expect 1\n", iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        intptr_t blklens[] = { 2, 2, 1, 3, 3 };
+        intptr_t displs[] = { 1, 3, 5, 6, 9 };
+        yaksa_type_create_indexed(5, blklens, displs, YAKSA_TYPE__DOUBLE, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len != 1) {
+            printf("Test indexed with consecutive blocks, got iov_len = %ld, expect 1\n", iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        intptr_t blklens[] = { 2, 2, 1, 3, 3 };
+        intptr_t displs[] = { 1, 2, 3, 5, 9 };
+        yaksa_type_create_indexed(5, blklens, displs, YAKSA_TYPE__DOUBLE, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len == 1) {
+            printf("Test indexed with non-consecutive blocks, got iov_len = %ld, expect 5\n",
+                   iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        intptr_t displs[] = { 2, 4, 6, 8, 10 };
+        yaksa_type_create_indexed_block(5, 2, displs, YAKSA_TYPE__DOUBLE, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len != 1) {
+            printf("Test indexed_block with consecutive blocks, got iov_len = %ld, expect 1\n",
+                   iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        intptr_t displs[] = { 2, 3, 4, 7, 10 };
+        yaksa_type_create_indexed_block(5, 2, displs, YAKSA_TYPE__DOUBLE, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len == 1) {
+            printf("Test indexed_block with non-consecutive blocks, got iov_len = %ld, expect 5\n",
+                   iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        yaksa_type_t types[] =
+            { YAKSA_TYPE__INT32_T, YAKSA_TYPE__INT32_T, YAKSA_TYPE__INT8_T, YAKSA_TYPE__INT8_T,
+            YAKSA_TYPE__INT16_T
+        };
+        intptr_t blklens[] = { 1, 1, 4, 4, 2 };
+        intptr_t displs[] = { 4, 8, 12, 16, 20 };
+        yaksa_type_create_struct(5, blklens, displs, types, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len != 1) {
+            printf("Test struct with consecutive blocks, got iov_len = %ld, expect 1\n", iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    {
+        yaksa_type_t types[] =
+            { YAKSA_TYPE__INT32_T, YAKSA_TYPE__INT32_T, YAKSA_TYPE__INT8_T, YAKSA_TYPE__INT8_T,
+            YAKSA_TYPE__INT16_T
+        };
+        intptr_t blklens[] = { 1, 1, 4, 4, 2 };
+        intptr_t displs[] = { 4, 12, 13, 14, 20 };
+        yaksa_type_create_struct(5, blklens, displs, types, NULL, &type);
+        yaksa_iov_len(1, type, &iov_len);
+        if (iov_len == 1) {
+            printf("Test struct with non-consecutive blocks, got iov_len = %ld, expect 5\n",
+                   iov_len);
+            errs++;
+        }
+        yaksa_type_free(type);
+    }
+
+    yaksa_finalize();
+
+    return errs;
+}


### PR DESCRIPTION
## Pull Request Description
The previous code is incorrect in only checking for starting position
between each block in yaksi_type_create_hindexed. We need check whether
previous upper bound is the same as the current lower bound.

Reference: https://github.com/pmodels/mpich/issues/5391

TODO: 
* [x] add tests for checking contig attributes

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
