### PR TITLE
infohint: add nogpu as a gpudriver_id hint [0.1x]

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -303,6 +303,8 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
             infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__CUDA;
         } else if (!strncmp(val, "ze", vallen)) {
             infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__ZE;
+        } else if (!strncmp(val, "nogpu", vallen)) {
+            infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__LAST;
         } else {
             assert(0);
         }


### PR DESCRIPTION
## Pull Request Description

[previous backport missed the actual nogpu info hint addition]

Add a way for application to tell yaksa that both in_buf and out_buf are
host memory.

Signed-off-by: Hui Zhou <hzhou321@anl.gov>

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
