### PR TITLE
init: skip gpu initialization with info hint [0.1x]

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -65,13 +65,21 @@ static void free_fn(void *buf, void *state)
     assert(0);
 }
 
-int yaksur_init_hook(void)
+int yaksur_init_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id;
 
     rc = yaksuri_seq_init_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info) {
+        yaksuri_info_s *infopriv = info->backend.priv;
+        if (infopriv->gpudriver_id == YAKSURI_GPUDRIVER_ID__LAST) {
+            /* gpu disabled */
+            goto fn_exit;
+        }
+    }
 
     /* CUDA hooks */
     id = YAKSURI_GPUDRIVER_ID__CUDA;

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -234,8 +234,20 @@ int yaksur_info_create_hook(yaksi_info_s * info)
 {
     int rc = YAKSA_SUCCESS;
 
+    info->backend.pre_init = !yaksu_atomic_load(&yaksi_is_initialized);
+
+    info->backend.priv = (yaksuri_info_s *) malloc(sizeof(yaksuri_info_s));
+
+    yaksuri_info_s *infopriv;
+    infopriv = (yaksuri_info_s *) info->backend.priv;
+    infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
+
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info->backend.pre_init) {
+        goto fn_exit;
+    }
 
     for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
@@ -245,12 +257,6 @@ int yaksur_info_create_hook(yaksi_info_s * info)
         rc = yaksuri_global.gpudriver[id].hooks->info_create(info);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
-
-    info->backend.priv = (yaksuri_info_s *) malloc(sizeof(yaksuri_info_s));
-
-    yaksuri_info_s *infopriv;
-    infopriv = (yaksuri_info_s *) info->backend.priv;
-    infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
 
   fn_exit:
     return rc;
@@ -266,6 +272,10 @@ int yaksur_info_free_hook(yaksi_info_s * info)
 
     rc = yaksuri_seq_info_free_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (info->backend.pre_init) {
+        goto fn_exit;
+    }
 
     for (yaksuri_gpudriver_id_e id = YAKSURI_GPUDRIVER_ID__UNSET;
          id < YAKSURI_GPUDRIVER_ID__LAST; id++) {

--- a/src/backend/src/yaksur_post.h
+++ b/src/backend/src/yaksur_post.h
@@ -10,7 +10,7 @@
 #include "yaksuri_cuda_post.h"
 #include "yaksuri_ze_post.h"
 
-int yaksur_init_hook(void);
+int yaksur_init_hook(yaksi_info_s * info);
 int yaksur_finalize_hook(void);
 int yaksur_type_create_hook(yaksi_type_s * type);
 int yaksur_type_free_hook(yaksi_type_s * type);

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -41,6 +41,7 @@ typedef struct {
 } yaksur_request_s;
 
 typedef struct {
+    bool pre_init;              /* set to true for info created before yaksa_init */
     yaksuri_seq_info_s seq;
     yaksuri_cuda_info_s cuda;
     yaksuri_ze_info_s ze;

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -158,7 +158,7 @@ int yaksa_init(yaksa_info_t info)
     /*************************************************************/
     /* initialize the backend */
     /*************************************************************/
-    rc = yaksur_init_hook();
+    rc = yaksur_init_hook((yaksi_info_s *) info);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
 


### PR DESCRIPTION
## Pull Request Description

Backport of gpu initialization skip feature.

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

Add more control over GPU initialization to MPICH 3.4.x series.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
