### PR TITLE
Add yaksa_pack_stream and yaksa_unpack_stream

### DIFF
--- a/maint/gentests.py
+++ b/maint/gentests.py
@@ -145,6 +145,8 @@ if __name__ == '__main__':
                        " -num-threads 4")
     gen_pack_iov_tests("pack", "test/pack/testlist.blocking.gen", True, \
                        " -blocking")
+    gen_pack_iov_tests("pack", "test/pack/testlist.stream.gen", True, \
+                       " -stream")
 
     gen_pack_iov_tests("iov", "test/iov/testlist.gen", False)
     gen_pack_iov_tests("iov", "test/iov/testlist.threads.gen", False, " -num-threads 4")

--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -204,7 +204,7 @@ def generate_host_function(b, darray):
             funcprefix = funcprefix + "%s_" % d
         funcprefix = funcprefix + b.replace(" ", "_")
 
-        yutils.display(OUTFILE, "void yaksuri_cudai_%s(const void *inbuf, void *outbuf, uintptr_t count, yaksa_op_t op, yaksuri_cudai_md_s *md, int n_threads, int n_blocks_x, int n_blocks_y, int n_blocks_z, int device)\n" % funcprefix)
+        yutils.display(OUTFILE, "void yaksuri_cudai_%s(const void *inbuf, void *outbuf, uintptr_t count, yaksa_op_t op, yaksuri_cudai_md_s *md, int n_threads, int n_blocks_x, int n_blocks_y, int n_blocks_z, cudaStream_t stream)\n" % funcprefix)
         yutils.display(OUTFILE, "{\n")
         yutils.display(OUTFILE, "void *args[] = { &inbuf, &outbuf, &count, &md };\n")
 
@@ -217,7 +217,7 @@ def generate_host_function(b, darray):
             funcprefix = funcprefix + b.replace(" ", "_")
             yutils.display(OUTFILE, "case YAKSA_OP__%s:\n" % op)
             yutils.display(OUTFILE, "cerr = cudaLaunchKernel((const void *) yaksuri_cudai_kernel_%s,\n" % funcprefix)
-            yutils.display(OUTFILE, "    dim3(n_blocks_x, n_blocks_y, n_blocks_z), dim3(n_threads), args, 0, yaksuri_cudai_global.stream[device]);\n")
+            yutils.display(OUTFILE, "    dim3(n_blocks_x, n_blocks_y, n_blocks_z), dim3(n_threads), args, 0, stream);\n")
             yutils.display(OUTFILE, "YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);\n")
             yutils.display(OUTFILE, "break;\n\n")
         yutils.display(OUTFILE, "}\n")
@@ -373,7 +373,7 @@ if __name__ == '__main__':
             OUTFILE.write("int n_blocks_x, ")
             OUTFILE.write("int n_blocks_y, ")
             OUTFILE.write("int n_blocks_z, ")
-            OUTFILE.write("int device);\n")
+            OUTFILE.write("cudaStream_t stream);\n")
         for darray in darraylist:
             # we don't need pup kernels for basic types
             if (len(darray) == 0):
@@ -395,7 +395,7 @@ if __name__ == '__main__':
                 OUTFILE.write("int n_blocks_x, ")
                 OUTFILE.write("int n_blocks_y, ")
                 OUTFILE.write("int n_blocks_z, ")
-                OUTFILE.write("int device);\n")
+                OUTFILE.write("cudaStream_t stream);\n")
 
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "#ifdef __cplusplus\n")

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -203,6 +203,7 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->event_record = yaksuri_cudai_event_record;
     (*hooks)->event_query = yaksuri_cudai_event_query;
     (*hooks)->add_dependency = yaksuri_cudai_add_dependency;
+    (*hooks)->launch_hostfn = yaksuri_cudai_launch_hostfn;
     (*hooks)->type_create = yaksuri_cudai_type_create_hook;
     (*hooks)->type_free = yaksuri_cudai_type_free_hook;
     (*hooks)->info_create = yaksuri_cudai_info_create_hook;

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -190,6 +190,8 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     (*hooks)->get_iov_unpack_threshold = yaksuri_cudai_get_iov_unpack_threshold;
     (*hooks)->ipack = yaksuri_cudai_ipack;
     (*hooks)->iunpack = yaksuri_cudai_iunpack;
+    (*hooks)->pack_with_stream = yaksuri_cudai_ipack_with_stream;
+    (*hooks)->unpack_with_stream = yaksuri_cudai_iunpack_with_stream;
     (*hooks)->synchronize = yaksuri_cudai_synchronize;
     (*hooks)->flush_all = yaksuri_cudai_flush_all;
     (*hooks)->pup_is_supported = yaksuri_cudai_pup_is_supported;

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -37,10 +37,10 @@ extern "C" {
 typedef struct yaksuri_cudai_type_s {
     void (*pack) (const void *inbuf, void *outbuf, uintptr_t count, yaksa_op_t op,
                   yaksuri_cudai_md_s * md, int n_threads, int n_blocks_x, int n_blocks_y,
-                  int n_blocks_z, int device);
+                  int n_blocks_z, cudaStream_t stream);
     void (*unpack) (const void *inbuf, void *outbuf, uintptr_t count, yaksa_op_t op,
                     yaksuri_cudai_md_s * md, int n_threads, int n_blocks_x, int n_blocks_y,
-                    int n_blocks_z, int device);
+                    int n_blocks_z, cudaStream_t stream);
     const char *name;
     yaksuri_cudai_md_s *md;
     pthread_mutex_t mdmutex;
@@ -80,6 +80,12 @@ int yaksuri_cudai_get_ptr_attr(const void *inbuf, void *outbuf, yaksi_info_s * i
 int yaksuri_cudai_md_alloc(yaksi_type_s * type);
 int yaksuri_cudai_populate_pupfns(yaksi_type_s * type);
 
+int yaksuri_cudai_ipack_with_stream(const void *inbuf, void *outbuf, uintptr_t count,
+                                    yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                    int target, void *stream);
+int yaksuri_cudai_iunpack_with_stream(const void *inbuf, void *outbuf, uintptr_t count,
+                                      yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                      int target, void *stream);
 int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                         yaksi_info_s * info, yaksa_op_t op, int target);
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -91,6 +91,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                           yaksi_info_s * info, yaksa_op_t op, int target);
 int yaksuri_cudai_synchronize(int target);
+int yaksuri_cudai_launch_hostfn(void *stream, yaksur_hostfn_t fn, void *userData);
 int yaksuri_cudai_flush_all(void);
 int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, yaksa_op_t op, bool * is_supported);
 uintptr_t yaksuri_cudai_get_iov_pack_threshold(yaksi_info_s * info);

--- a/src/backend/cuda/pup/yaksuri_cudai_event.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_event.c
@@ -111,3 +111,16 @@ int yaksuri_cudai_add_dependency(int device1, int device2)
   fn_fail:
     goto fn_exit;
 }
+
+int yaksuri_cudai_launch_hostfn(void *stream, yaksur_hostfn_t fn, void *userData)
+{
+    int rc = YAKSA_SUCCESS;
+    cudaError_t cerr;
+    cerr = cudaLaunchHostFunc(*(cudaStream_t *) stream, fn, userData);
+    YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -82,10 +82,12 @@ uintptr_t yaksuri_cudai_get_iov_unpack_threshold(yaksi_info_s * info)
     return iov_unpack_threshold;
 }
 
-int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                        yaksi_info_s * info, yaksa_op_t op, int target)
+int yaksuri_cudai_ipack_with_stream(const void *inbuf, void *outbuf, uintptr_t count,
+                                    yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                    int target, void *stream_p)
 {
     int rc = YAKSA_SUCCESS;
+    cudaStream_t stream = *(cudaStream_t *) stream_p;
     yaksuri_cudai_type_s *cuda_type = (yaksuri_cudai_type_s *) type->backend.cuda.priv;
     cudaError_t cerr;
 
@@ -97,7 +99,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
          * source buffer's GPU */
         cerr =
             cudaMemcpyAsync(outbuf, (const char *) inbuf + type->true_lb, count * type->size,
-                            cudaMemcpyDefault, yaksuri_cudai_global.stream[target]);
+                            cudaMemcpyDefault, stream);
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
     } else if (op == YAKSA_OP__REPLACE && type->size / type->num_contig >= iov_pack_threshold) {
         struct iovec iov[MAX_IOV_LENGTH];
@@ -110,8 +112,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
             YAKSU_ERR_CHECK(rc, fn_fail);
 
             for (uintptr_t i = 0; i < actual_iov_len; i++) {
-                cudaMemcpyAsync(dbuf, iov[i].iov_base, iov[i].iov_len, cudaMemcpyDefault,
-                                yaksuri_cudai_global.stream[target]);
+                cudaMemcpyAsync(dbuf, iov[i].iov_base, iov[i].iov_len, cudaMemcpyDefault, stream);
                 dbuf += iov[i].iov_len;
             }
 
@@ -134,7 +135,7 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
         cuda_type->pack(inbuf, outbuf, count, op, cuda_type->md, n_threads, n_blocks_x, n_blocks_y,
-                        n_blocks_z, target);
+                        n_blocks_z, stream);
 
         cerr = cudaSetDevice(cur_device);
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
@@ -146,10 +147,12 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     goto fn_exit;
 }
 
-int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                          yaksi_info_s * info, yaksa_op_t op, int target)
+int yaksuri_cudai_iunpack_with_stream(const void *inbuf, void *outbuf, uintptr_t count,
+                                      yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                      int target, void *stream_p)
 {
     int rc = YAKSA_SUCCESS;
+    cudaStream_t stream = *(cudaStream_t *) stream_p;
     yaksuri_cudai_type_s *cuda_type = (yaksuri_cudai_type_s *) type->backend.cuda.priv;
     cudaError_t cerr;
 
@@ -161,7 +164,7 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
          * source buffer's GPU */
         cerr =
             cudaMemcpyAsync((char *) outbuf + type->true_lb, inbuf, count * type->size,
-                            cudaMemcpyDefault, yaksuri_cudai_global.stream[target]);
+                            cudaMemcpyDefault, stream);
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
     } else if (op == YAKSA_OP__REPLACE && type->size / type->num_contig >= iov_unpack_threshold) {
         struct iovec iov[MAX_IOV_LENGTH];
@@ -174,8 +177,7 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
             YAKSU_ERR_CHECK(rc, fn_fail);
 
             for (uintptr_t i = 0; i < actual_iov_len; i++) {
-                cudaMemcpyAsync(iov[i].iov_base, sbuf, iov[i].iov_len, cudaMemcpyDefault,
-                                yaksuri_cudai_global.stream[target]);
+                cudaMemcpyAsync(iov[i].iov_base, sbuf, iov[i].iov_len, cudaMemcpyDefault, stream);
                 sbuf += iov[i].iov_len;
             }
 
@@ -198,7 +200,7 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
         cuda_type->unpack(inbuf, outbuf, count, op, cuda_type->md, n_threads, n_blocks_x,
-                          n_blocks_y, n_blocks_z, target);
+                          n_blocks_y, n_blocks_z, stream);
 
         cerr = cudaSetDevice(cur_device);
         YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
@@ -208,6 +210,20 @@ int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaks
     return rc;
   fn_fail:
     goto fn_exit;
+}
+
+int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                        yaksi_info_s * info, yaksa_op_t op, int target)
+{
+    return yaksuri_cudai_ipack_with_stream(inbuf, outbuf, count, type, info, op, target,
+                                           &yaksuri_cudai_global.stream[target]);
+}
+
+int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
+                          yaksi_info_s * info, yaksa_op_t op, int target)
+{
+    return yaksuri_cudai_iunpack_with_stream(inbuf, outbuf, count, type, info, op, target,
+                                             &yaksuri_cudai_global.stream[target]);
 }
 
 int yaksuri_cudai_synchronize(int target)

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -120,6 +120,9 @@ int yaksur_init_hook(yaksi_info_s * info)
         yaksuri_global.gpudriver[id].ndevices = ndevices;
     }
 
+    rc = yaksuri_progress_init();
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
   fn_exit:
     return rc;
   fn_fail:
@@ -129,6 +132,9 @@ int yaksur_init_hook(yaksi_info_s * info)
 int yaksur_finalize_hook(void)
 {
     int rc = YAKSA_SUCCESS;
+
+    rc = yaksuri_progress_finalize();
+    YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = yaksuri_seq_finalize_hook();
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -66,6 +66,12 @@ typedef struct yaksur_gpudriver_hooks_s {
                   int device);
     int (*iunpack) (const void *inbuf, void *outbuf, uintptr_t count, struct yaksi_type_s * type,
                     struct yaksi_info_s * info, yaksa_op_t op, int device);
+    int (*pack_with_stream) (const void *inbuf, void *outbuf, uintptr_t count,
+                             struct yaksi_type_s * type, struct yaksi_info_s * info, yaksa_op_t op,
+                             int device, void *stream);
+    int (*unpack_with_stream) (const void *inbuf, void *outbuf, uintptr_t count,
+                               struct yaksi_type_s * type, struct yaksi_info_s * info,
+                               yaksa_op_t op, int device, void *stream);
     int (*synchronize) (int device);    /* complete all outstanding tasks that are created by yaksa on the device */
     int (*flush_all) (void);
     int (*pup_is_supported) (struct yaksi_type_s * type, yaksa_op_t op, bool * is_supported);

--- a/src/backend/src/yaksur_pre.h
+++ b/src/backend/src/yaksur_pre.h
@@ -48,6 +48,8 @@ typedef struct {
     void *priv;
 } yaksur_info_s;
 
+typedef void (*yaksur_hostfn_t) (void *userData);
+
 typedef struct yaksur_gpudriver_hooks_s {
     /* miscellaneous */
     int (*get_num_devices) (int *ndevices);
@@ -75,6 +77,7 @@ typedef struct yaksur_gpudriver_hooks_s {
     int (*synchronize) (int device);    /* complete all outstanding tasks that are created by yaksa on the device */
     int (*flush_all) (void);
     int (*pup_is_supported) (struct yaksi_type_s * type, yaksa_op_t op, bool * is_supported);
+    int (*launch_hostfn) (void *stream, yaksur_hostfn_t fn, void *userData);
 
     /* memory management */
     void *(*host_malloc) (uintptr_t size);

--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -65,6 +65,8 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
         rc = yaksuri_seq_pup_is_supported(type, op, &is_supported);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
+        /* FIXME: check request-kind == YAKSI_REQUEST_KIND__CUDA_STREAM
+         *        if stream, we need enqueue seq_ipack/iunpack */
         if (!is_supported) {
             rc = YAKSA_ERR__NOT_SUPPORTED;
         } else {

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -105,5 +105,7 @@ typedef struct {
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                              yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request);
 int yaksuri_progress_poke(void);
+int yaksuri_progress_init(void);
+int yaksuri_progress_finalize(void);
 
 #endif /* YAKSURI_H_INCLUDED */

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1072,7 +1072,8 @@ static int singlechunk_pack(yaksuri_gpudriver_id_e id, int device, const void *i
 
     /* Try to complete immediately for blocking request to avoid overhead
      * caused by subreq enqueue and event management */
-    if (request->is_blocking && yaksuri_global.gpudriver[id].hooks->synchronize) {
+    if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
+        yaksuri_global.gpudriver[id].hooks->synchronize) {
         yaksuri_global.gpudriver[id].hooks->synchronize(device);
     } else {
         yaksuri_subreq_s *subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
@@ -1101,7 +1102,8 @@ static int singlechunk_unpack(yaksuri_gpudriver_id_e id, int device, const void 
 
     /* Try to complete immediately for blocking request to avoid overhead
      * caused by subreq enqueue and event management */
-    if (request->is_blocking && yaksuri_global.gpudriver[id].hooks->synchronize) {
+    if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
+        yaksuri_global.gpudriver[id].hooks->synchronize) {
         yaksuri_global.gpudriver[id].hooks->synchronize(device);
     } else {
         yaksuri_subreq_s *subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -79,14 +79,21 @@ static yaksi_type_s *get_base_type(yaksi_type_s * type)
 }
 
 static int icopy(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
-                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device)
+                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *base_type = get_base_type(type);
 
-    rc = yaksuri_global.gpudriver[id].hooks->ipack(inbuf, outbuf,
-                                                   count * type->size / base_type->size,
-                                                   base_type, info, op, device);
+    if (stream) {
+        rc = yaksuri_global.gpudriver[id].hooks->pack_with_stream(inbuf, outbuf,
+                                                                  count * type->size /
+                                                                  base_type->size, base_type, info,
+                                                                  op, device, stream);
+    } else {
+        rc = yaksuri_global.gpudriver[id].hooks->ipack(inbuf, outbuf,
+                                                       count * type->size / base_type->size,
+                                                       base_type, info, op, device);
+    }
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -96,11 +103,17 @@ static int icopy(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uin
 }
 
 static int ipack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
-                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device)
+                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = yaksuri_global.gpudriver[id].hooks->ipack(inbuf, outbuf, count, type, info, op, device);
+    if (stream) {
+        rc = yaksuri_global.gpudriver[id].hooks->pack_with_stream(inbuf, outbuf, count, type, info,
+                                                                  op, device, stream);
+    } else {
+        rc = yaksuri_global.gpudriver[id].hooks->ipack(inbuf, outbuf, count, type, info, op,
+                                                       device);
+    }
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -110,11 +123,18 @@ static int ipack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uin
 }
 
 static int iunpack(yaksuri_gpudriver_id_e id, const void *inbuf, void *outbuf, uintptr_t count,
-                   yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device)
+                   yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op, int device,
+                   void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = yaksuri_global.gpudriver[id].hooks->iunpack(inbuf, outbuf, count, type, info, op, device);
+    if (stream) {
+        rc = yaksuri_global.gpudriver[id].hooks->unpack_with_stream(inbuf, outbuf, count, type,
+                                                                    info, op, device, stream);
+    } else {
+        rc = yaksuri_global.gpudriver[id].hooks->iunpack(inbuf, outbuf, count, type, info, op,
+                                                         device);
+    }
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -260,6 +280,178 @@ static int simple_release(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subreq
     goto fn_exit;
 }
 
+/* Stream callback versions of alloc_chunk and simple_release */
+/* Assumption: for each stream, only one set of tempbufs need be active at a
+ * time */
+struct stream_buf {
+    yaksuri_gpudriver_id_e id;
+    void *stream;
+    int device;
+    void *buf;
+    yaksu_buffer_pool_s pool;
+    bool is_free;
+};
+
+struct stream_buf *stream_buf_list = NULL;
+int stream_buf_list_count = 0;
+int stream_buf_list_capacity = 0;
+
+static int stream_buf_list_grow(void)
+{
+    int rc = YAKSA_SUCCESS;
+    if (stream_buf_list_capacity == 0) {
+        stream_buf_list = malloc(10 * sizeof(struct stream_buf));
+        if (stream_buf_list == NULL) {
+            rc = YAKSA_ERR__OUT_OF_MEM;
+            goto fn_fail;
+        }
+        stream_buf_list_capacity = 10;
+    } else {
+        int new_capacity = stream_buf_list_capacity * 2;
+        void *new_list = realloc(stream_buf_list, new_capacity * sizeof(struct stream_buf));
+        if (new_list == NULL) {
+            rc = YAKSA_ERR__OUT_OF_MEM;
+            goto fn_fail;
+        }
+        stream_buf_list = new_list;
+        stream_buf_list_capacity = new_capacity;
+    }
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void stream_buf_list_free(void)
+{
+    if (stream_buf_list_capacity > 0) {
+        for (int i = 0; i < stream_buf_list_count; i++) {
+            int rc = yaksu_buffer_pool_elem_free(stream_buf_list[i].pool, stream_buf_list[i].buf);
+            assert(rc == YAKSA_SUCCESS);
+        }
+        free(stream_buf_list);
+        stream_buf_list_count = 0;
+        stream_buf_list_capacity = 0;
+    }
+}
+
+/* NOTE: we could use a hash to optimize; however, practically we don't expect
+ * the list to get long and the alloction is off the critical path anyway */
+/* Return index to stream_buf_list.
+ * Return -1 on error */
+static int alloc_stream_buf(yaksuri_gpudriver_id_e id, int device, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+
+    /* first check for existing allocations */
+    if (stream_buf_list_count > 0) {
+        for (int i = 0; i < stream_buf_list_count; i++) {
+            if (stream_buf_list[i].is_free && stream_buf_list[i].id == id &&
+                stream_buf_list[i].device == device && stream_buf_list[i].stream == stream) {
+                stream_buf_list[i].is_free = false;
+                return i;
+            }
+        }
+    }
+    /* potentially grow the capacity */
+    if (stream_buf_list_count == stream_buf_list_capacity) {
+        rc = stream_buf_list_grow();
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
+    /* get a new buffer */
+    void *buf;
+    yaksu_buffer_pool_s pool;
+    if (device >= 0) {
+        pool = yaksuri_global.gpudriver[id].device[device];
+    } else {
+        pool = yaksuri_global.gpudriver[id].host;
+    }
+    rc = yaksu_buffer_pool_elem_alloc(pool, &buf);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    int idx;
+    idx = stream_buf_list_count++;
+    stream_buf_list[idx].buf = buf;
+    stream_buf_list[idx].pool = pool;
+    stream_buf_list[idx].id = id;
+    stream_buf_list[idx].stream = stream;
+    stream_buf_list[idx].device = device;
+    stream_buf_list[idx].is_free = false;
+
+    return idx;
+  fn_fail:
+    return -1;
+}
+
+static void *get_stream_buf(int idx)
+{
+    return stream_buf_list[idx].buf;
+}
+
+static void free_stream_buf(int idx)
+{
+    stream_buf_list[idx].is_free = true;
+}
+
+static int alloc_tmpbufs(yaksuri_gpudriver_id_e id,
+                         int *tmpbufs, int num_tmpbufs, int *devices, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+
+    for (int i = 0; i < num_tmpbufs; i++) {
+        tmpbufs[i] = alloc_stream_buf(id, devices[i], stream);
+        if (tmpbufs[i] < 0) {
+            rc = YAKSA_ERR__OUT_OF_MEM;
+            goto fn_fail;
+        }
+    }
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* data used by stream callbacks */
+struct callback_chunk {
+    int err;
+    int tmpbufs[YAKSURI_SUBREQ_CHUNK_MAX_TMPBUFS];      /* indexes to stream_buf_list */
+    int num_tmpbufs;
+    /* following only needed by per-chunk callbacks */
+    const void *inbuf;
+    void *outbuf;
+    intptr_t count;
+    yaksi_type_s *type;
+    yaksa_op_t op;
+    yaksi_info_s *info;
+    /* offset will start as 0, incremented by each callbacks */
+    intptr_t count_offset;
+};
+
+/* called when we schedule chunk_free_stream_cb. This allows next stream
+ * operation to reuse the tmpbufs. */
+static void tmpbufs_stream_release(struct callback_chunk *chunk)
+{
+    for (int i = 0; i < chunk->num_tmpbufs; i++) {
+        free_stream_buf(chunk->tmpbufs[i]);
+    }
+}
+
+static void chunk_free_stream_cb(void *data)
+{
+    struct callback_chunk *chunk = data;
+    yaksi_type_free(chunk->type);
+    free(data);
+}
+
+/* Subroutines for multi-chunk pack
+ *   pack_d2d_p2p_acquire
+ *   pack_d2d_nop2p_acquire
+ *   pack_d2d_unaligned_acquire
+ *   pack_d2rh_acquire, pack_d2rh_release
+ *   pack_d2urh_acquire, pack_d2urh_release
+ *   pack_h2d_acquire
+ */
 static int pack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subreq,
                                 yaksuri_subreq_chunk_s ** chunk)
 {
@@ -308,19 +500,19 @@ static int pack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
         (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
 
     rc = ipack(id, sbuf, src_d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     if (op == YAKSA_OP__REPLACE) {
         rc = icopy(id, src_d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else if (buf_is_aligned(base_addr, subreq->u.multiple.type)) {
         rc = icopy(id, src_d_buf, dst_d_buf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = add_dependency(id, reqpriv->request->backend.inattr.device,
@@ -328,18 +520,19 @@ static int pack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, op, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else {
         rc = icopy(id, src_d_buf, dst_d_buf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dbuf, dst_d_buf2, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = add_dependency(id, reqpriv->request->backend.inattr.device,
@@ -347,11 +540,12 @@ static int pack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf, dst_d_buf2, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, op, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf2, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
@@ -413,11 +607,11 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
         (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
 
     rc = ipack(id, sbuf, src_d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = icopy(id, src_d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = add_dependency(id, reqpriv->request->backend.inattr.device,
@@ -426,31 +620,35 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
 
     if (op == YAKSA_OP__REPLACE) {
         rc = icopy(id, rh_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else if (buf_is_aligned(base_addr, subreq->u.multiple.type)) {
         rc = icopy(id, rh_buf, dst_d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, op, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else {
         rc = icopy(id, rh_buf, dst_d_buf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dbuf, dst_d_buf2, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf, dst_d_buf2, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, op, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dst_d_buf2, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
 
@@ -490,15 +688,15 @@ static int pack_d2d_unaligned_acquire(yaksuri_request_s * reqpriv, yaksuri_subre
         (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
 
     rc = icopy(id, dbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               op, reqpriv->request->backend.inattr.device);
+               op, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = icopy(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
@@ -544,16 +742,16 @@ static int pack_d2rh_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * sub
         subreq->u.multiple.type->size;
 
     rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     if (op == YAKSA_OP__REPLACE) {
         rc = icopy(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else {
         rc = icopy(id, d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
 
@@ -617,11 +815,11 @@ static int pack_d2urh_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * su
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
     rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = icopy(id, d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
@@ -704,31 +902,31 @@ static int pack_h2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subr
 
     if (op == YAKSA_OP__REPLACE) {
         rc = icopy(id, rh_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else if (buf_is_aligned(base_addr, subreq->u.multiple.type)) {
         rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   op, reqpriv->request->backend.outattr.device);
+                   op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else {
         rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, dbuf, d_buf2, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, d_buf, d_buf2, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   op, reqpriv->request->backend.outattr.device);
+                   op, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
 
         rc = icopy(id, d_buf2, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
         YAKSU_ERR_CHECK(rc, fn_fail);
     }
 
@@ -740,6 +938,15 @@ static int pack_h2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subr
   fn_fail:
     goto fn_exit;
 }
+
+/* Subroutines for multi-chunk unpack
+ *   unpack_d2d_p2p_acquire
+ *   unpack_d2d_nop2p_acquire
+ *   unpack_d2d_unaligned_acquire
+ *   unpack_rh2d_acquire
+ *   unpack_urh2d_acquire
+ *   unpack_d2h_acquire, unpack_d2h_release
+ */
 
 static int unpack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subreq,
                                   yaksuri_subreq_chunk_s ** chunk)
@@ -769,7 +976,7 @@ static int unpack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
     rc = icopy(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = add_dependency(id, reqpriv->request->backend.inattr.device,
@@ -777,7 +984,7 @@ static int unpack_d2d_p2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device);
+                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
@@ -818,7 +1025,7 @@ static int unpack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
     rc = icopy(id, sbuf, rh_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = add_dependency(id, reqpriv->request->backend.inattr.device,
@@ -826,11 +1033,12 @@ static int unpack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                 reqpriv->info, subreq->u.multiple.op, reqpriv->request->backend.outattr.device);
+                 reqpriv->info, subreq->u.multiple.op, reqpriv->request->backend.outattr.device,
+                 NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
@@ -868,11 +1076,11 @@ static int unpack_d2d_unaligned_acquire(yaksuri_request_s * reqpriv, yaksuri_sub
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
     rc = icopy(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                 subreq->u.multiple.op, reqpriv->request->backend.inattr.device);
+                 subreq->u.multiple.op, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
@@ -910,11 +1118,11 @@ static int unpack_rh2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * s
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
     rc = icopy(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device);
+                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
@@ -961,11 +1169,11 @@ static int unpack_urh2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device);
+                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
@@ -1000,7 +1208,7 @@ static int unpack_d2h_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * su
         (*chunk)->count_offset * subreq->u.multiple.type->size;
 
     rc = icopy(id, sbuf, rh_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device);
+               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
@@ -1059,21 +1267,942 @@ static int set_multichunk_subreq(const void *inbuf, void *outbuf, uintptr_t coun
     return rc;
 }
 
+/* Subroutines for multi-chunk stream pack
+ *   pack_d2d_p2p_stream
+ *   pack_d2d_nop2p_stream
+ *   pack_d2d_unaligned_stream
+ *   pack_d2rh_stream_cb, pack_d2rh_stream
+ *   pack_d2urh_stream_cb, pack_d2urh_stream
+ *   pack_h2d_stream_cb, pack_h2d_stream
+ */
+
+static int pack_d2d_p2p_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                               uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+    int out_device = reqpriv->request->backend.outattr.device;
+    assert(in_device != out_device);
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    /* allocate tmpbufs */
+    int devices[] = { in_device, out_device, out_device };
+
+    void *base_addr = (char *) outbuf + type->true_lb;
+    if (op == YAKSA_OP__REPLACE) {
+        chunk->num_tmpbufs = 1;
+    } else if (buf_is_aligned(base_addr, type)) {
+        chunk->num_tmpbufs = 2;
+    } else {
+        chunk->num_tmpbufs = 3;
+    }
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *src_d_buf, *dst_d_buf, *dst_d_buf2;
+    src_d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    dst_d_buf = NULL;
+    dst_d_buf2 = NULL;
+    if (chunk->num_tmpbufs > 1) {
+        dst_d_buf = get_stream_buf(chunk->tmpbufs[1]);
+    }
+    if (chunk->num_tmpbufs > 2) {
+        dst_d_buf2 = get_stream_buf(chunk->tmpbufs[2]);
+    }
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->extent;
+        char *dbuf = (char *) outbuf + count_offset * type->size;
+
+        rc = ipack(id, sbuf, src_d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (op == YAKSA_OP__REPLACE) {
+            rc = icopy(id, src_d_buf, dbuf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, in_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else if (buf_is_aligned(base_addr, type)) {
+            rc = icopy(id, src_d_buf, dst_d_buf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, in_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf, dbuf, chunk_count, type,
+                       reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = icopy(id, src_d_buf, dst_d_buf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, in_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dbuf, dst_d_buf2, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf, dst_d_buf2, chunk_count, type,
+                       reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf2, dbuf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2d_nop2p_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                                 uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+    int out_device = reqpriv->request->backend.outattr.device;
+    assert(in_device != out_device);
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    /* allocate tmpbufs */
+    int devices[] = { in_device, -1, out_device, out_device };
+
+    void *base_addr = (char *) outbuf + type->true_lb;
+    if (op == YAKSA_OP__REPLACE) {
+        chunk->num_tmpbufs = 2;
+    } else if (buf_is_aligned(base_addr, type)) {
+        chunk->num_tmpbufs = 3;
+    } else {
+        chunk->num_tmpbufs = 4;
+    }
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *src_d_buf, *rh_buf, *dst_d_buf, *dst_d_buf2;
+    src_d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+    dst_d_buf = NULL;
+    dst_d_buf2 = NULL;
+    if (chunk->num_tmpbufs > 2) {
+        dst_d_buf = get_stream_buf(chunk->tmpbufs[2]);
+    }
+    if (chunk->num_tmpbufs > 3) {
+        dst_d_buf2 = get_stream_buf(chunk->tmpbufs[3]);
+    }
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->extent;
+        char *dbuf = (char *) outbuf + count_offset * type->size;
+
+        rc = ipack(id, sbuf, src_d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, src_d_buf, rh_buf, chunk_count, type,
+                   reqpriv->info, YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (op == YAKSA_OP__REPLACE) {
+            rc = icopy(id, rh_buf, dbuf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else if (buf_is_aligned(base_addr, type)) {
+            rc = icopy(id, rh_buf, dst_d_buf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf, dbuf, chunk_count, type,
+                       reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = icopy(id, rh_buf, dst_d_buf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dbuf, dst_d_buf2, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf, dst_d_buf2, chunk_count, type,
+                       reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dst_d_buf2, dbuf, chunk_count, type,
+                       reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int pack_d2d_unaligned_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                                     uintptr_t count, yaksi_type_s * type, yaksa_op_t op,
+                                     void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { in_device };
+    chunk->num_tmpbufs = 1;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->extent;
+        char *dbuf = (char *) outbuf + count_offset * type->size;
+
+        rc = icopy(id, dbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = ipack(id, sbuf, d_buf, chunk_count, type, reqpriv->info, op, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, d_buf, dbuf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void pack_d2rh_stream_cb(void *data)
+{
+    struct callback_chunk *chunk = data;
+
+    yaksa_op_t op = chunk->op;
+    yaksi_type_s *type = chunk->type;
+
+    assert(op != YAKSA_OP__REPLACE);
+
+    yaksi_type_s *base_type = get_base_type(type);
+    char *dbuf = (char *) chunk->outbuf + chunk->count_offset * type->size;
+
+    intptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    intptr_t chunk_count = YAKSU_MIN(count_per_chunk, chunk->count - chunk->count_offset);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    int rc;
+    rc = yaksuri_seq_ipack(rh_buf, dbuf,
+                           chunk_count * type->size / base_type->size, base_type, chunk->info, op);
+    assert(rc == YAKSA_SUCCESS);
+    chunk->count_offset += chunk_count;
+}
+
+static int pack_d2rh_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                            uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { in_device, -1 };
+    if (op == YAKSA_OP__REPLACE) {
+        chunk->num_tmpbufs = 1;
+    } else {
+        chunk->num_tmpbufs = 2;
+    }
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf, *rh_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    if (chunk->num_tmpbufs > 1) {
+        rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+    } else {
+        rh_buf = NULL;
+    }
+
+    /* setup chunk for pack_d2rh_stream_cb */
+    if (op != YAKSA_OP__REPLACE) {
+        chunk->inbuf = inbuf;
+        chunk->outbuf = outbuf;
+        chunk->op = op;
+        chunk->info = reqpriv->info;
+        chunk->count = count;
+        chunk->count_offset = 0;
+    }
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->extent;
+        char *dbuf = (char *) outbuf + count_offset * type->size;
+
+        rc = ipack(id, sbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (op == YAKSA_OP__REPLACE) {
+            rc = icopy(id, d_buf, dbuf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, in_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = icopy(id, d_buf, rh_buf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, in_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+        /* pack op on the host buffer */
+        if (op != YAKSA_OP__REPLACE) {
+            rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, pack_d2rh_stream_cb,
+                                                                   chunk);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void pack_d2urh_stream_cb(void *data)
+{
+    struct callback_chunk *chunk = data;
+
+    yaksa_op_t op = chunk->op;
+    yaksi_type_s *type = chunk->type;
+
+    yaksi_type_s *base_type = get_base_type(type);
+    char *dbuf = (char *) chunk->outbuf + chunk->count_offset * type->size;
+
+    intptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    intptr_t chunk_count = YAKSU_MIN(count_per_chunk, chunk->count - chunk->count_offset);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    int rc;
+    rc = yaksuri_seq_ipack(rh_buf, dbuf,
+                           chunk_count * type->size / base_type->size, base_type, chunk->info, op);
+    assert(rc == YAKSA_SUCCESS);
+    chunk->count_offset += chunk_count;
+}
+
+static int pack_d2urh_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                             uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { in_device, -1 };
+    chunk->num_tmpbufs = 2;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf, *rh_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    /* setup chunk for pack_d2urh_stream_cb */
+    chunk->inbuf = inbuf;
+    chunk->outbuf = outbuf;
+    chunk->op = op;
+    chunk->info = reqpriv->info;
+    chunk->count = count;
+    chunk->count_offset = 0;
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->extent;
+
+        rc = ipack(id, sbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, d_buf, rh_buf, chunk_count, type,
+                   reqpriv->info, YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, pack_d2urh_stream_cb, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void pack_h2d_stream_cb(void *data)
+{
+    int rc;
+    struct callback_chunk *chunk = data;
+
+    yaksi_type_s *type = chunk->type;
+
+    yaksi_type_s *byte_type;
+    rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
+    assert(rc == YAKSA_SUCCESS);
+
+    const char *sbuf = (const char *) chunk->inbuf + chunk->count_offset * type->size;
+
+    intptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    intptr_t chunk_count = YAKSU_MIN(count_per_chunk, chunk->count - chunk->count_offset);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    rc = yaksuri_seq_ipack(sbuf, rh_buf, chunk_count, type, chunk->info, YAKSA_OP__REPLACE);
+    assert(rc == YAKSA_SUCCESS);
+    chunk->count_offset += chunk_count;
+}
+
+static int pack_h2d_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                           uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int out_device = reqpriv->request->backend.outattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { -1, out_device, out_device };
+    void *base_addr = (char *) outbuf + type->true_lb;
+    if (op == YAKSA_OP__REPLACE) {
+        chunk->num_tmpbufs = 1;
+    } else if (buf_is_aligned(base_addr, type)) {
+        chunk->num_tmpbufs = 2;
+    } else {
+        chunk->num_tmpbufs = 3;
+    }
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *rh_buf, *d_buf, *d_buf2;
+    rh_buf = get_stream_buf(chunk->tmpbufs[0]);
+    d_buf = NULL;
+    d_buf2 = NULL;
+    if (chunk->num_tmpbufs > 1) {
+        d_buf = get_stream_buf(chunk->tmpbufs[1]);
+    }
+    if (chunk->num_tmpbufs > 2) {
+        d_buf2 = get_stream_buf(chunk->tmpbufs[2]);
+    }
+
+    /* setup chunk for pack_h2d_stream_cb */
+    chunk->inbuf = inbuf;
+    chunk->outbuf = outbuf;
+    chunk->op = op;
+    chunk->info = reqpriv->info;
+    chunk->count = count;
+    chunk->count_offset = 0;
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        char *dbuf = (char *) outbuf + count_offset * type->size;
+
+        rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, pack_h2d_stream_cb, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (op == YAKSA_OP__REPLACE) {
+            rc = icopy(id, rh_buf, dbuf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else if (buf_is_aligned(base_addr, type)) {
+            rc = icopy(id, rh_buf, d_buf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = icopy(id, rh_buf, d_buf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, dbuf, d_buf2, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, d_buf, d_buf2, chunk_count, type, reqpriv->info, op, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            rc = icopy(id, d_buf2, dbuf, chunk_count, type, reqpriv->info,
+                       YAKSA_OP__REPLACE, out_device, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        }
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+/* Subroutines for multi-chunk stream unpack
+ *   unpack_d2d_p2p_stream
+ *   unpack_d2d_nop2p_stream
+ *   unpack_d2d_unaligned_stream
+ *   unpack_rh2d_stream
+ *   unpack_urh2d_stream
+ *   unpack_d2h_stream_cb, unpack_d2h_stream
+ */
+
+static int unpack_d2d_p2p_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                                 uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+    int out_device = reqpriv->request->backend.outattr.device;
+    assert(in_device != out_device);
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { out_device };
+    chunk->num_tmpbufs = 1;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->size;
+        char *dbuf = (char *) outbuf + count_offset * type->extent;
+
+        rc = icopy(id, sbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = iunpack(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_d2d_nop2p_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                                   uintptr_t count, yaksi_type_s * type, yaksa_op_t op,
+                                   void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+    int out_device = reqpriv->request->backend.outattr.device;
+    assert(in_device != out_device);
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { out_device, -1 };
+    chunk->num_tmpbufs = 2;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf, *rh_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->size;
+        char *dbuf = (char *) outbuf + count_offset * type->extent;
+
+        rc = icopy(id, sbuf, rh_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, rh_buf, d_buf, chunk_count, type,
+                   reqpriv->info, YAKSA_OP__REPLACE, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = iunpack(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_d2d_unaligned_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                                       uintptr_t count, yaksi_type_s * type, yaksa_op_t op,
+                                       void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { in_device };
+    chunk->num_tmpbufs = 1;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->size;
+        char *dbuf = (char *) outbuf + count_offset * type->extent;
+
+        rc = icopy(id, sbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = iunpack(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static int unpack_rh2d_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                              uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int out_device = reqpriv->request->backend.outattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { out_device };
+    chunk->num_tmpbufs = 1;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->size;
+        char *dbuf = (char *) outbuf + count_offset * type->extent;
+
+        rc = icopy(id, sbuf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = iunpack(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void unpack_urh2d_stream_cb(void *data)
+{
+    int rc;
+    struct callback_chunk *chunk = data;
+
+    yaksi_type_s *type = chunk->type;
+
+    yaksi_type_s *byte_type;
+    rc = yaksi_type_get(YAKSA_TYPE__BYTE, &byte_type);
+    assert(rc == YAKSA_SUCCESS);
+
+    const char *sbuf = (const char *) chunk->inbuf + chunk->count_offset * type->size;
+
+    intptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    intptr_t chunk_count = YAKSU_MIN(count_per_chunk, chunk->count - chunk->count_offset);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    rc = yaksuri_seq_ipack(sbuf, rh_buf, chunk_count * type->size, byte_type,
+                           chunk->info, YAKSA_OP__REPLACE);
+    assert(rc == YAKSA_SUCCESS);
+    chunk->count_offset += chunk_count;
+}
+
+static int unpack_urh2d_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                               uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int out_device = reqpriv->request->backend.outattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { out_device, -1 };
+    chunk->num_tmpbufs = 2;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *d_buf, *rh_buf;
+    d_buf = get_stream_buf(chunk->tmpbufs[0]);
+    rh_buf = get_stream_buf(chunk->tmpbufs[1]);
+
+    /* setup chunk for unpack_urh2d_stream_cb */
+    chunk->inbuf = inbuf;
+    chunk->outbuf = outbuf;
+    chunk->info = reqpriv->info;
+    chunk->count = count;
+    chunk->count_offset = 0;
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        char *dbuf = (char *) outbuf + count_offset * type->extent;
+
+        rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, unpack_urh2d_stream_cb,
+                                                               chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = icopy(id, rh_buf, d_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = iunpack(id, d_buf, dbuf, chunk_count, type, reqpriv->info, op, out_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
+static void unpack_d2h_stream_cb(void *data)
+{
+    struct callback_chunk *chunk = data;
+
+    yaksa_op_t op = chunk->op;
+    yaksi_type_s *type = chunk->type;
+
+    char *dbuf = (char *) chunk->outbuf + chunk->count_offset * type->size;
+
+    intptr_t count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    intptr_t chunk_count = YAKSU_MIN(count_per_chunk, chunk->count - chunk->count_offset);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    int rc;
+    rc = yaksuri_seq_iunpack(rh_buf, dbuf, chunk_count, type, chunk->info, op);
+    assert(rc == YAKSA_SUCCESS);
+    chunk->count_offset += chunk_count;
+}
+
+static int unpack_d2h_stream(yaksuri_request_s * reqpriv, const void *inbuf, void *outbuf,
+                             uintptr_t count, yaksi_type_s * type, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+    yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    int in_device = reqpriv->request->backend.inattr.device;
+
+    struct callback_chunk *chunk = malloc(sizeof(struct callback_chunk));
+    assert(chunk);
+
+    chunk->type = type;
+    yaksu_atomic_incr(&type->refcount);
+
+    int devices[] = { -1 };
+    chunk->num_tmpbufs = 1;
+    rc = alloc_tmpbufs(id, chunk->tmpbufs, chunk->num_tmpbufs, devices, stream);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    void *rh_buf;
+    rh_buf = get_stream_buf(chunk->tmpbufs[0]);
+
+    /* setup chunk for unpack_d2h_stream_cb */
+    chunk->inbuf = inbuf;
+    chunk->outbuf = outbuf;
+    chunk->op = op;
+    chunk->info = reqpriv->info;
+    chunk->count = count;
+    chunk->count_offset = 0;
+
+    intptr_t count_per_chunk, count_offset;
+    count_per_chunk = YAKSURI_TMPBUF_EL_SIZE / type->size;
+    count_offset = 0;
+    while (count_offset < count) {
+        intptr_t chunk_count = YAKSU_MIN(count_per_chunk, count - count_offset);
+        const char *sbuf = (const char *) inbuf + count_offset * type->size;
+
+        rc = icopy(id, sbuf, rh_buf, chunk_count, type, reqpriv->info,
+                   YAKSA_OP__REPLACE, in_device, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, unpack_d2h_stream_cb, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        count_offset += chunk_count;
+    }
+    tmpbufs_stream_release(chunk);
+    rc = yaksuri_global.gpudriver[id].hooks->launch_hostfn(stream, chunk_free_stream_cb, chunk);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}
+
 /* Fast-path pack subroutine */
 static int singlechunk_pack(yaksuri_gpudriver_id_e id, int device, const void *inbuf, void *outbuf,
                             uintptr_t count, yaksi_type_s * type, yaksi_info_s * info,
                             yaksa_op_t op, yaksi_request_s * request,
-                            yaksuri_subreq_s ** subreq_ptr)
+                            yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = ipack(id, inbuf, outbuf, count, type, info, op, device);
+    rc = ipack(id, inbuf, outbuf, count, type, info, op, device, stream);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    /* Try to complete immediately for blocking request to avoid overhead
-     * caused by subreq enqueue and event management */
-    if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
-        yaksuri_global.gpudriver[id].hooks->synchronize) {
+    if (stream) {
+        /* all done */
+    } else if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
+               /* Try to complete immediately for blocking request to avoid overhead
+                * caused by subreq enqueue and event management */
+               yaksuri_global.gpudriver[id].hooks->synchronize) {
         yaksuri_global.gpudriver[id].hooks->synchronize(device);
     } else {
         yaksuri_subreq_s *subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
@@ -1093,17 +2222,19 @@ static int singlechunk_pack(yaksuri_gpudriver_id_e id, int device, const void *i
 static int singlechunk_unpack(yaksuri_gpudriver_id_e id, int device, const void *inbuf,
                               void *outbuf, uintptr_t count, yaksi_type_s * type,
                               yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request,
-                              yaksuri_subreq_s ** subreq_ptr)
+                              yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = iunpack(id, inbuf, outbuf, count, type, info, op, device);
+    rc = iunpack(id, inbuf, outbuf, count, type, info, op, device, stream);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    /* Try to complete immediately for blocking request to avoid overhead
-     * caused by subreq enqueue and event management */
-    if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
-        yaksuri_global.gpudriver[id].hooks->synchronize) {
+    if (stream) {
+        /* all done */
+    } else if (request->kind == YAKSI_REQUEST_KIND__BLOCKING &&
+               /* Try to complete immediately for blocking request to avoid overhead
+                * caused by subreq enqueue and event management */
+               yaksuri_global.gpudriver[id].hooks->synchronize) {
         yaksuri_global.gpudriver[id].hooks->synchronize(device);
     } else {
         yaksuri_subreq_s *subreq = (yaksuri_subreq_s *) malloc(sizeof(yaksuri_subreq_s));
@@ -1119,11 +2250,18 @@ static int singlechunk_unpack(yaksuri_gpudriver_id_e id, int device, const void 
     goto fn_exit;
 }
 
-/* Subroutines to setup subreq for pack with different buffer types */
+/* Subroutines to setup subreq for pack with different buffer types
+ *   set_subreq_pack_d2d
+ *   set_subreq_pack_d2m
+ *   set_subreq_pack_d2rh
+ *   set_subreq_pack_from_device
+ *   set_subreq_pack_from_managed
+ *   set_subreq_pack_from_rhost
+ */
 static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                               yaksuri_subreq_s ** subreq_ptr)
+                               yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1137,32 +2275,46 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
          check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                         reqpriv->request->backend.outattr.device)) && aligned) {
         rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                              type, info, op, request, subreq_ptr);
+                              type, info, op, request, subreq_ptr, stream);
     }
     /* Fast path for other reduce operations with aligned buffer on the same device */
     else if (request->backend.inattr.device == request->backend.outattr.device && aligned) {
         rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                              type, info, op, request, subreq_ptr);
+                              type, info, op, request, subreq_ptr, stream);
     }
     /* Slow paths */
     else if (request->backend.inattr.device == request->backend.outattr.device) {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_d2d_unaligned_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_d2d_unaligned_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_d2d_unaligned_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     } else {
         bool is_enabled = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                                          reqpriv->request->backend.outattr.device);
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (is_enabled) {
-            (*subreq_ptr)->u.multiple.acquire = pack_d2d_p2p_acquire;
+        if (stream) {
+            if (is_enabled) {
+                rc = pack_d2d_p2p_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            } else {
+                rc = pack_d2d_nop2p_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            }
+            YAKSU_ERR_CHECK(rc, fn_fail);
         } else {
-            (*subreq_ptr)->u.multiple.acquire = pack_d2d_nop2p_acquire;
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+
+            if (is_enabled) {
+                (*subreq_ptr)->u.multiple.acquire = pack_d2d_p2p_acquire;
+            } else {
+                (*subreq_ptr)->u.multiple.acquire = pack_d2d_nop2p_acquire;
+            }
+            (*subreq_ptr)->u.multiple.release = simple_release;
         }
-        (*subreq_ptr)->u.multiple.release = simple_release;
     }
 
   fn_exit:
@@ -1174,7 +2326,7 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
 static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                               yaksuri_subreq_s ** subreq_ptr)
+                               yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1184,22 +2336,32 @@ static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
          request->backend.inattr.device == request->backend.outattr.device) &&
         buf_is_aligned(outbuf, type)) {
         rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count, type, info,
-                              op, request, subreq_ptr);
+                              op, request, subreq_ptr, stream);
     }
     /* Slow paths */
     else if (request->backend.outattr.device == -1 ||
              request->backend.inattr.device == request->backend.outattr.device) {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_d2d_unaligned_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_d2d_unaligned_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_d2d_unaligned_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     } else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_d2urh_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_d2urh_acquire;
-        (*subreq_ptr)->u.multiple.release = pack_d2urh_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_d2urh_acquire;
+            (*subreq_ptr)->u.multiple.release = pack_d2urh_release;
+        }
     }
 
   fn_exit:
@@ -1211,7 +2373,7 @@ static int set_subreq_pack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
 static int set_subreq_pack_d2rh(const void *inbuf, void *outbuf, uintptr_t count,
                                 yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                 yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                yaksuri_subreq_s ** subreq_ptr)
+                                yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1220,15 +2382,20 @@ static int set_subreq_pack_d2rh(const void *inbuf, void *outbuf, uintptr_t count
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
         rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                              type, info, op, request, subreq_ptr);
+                              type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_d2rh_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_d2rh_acquire;
-        (*subreq_ptr)->u.multiple.release = pack_d2rh_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_d2rh_acquire;
+            (*subreq_ptr)->u.multiple.release = pack_d2rh_release;
+        }
     }
 
   fn_exit:
@@ -1240,30 +2407,35 @@ static int set_subreq_pack_d2rh(const void *inbuf, void *outbuf, uintptr_t count
 static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_t count,
                                        yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                        yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                       yaksuri_subreq_s ** subreq_ptr)
+                                       yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
     switch (request->backend.outattr.type) {
         case YAKSUR_PTR_TYPE__GPU:
             rc = set_subreq_pack_d2d(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                     subreq_ptr);
+                                     subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__MANAGED:
             rc = set_subreq_pack_d2m(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                     subreq_ptr);
+                                     subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__REGISTERED_HOST:
             rc = set_subreq_pack_d2rh(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                      subreq_ptr);
+                                      subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
         default:
-            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-            YAKSU_ERR_CHECK(rc, fn_fail);
+            if (stream) {
+                rc = pack_d2urh_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            } else {
+                rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+                YAKSU_ERR_CHECK(rc, fn_fail);
 
-            (*subreq_ptr)->u.multiple.acquire = pack_d2urh_acquire;
-            (*subreq_ptr)->u.multiple.release = pack_d2urh_release;
+                (*subreq_ptr)->u.multiple.acquire = pack_d2urh_acquire;
+                (*subreq_ptr)->u.multiple.release = pack_d2urh_release;
+            }
     }
 
   fn_exit:
@@ -1275,7 +2447,7 @@ static int set_subreq_pack_from_device(const void *inbuf, void *outbuf, uintptr_
 static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr_t count,
                                         yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                         yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                        yaksuri_subreq_s ** subreq_ptr)
+                                        yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1285,15 +2457,20 @@ static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr
          request->backend.inattr.device == request->backend.outattr.device) &&
         buf_is_aligned(outbuf, type)) {
         rc = singlechunk_pack(id, request->backend.outattr.device, inbuf, outbuf, count, type, info,
-                              op, request, subreq_ptr);
+                              op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_h2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_h2d_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_h2d_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     }
 
   fn_exit:
@@ -1305,7 +2482,7 @@ static int set_subreq_pack_from_managed(const void *inbuf, void *outbuf, uintptr
 static int set_subreq_pack_from_rhost(const void *inbuf, void *outbuf, uintptr_t count,
                                       yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                       yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                      yaksuri_subreq_s ** subreq_ptr)
+                                      yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1314,15 +2491,20 @@ static int set_subreq_pack_from_rhost(const void *inbuf, void *outbuf, uintptr_t
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
         rc = singlechunk_pack(id, request->backend.outattr.device, inbuf, outbuf, count,
-                              type, info, op, request, subreq_ptr);
+                              type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = pack_h2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = pack_h2d_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = pack_h2d_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     }
 
   fn_exit:
@@ -1331,11 +2513,18 @@ static int set_subreq_pack_from_rhost(const void *inbuf, void *outbuf, uintptr_t
     goto fn_exit;
 }
 
-/* Subroutines to setup subreq for unpack with different buffer types */
+/* Subroutines to setup subreq for unpack with different buffer types
+ *   set_subreq_unpack_d2d
+ *   set_subreq_unpack_d2m
+ *   set_subreq_unpack_d2rh
+ *   set_subreq_unpack_from_device
+ *   set_subreq_unpack_from_managed
+ *   set_subreq_unpack_from_rhost
+ */
 static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
                                  yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                  yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                 yaksuri_subreq_s ** subreq_ptr)
+                                 yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1349,33 +2538,46 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
          check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                         reqpriv->request->backend.outattr.device)) && aligned) {
         rc = singlechunk_unpack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Fast path for other reduce operations with aligned buffer on the same device */
     else if (request->backend.inattr.device == request->backend.outattr.device && aligned) {
         rc = singlechunk_unpack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Slow paths */
     else if (request->backend.inattr.device == request->backend.outattr.device) {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = unpack_d2d_unaligned_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = unpack_d2d_unaligned_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = unpack_d2d_unaligned_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     } else {
         bool is_enabled = check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                                          reqpriv->request->backend.outattr.device);
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
-
-        if (is_enabled) {
-            (*subreq_ptr)->u.multiple.acquire = unpack_d2d_p2p_acquire;
+        if (stream) {
+            if (is_enabled) {
+                rc = unpack_d2d_p2p_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            } else {
+                rc = unpack_d2d_nop2p_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            }
+            YAKSU_ERR_CHECK(rc, fn_fail);
         } else {
-            (*subreq_ptr)->u.multiple.acquire = unpack_d2d_nop2p_acquire;
-        }
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
+            if (is_enabled) {
+                (*subreq_ptr)->u.multiple.acquire = unpack_d2d_p2p_acquire;
+            } else {
+                (*subreq_ptr)->u.multiple.acquire = unpack_d2d_nop2p_acquire;
+            }
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     }
 
   fn_exit:
@@ -1387,7 +2589,7 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
 static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t count,
                                  yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                  yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                 yaksuri_subreq_s ** subreq_ptr)
+                                 yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1397,15 +2599,20 @@ static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t coun
          request->backend.inattr.device == request->backend.outattr.device) &&
         buf_is_aligned(inbuf, type)) {
         rc = singlechunk_unpack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = unpack_d2h_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
-        (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+            (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
+            (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+        }
     }
 
   fn_exit:
@@ -1417,7 +2624,7 @@ static int set_subreq_unpack_d2m(const void *inbuf, void *outbuf, uintptr_t coun
 static int set_subreq_unpack_d2rh(const void *inbuf, void *outbuf, uintptr_t count,
                                   yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                   yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                  yaksuri_subreq_s ** subreq_ptr)
+                                  yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1426,15 +2633,20 @@ static int set_subreq_unpack_d2rh(const void *inbuf, void *outbuf, uintptr_t cou
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
         rc = singlechunk_unpack(id, request->backend.inattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = unpack_d2h_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
-        (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+            (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
+            (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+        }
     }
 
   fn_exit:
@@ -1446,30 +2658,35 @@ static int set_subreq_unpack_d2rh(const void *inbuf, void *outbuf, uintptr_t cou
 static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintptr_t count,
                                          yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                          yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                         yaksuri_subreq_s ** subreq_ptr)
+                                         yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 
     switch (request->backend.outattr.type) {
         case YAKSUR_PTR_TYPE__GPU:
             rc = set_subreq_unpack_d2d(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                       subreq_ptr);
+                                       subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__MANAGED:
             rc = set_subreq_unpack_d2m(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                       subreq_ptr);
+                                       subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__REGISTERED_HOST:
             rc = set_subreq_unpack_d2rh(inbuf, outbuf, count, type, info, op, request, reqpriv,
-                                        subreq_ptr);
+                                        subreq_ptr, stream);
             break;
         case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
         default:
-            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-            YAKSU_ERR_CHECK(rc, fn_fail);
+            if (stream) {
+                rc = unpack_d2h_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+                YAKSU_ERR_CHECK(rc, fn_fail);
+            } else {
+                rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+                YAKSU_ERR_CHECK(rc, fn_fail);
 
-            (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
-            (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+                (*subreq_ptr)->u.multiple.acquire = unpack_d2h_acquire;
+                (*subreq_ptr)->u.multiple.release = unpack_d2h_release;
+            }
     }
 
   fn_exit:
@@ -1481,7 +2698,7 @@ static int set_subreq_unpack_from_device(const void *inbuf, void *outbuf, uintpt
 static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintptr_t count,
                                           yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                           yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                          yaksuri_subreq_s ** subreq_ptr)
+                                          yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1491,15 +2708,20 @@ static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintp
          request->backend.inattr.device == request->backend.outattr.device) &&
         buf_is_aligned(inbuf, type)) {
         rc = singlechunk_unpack(id, request->backend.outattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = unpack_urh2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = unpack_urh2d_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = unpack_urh2d_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     }
 
   fn_exit:
@@ -1511,7 +2733,7 @@ static int set_subreq_unpack_from_managed(const void *inbuf, void *outbuf, uintp
 static int set_subreq_unpack_from_rhost(const void *inbuf, void *outbuf, uintptr_t count,
                                         yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
                                         yaksi_request_s * request, yaksuri_request_s * reqpriv,
-                                        yaksuri_subreq_s ** subreq_ptr)
+                                        yaksuri_subreq_s ** subreq_ptr, void *stream)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
@@ -1520,15 +2742,20 @@ static int set_subreq_unpack_from_rhost(const void *inbuf, void *outbuf, uintptr
     /* Fast path for REPLACE with contig type or noncontig type with large contig chunk */
     if (op == YAKSA_OP__REPLACE && (type->is_contig || type->size / type->num_contig >= threshold)) {
         rc = singlechunk_unpack(id, request->backend.outattr.device, inbuf, outbuf, count,
-                                type, info, op, request, subreq_ptr);
+                                type, info, op, request, subreq_ptr, stream);
     }
     /* Slow path */
     else {
-        rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
-        YAKSU_ERR_CHECK(rc, fn_fail);
+        if (stream) {
+            rc = unpack_rh2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+            YAKSU_ERR_CHECK(rc, fn_fail);
+        } else {
+            rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, subreq_ptr);
+            YAKSU_ERR_CHECK(rc, fn_fail);
 
-        (*subreq_ptr)->u.multiple.acquire = unpack_rh2d_acquire;
-        (*subreq_ptr)->u.multiple.release = simple_release;
+            (*subreq_ptr)->u.multiple.acquire = unpack_rh2d_acquire;
+            (*subreq_ptr)->u.multiple.release = simple_release;
+        }
     }
 
   fn_exit:
@@ -1536,6 +2763,8 @@ static int set_subreq_unpack_from_rhost(const void *inbuf, void *outbuf, uintptr
   fn_fail:
     goto fn_exit;
 }
+
+/* Progress functions */
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                              yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request)
@@ -1561,56 +2790,75 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
         goto fn_exit;
     }
 
+    void *stream;
+    if (request->kind == YAKSI_REQUEST_KIND__CUDA_STREAM) {
+        assert(id == YAKSURI_GPUDRIVER_ID__CUDA);
+        assert(request->stream != NULL);
+        stream = request->stream;
+    } else {
+        stream = NULL;
+    }
+
     if (reqpriv->optype == YAKSURI_OPTYPE__PACK) {
         switch (request->backend.inattr.type) {
             case YAKSUR_PTR_TYPE__GPU:
                 rc = set_subreq_pack_from_device(inbuf, outbuf, count, type, info, op, request,
-                                                 reqpriv, &subreq);
+                                                 reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__MANAGED:
                 rc = set_subreq_pack_from_managed(inbuf, outbuf, count, type, info, op, request,
-                                                  reqpriv, &subreq);
+                                                  reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__REGISTERED_HOST:
                 rc = set_subreq_pack_from_rhost(inbuf, outbuf, count, type, info, op, request,
-                                                reqpriv, &subreq);
+                                                reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
             default:
-                rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, &subreq);
-                YAKSU_ERR_CHECK(rc, fn_fail);
+                if (stream) {
+                    rc = pack_h2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
+                } else {
+                    rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, &subreq);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
 
-                subreq->u.multiple.acquire = pack_h2d_acquire;
-                subreq->u.multiple.release = simple_release;
+                    subreq->u.multiple.acquire = pack_h2d_acquire;
+                    subreq->u.multiple.release = simple_release;
+                }
                 break;
         }
     } else {
         switch (request->backend.inattr.type) {
             case YAKSUR_PTR_TYPE__GPU:
                 rc = set_subreq_unpack_from_device(inbuf, outbuf, count, type, info, op, request,
-                                                   reqpriv, &subreq);
+                                                   reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__MANAGED:
                 rc = set_subreq_unpack_from_managed(inbuf, outbuf, count, type, info, op, request,
-                                                    reqpriv, &subreq);
+                                                    reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__REGISTERED_HOST:
                 rc = set_subreq_unpack_from_rhost(inbuf, outbuf, count, type, info, op, request,
-                                                  reqpriv, &subreq);
+                                                  reqpriv, &subreq, stream);
                 YAKSU_ERR_CHECK(rc, fn_fail);
                 break;
             case YAKSUR_PTR_TYPE__UNREGISTERED_HOST:
             default:
-                rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, &subreq);
-                YAKSU_ERR_CHECK(rc, fn_fail);
+                if (stream) {
+                    rc = unpack_urh2d_stream(reqpriv, inbuf, outbuf, count, type, op, stream);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
+                } else {
+                    rc = set_multichunk_subreq(inbuf, outbuf, count, type, op, &subreq);
+                    YAKSU_ERR_CHECK(rc, fn_fail);
 
-                subreq->u.multiple.acquire = unpack_urh2d_acquire;
-                subreq->u.multiple.release = simple_release;
+                    subreq->u.multiple.acquire = unpack_urh2d_acquire;
+                    subreq->u.multiple.release = simple_release;
+                }
                 break;
         }
     }
@@ -1747,5 +2995,6 @@ int yaksuri_progress_init(void)
 
 int yaksuri_progress_finalize(void)
 {
+    stream_buf_list_free();
     return YAKSA_SUCCESS;
 }

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -1739,3 +1739,13 @@ int yaksuri_progress_poke(void)
   fn_fail:
     goto fn_exit;
 }
+
+int yaksuri_progress_init(void)
+{
+    return YAKSA_SUCCESS;
+}
+
+int yaksuri_progress_finalize(void)
+{
+    return YAKSA_SUCCESS;
+}

--- a/src/frontend/include/yaksa.h.in
+++ b/src/frontend/include/yaksa.h.in
@@ -539,6 +539,42 @@ int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t ou
                  yaksa_info_t info, yaksa_op_t op);
 
 /*!
+ * \brief Asynchronously packs the data represented by the (incount, type) tuple into a contiguous buffer.
+ *
+ * \param[in]  inbuf             Input buffer from which data is being packed
+ * \param[in]  incount           Number of elements of the datatype representing the layout
+ * \param[in]  type              Datatype representing the layout
+ * \param[in]  inoffset          Number of bytes to skip from the layout represented by the
+ *                               (incount, type) tuple
+ * \param[out] outbuf            Output buffer into which data is being packed
+ * \param[in]  max_pack_bytes    Maximum number of bytes that can be packed in the output buffer
+ * \param[out] actual_pack_bytes Actual number of bytes that were packed into the output buffer
+ * \param[in]  info              Info hint to apply
+ * \param[in]  stream            pointer to cudaStream_t
+ */
+int yaksa_pack_stream(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
+                      void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
+                      yaksa_info_t info, yaksa_op_t op, void *stream);
+
+/*!
+ * \brief Asynchronously unpacks data from a contiguous buffer into a buffer represented by the (incount, type) tuple.
+ *
+ * \param[in]  inbuf             Input buffer from which data is being unpacked
+ * \param[in]  insize            Number of bytes in the input buffer
+ * \param[out] outbuf            Output buffer into which data is being unpacked
+ * \param[in]  outcount          Number of elements of the datatype representing the layout
+ * \param[in]  type              Datatype representing the layout
+ * \param[in]  outoffset         Number of bytes to skip from the layout represented by the
+ *                               (outcount, type) tuple
+ * \param[out] actual_unpack_bytes Actual number of bytes that were unpacked into the output buffer
+ * \param[in]  info              Info hint to apply
+ * \param[in]  stream            Pointer to cudaStream_t
+ */
+int yaksa_unpack_stream(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
+                        yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                        yaksa_info_t info, yaksa_op_t op, void *stream);
+
+/*!
  * \brief gets the number of contiguous segments in the (count, type) tuple
  *
  * \param[in]  count             Number of elements of the datatype representing the layout

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -145,11 +145,18 @@ typedef struct yaksi_type_s {
     yaksur_type_s backend;
 } yaksi_type_s;
 
+#define YAKSI_REQUEST_KIND__NONBLOCKING 0
+#define YAKSI_REQUEST_KIND__BLOCKING    1
+#define YAKSI_REQUEST_KIND__CUDA_STREAM 2
+
 typedef struct yaksi_request_s {
     yaksu_handle_t id;
     yaksu_atomic_int cc;        /* completion counter */
-    bool is_blocking;           /* ipack/iunpack are nonblocking; pack/unpack are blocking */
-
+    /* kind takes value of YAKSI_REQUEST_KIND__{NONBLOCKING, BLOCKING, CUDA_STREAM}
+     * ipack/iunpack are nonblocking; pack/unpack are blocking;
+     * pack_stream/unpack_stream sets stream */
+    int kind;
+    void *stream;               /* for CUDA, it's pointer to cudaStream_t */
     /* give some private space for the backend to store content */
     yaksur_request_s backend;
 
@@ -265,8 +272,10 @@ int yaksi_type_handle_dealloc(yaksa_type_t handle, yaksi_type_s ** type);
 int yaksi_type_get(yaksa_type_t type, yaksi_type_s ** yaksi_type);
 
 /* request pool */
-int yaksi_request_create(yaksi_request_s ** request, bool is_blocking);
+int yaksi_request_create(yaksi_request_s ** request);
 int yaksi_request_free(yaksi_request_s * request);
 int yaksi_request_get(yaksa_request_t request, yaksi_request_s ** yaksi_request);
+void yaksi_request_set_blocking(yaksi_request_s * request);
+void yaksi_request_set_stream(yaksi_request_s * request, void *stream);
 
 #endif /* YAKSI_H_INCLUDED */

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -266,7 +266,7 @@ int yaksa_init(yaksa_info_t info)
 
     /* allocate the NULL request */
     struct yaksi_request_s *request;
-    rc = yaksi_request_create(&request, false /* is_blocking */);
+    rc = yaksi_request_create(&request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     assert(request->id == YAKSA_REQUEST__NULL);

--- a/src/frontend/pup/Makefile.mk
+++ b/src/frontend/pup/Makefile.mk
@@ -10,6 +10,8 @@ libyaksa_la_SOURCES += \
 	src/frontend/pup/yaksa_pack.c \
 	src/frontend/pup/yaksa_iunpack.c \
 	src/frontend/pup/yaksa_unpack.c \
+	src/frontend/pup/yaksa_pack_stream.c \
+	src/frontend/pup/yaksa_unpack_stream.c \
 	src/frontend/pup/yaksa_request.c \
 	src/frontend/pup/yaksi_ipack.c \
 	src/frontend/pup/yaksi_ipack_element.c \

--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -32,7 +32,7 @@ int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr
     }
 
     yaksi_request_s *yaksi_request;
-    rc = yaksi_request_create(&yaksi_request, false /* is_blocking */);
+    rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     yaksi_info_s *yaksi_info;

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -35,7 +35,7 @@ int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t o
 
     yaksi_request_s *yaksi_request;
     yaksi_request = NULL;
-    rc = yaksi_request_create(&yaksi_request, false /* is_blocking */);
+    rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
     yaksi_info_s *yaksi_info;

--- a/src/frontend/pup/yaksa_pack.c
+++ b/src/frontend/pup/yaksa_pack.c
@@ -31,8 +31,9 @@ int yaksa_pack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_
 
     yaksi_request_s *yaksi_request;
     yaksi_request = NULL;
-    rc = yaksi_request_create(&yaksi_request, true /* is_blocking */);
+    rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
+    yaksi_request_set_blocking(yaksi_request);
 
     yaksi_info_s *yaksi_info;
     yaksi_info = (yaksi_info_s *) info;

--- a/src/frontend/pup/yaksa_pack_stream.c
+++ b/src/frontend/pup/yaksa_pack_stream.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksi.h"
+#include "yaksu.h"
+#include <assert.h>
+
+int yaksa_pack_stream(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
+                      void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
+                      yaksa_info_t info, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    if (incount == 0) {
+        *actual_pack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_type_s *yaksi_type;
+    rc = yaksi_type_get(type, &yaksi_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *actual_pack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_request_s *yaksi_request;
+    rc = yaksi_request_create(&yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+    yaksi_request_set_stream(yaksi_request, stream);
+
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
+
+    rc = yaksi_ipack(inbuf, incount, yaksi_type, inoffset, outbuf, max_pack_bytes,
+                     actual_pack_bytes, yaksi_info, op, yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksi_request_free(yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/frontend/pup/yaksa_unpack.c
+++ b/src/frontend/pup/yaksa_unpack.c
@@ -33,8 +33,9 @@ int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t ou
 
     yaksi_request_s *yaksi_request;
     yaksi_request = NULL;
-    rc = yaksi_request_create(&yaksi_request, true /* is_blocking */);
+    rc = yaksi_request_create(&yaksi_request);
     YAKSU_ERR_CHECK(rc, fn_fail);
+    yaksi_request_set_blocking(yaksi_request);
 
     yaksi_info_s *yaksi_info;
     yaksi_info = (yaksi_info_s *) info;

--- a/src/frontend/pup/yaksa_unpack_stream.c
+++ b/src/frontend/pup/yaksa_unpack_stream.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include "yaksi.h"
+#include "yaksu.h"
+#include <assert.h>
+
+int yaksa_unpack_stream(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
+                        yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
+                        yaksa_info_t info, yaksa_op_t op, void *stream)
+{
+    int rc = YAKSA_SUCCESS;
+
+    assert(yaksu_atomic_load(&yaksi_is_initialized));
+
+    if (outcount == 0) {
+        *actual_unpack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_type_s *yaksi_type;
+    rc = yaksi_type_get(type, &yaksi_type);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    if (yaksi_type->size == 0) {
+        *actual_unpack_bytes = 0;
+        goto fn_exit;
+    }
+
+    yaksi_request_s *yaksi_request;
+    rc = yaksi_request_create(&yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+    yaksi_request_set_stream(yaksi_request, stream);
+
+    yaksi_info_s *yaksi_info;
+    yaksi_info = (yaksi_info_s *) info;
+
+    rc = yaksi_iunpack(inbuf, insize, outbuf, outcount, yaksi_type, outoffset,
+                       actual_unpack_bytes, yaksi_info, op, yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+    rc = yaksi_request_free(yaksi_request);
+    YAKSU_ERR_CHECK(rc, fn_fail);
+
+  fn_exit:
+    return rc;
+  fn_fail:
+    goto fn_exit;
+}

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -7,7 +7,7 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksi_request_create(yaksi_request_s ** request, bool is_blocking)
+int yaksi_request_create(yaksi_request_s ** request)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_request_s *req;
@@ -21,7 +21,7 @@ int yaksi_request_create(yaksi_request_s ** request, bool is_blocking)
     assert(req->id < ((yaksa_request_t) 1 << YAKSI_REQUEST_OBJECT_ID_BITS));
 
     yaksu_atomic_store(&req->cc, 0);
-    req->is_blocking = is_blocking;
+    req->kind = YAKSI_REQUEST_KIND__NONBLOCKING;
 
     rc = yaksur_request_create_hook(req);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -65,4 +65,15 @@ int yaksi_request_get(yaksa_request_t request, struct yaksi_request_s **yaksi_re
     return rc;
   fn_fail:
     goto fn_exit;
+}
+
+void yaksi_request_set_blocking(yaksi_request_s * request)
+{
+    request->kind = YAKSI_REQUEST_KIND__BLOCKING;
+}
+
+void yaksi_request_set_stream(yaksi_request_s * request, void *stream)
+{
+    request->kind = YAKSI_REQUEST_KIND__CUDA_STREAM;
+    request->stream = stream;
 }

--- a/test/dtpools/Makefile.mk
+++ b/test/dtpools/Makefile.mk
@@ -9,6 +9,7 @@ test_dtpools_libdtpools_la_CPPFLAGS = $(test_cppflags)
 
 test_dtpools_libdtpools_la_SOURCES = \
 	test/dtpools/src/dtpools.c \
+	test/dtpools/src/dtpools_custom.c \
 	test/dtpools/src/dtpools_attr.c \
 	test/dtpools/src/dtpools_desc.c \
 	test/dtpools/src/dtpools_init_verify.c \

--- a/test/dtpools/src/dtpools.c
+++ b/test/dtpools/src/dtpools.c
@@ -166,6 +166,57 @@ int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, uintptr_t maxbufsize)
     goto fn_exit;
 }
 
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    DTPI_pool_s *dtpi = dtp.priv;
+    DTPI_ERR_ARG_CHECK(!dtpi, rc);
+
+    DTPI_ALLOC_OR_FAIL(obj->priv, sizeof(DTPI_obj_s), rc);
+    DTPI_obj_s *obj_priv = obj->priv;
+    obj_priv->dtp = dtp;
+    if (desc == NULL) {
+        obj_priv->attr_tree = NULL;
+        obj->DTP_datatype = dtp.DTP_base_type;
+        obj->DTP_type_count = dtpi->base_type_count;
+    } else {
+        const char *desc_parts[10];
+        int num_parts;
+        rc = DTPI_parse_desc(desc, desc_parts, &num_parts, 10);
+        DTPI_ERR_CHK_RC(rc);
+        rc = DTPI_custom_datatype(dtp, &obj_priv->attr_tree, &obj->DTP_datatype,
+                                  &obj->DTP_type_count, desc_parts, num_parts);
+        DTPI_ERR_CHK_RC(rc);
+    }
+
+    intptr_t true_lb;
+    intptr_t true_extent;
+    intptr_t lb;
+    intptr_t extent;
+
+    rc = yaksa_type_get_true_extent(obj->DTP_datatype, &true_lb, &true_extent);
+    DTPI_ERR_CHK_RC(rc);
+    rc = yaksa_type_get_extent(obj->DTP_datatype, &lb, &extent);
+    DTPI_ERR_CHK_RC(rc);
+
+    obj->DTP_bufsize = (extent * obj->DTP_type_count) + true_extent - extent;
+    if (true_lb > 0) {
+        obj->DTP_bufsize += true_lb;
+        obj->DTP_buf_offset = 0;
+    } else {
+        obj->DTP_buf_offset = -true_lb;
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
 int DTP_obj_get_description(DTP_obj_s obj, char **desc)
 {
     DTPI_obj_s *obj_priv = obj.priv;

--- a/test/dtpools/src/dtpools.h
+++ b/test/dtpools/src/dtpools.h
@@ -35,6 +35,7 @@ int DTP_pool_create(const char *basic_type_str, uintptr_t basic_type_count, int 
 int DTP_pool_free(DTP_pool_s dtp);
 
 int DTP_obj_create(DTP_pool_s dtp, DTP_obj_s * obj, uintptr_t maxbufsize);
+int DTP_obj_create_custom(DTP_pool_s dtp, DTP_obj_s * obj, const char *desc);
 int DTP_obj_free(DTP_obj_s obj);
 int DTP_obj_get_description(DTP_obj_s obj, char **desc);
 

--- a/test/dtpools/src/dtpools_custom.c
+++ b/test/dtpools/src/dtpools_custom.c
@@ -1,0 +1,701 @@
+#include <string.h>
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <ctype.h>
+#include "dtpools_internal.h"
+
+#define SKIP_SPACE while (isspace(*s)) s++
+#define EXPECT_DIGIT \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isdigit(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_ALPHA \
+    do { \
+        while (isspace(*s)) s++; \
+        if (!isalpha(*s)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define EXPECT_CHAR(c) \
+    do { \
+        while (isspace(*s)) s++; \
+        if (*s != (c)) { \
+            DTPI_ERR_ASSERT(0, rc); \
+        } \
+    } while (0)
+#define SKIP_DIGIT \
+    do { \
+        while (*s && isdigit(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_ALPHA \
+    do { \
+        while (*s && isalpha(*s)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+#define SKIP_UNTIL(c) \
+    do { \
+        while (*s && *s != (c)) s++; \
+        DTPI_ERR_ASSERT(*s, rc); \
+    } while (0)
+
+int DTPI_parse_desc(const char *s, const char **parts, int *num_parts, int max_parts)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    int i = 0;
+    while (*s) {
+        EXPECT_DIGIT;
+        SKIP_DIGIT;
+        EXPECT_CHAR(':');
+        s++;
+        EXPECT_ALPHA;
+
+        parts[i++] = s;
+        DTPI_ERR_ASSERT(i < max_parts, rc);
+
+        SKIP_ALPHA;
+        EXPECT_CHAR('[');
+        SKIP_UNTIL(']');
+        s++;
+        SKIP_SPACE;
+    }
+    *num_parts = i;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_contig(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                         intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__CONTIG;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "blklen %d", &attr->u.contig.blklen);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    rc = yaksa_type_create_contig(attr->u.contig.blklen, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    DTPI_ERR_ASSERT(count % attr->u.contig.blklen == 0, rc);
+    count /= attr->u.contig.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_dup(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                      intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__DUP;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    rc = yaksa_type_create_dup(type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_resized(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                          intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__RESIZED;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "lb %zd, extent %zd", &attr->u.resized.lb, &attr->u.resized.extent);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    rc = yaksa_type_create_resized(type, attr->u.resized.lb, attr->u.resized.extent, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_vector(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                         intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__VECTOR;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %d, stride %d", &attr->u.vector.numblks,
+               &attr->u.vector.blklen, &attr->u.vector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = yaksa_type_create_vector(attr->u.vector.numblks, attr->u.vector.blklen,
+                                  attr->u.vector.stride, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.vector.numblks * attr->u.vector.blklen) == 0, rc);
+    count /= attr->u.vector.numblks * attr->u.vector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hvector(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                          intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HVECTOR;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %ld, stride %zd", &attr->u.hvector.numblks,
+               &attr->u.hvector.blklen, &attr->u.hvector.stride);
+    DTPI_ERR_ASSERT(n == 3, rc);
+    rc = yaksa_type_create_hvector(attr->u.hvector.numblks, attr->u.hvector.blklen,
+                                   attr->u.hvector.stride, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    printf("hvector: count=%ld, numblks=%d, blklen=%ld\n", count, attr->u.hvector.numblks,
+           attr->u.hvector.blklen);
+    DTPI_ERR_ASSERT(count % (attr->u.hvector.numblks * attr->u.hvector.blklen) == 0, rc);
+    count /= attr->u.hvector.numblks * attr->u.hvector.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkindx(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                          intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKINDX;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %ld", &attr->u.blkindx.numblks, &attr->u.blkindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkindx.array_of_displs, attr->u.blkindx.numblks * sizeof(intptr_t),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = yaksa_type_create_indexed_block(attr->u.blkindx.numblks, attr->u.blkindx.blklen,
+                                         attr->u.blkindx.array_of_displs, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkindx.numblks * attr->u.blkindx.blklen) == 0, rc);
+    count /= attr->u.blkindx.numblks * attr->u.blkindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_blkhindx(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                           intptr_t * new_count, const char *desc, yaksa_type_t type,
+                           intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__BLKHINDX;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d, blklen %ld", &attr->u.blkhindx.numblks, &attr->u.blkhindx.blklen);
+    DTPI_ERR_ASSERT(n == 2, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.blkhindx.array_of_displs,
+                       attr->u.blkhindx.numblks * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.blkhindx.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.blkhindx.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = yaksa_type_create_hindexed_block(attr->u.blkhindx.numblks, attr->u.blkhindx.blklen,
+                                          attr->u.blkhindx.array_of_displs, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    DTPI_ERR_ASSERT(count % (attr->u.blkhindx.numblks * attr->u.blkhindx.blklen) == 0, rc);
+    count /= attr->u.blkhindx.numblks * attr->u.blkhindx.blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_indexed(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                          intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__INDEXED;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.indexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_blklens, attr->u.indexed.numblks * sizeof(intptr_t),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.indexed.array_of_displs, attr->u.indexed.numblks * sizeof(intptr_t),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.indexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = yaksa_type_create_indexed(attr->u.indexed.numblks, attr->u.indexed.array_of_blklens,
+                                   attr->u.indexed.array_of_displs, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.indexed.numblks; i++) {
+        total_blklen += attr->u.indexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_hindexed(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                           intptr_t * new_count, const char *desc, yaksa_type_t type,
+                           intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__HINDEXED;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.hindexed.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_blklens,
+                       attr->u.hindexed.numblks * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.hindexed.array_of_displs,
+                       attr->u.hindexed.numblks * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.hindexed.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+
+    rc = yaksa_type_create_hindexed(attr->u.hindexed.numblks, attr->u.hindexed.array_of_blklens,
+                                    attr->u.hindexed.array_of_displs, type, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.hindexed.numblks; i++) {
+        total_blklen += attr->u.hindexed.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_subarray(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                           intptr_t * new_count, const char *desc, yaksa_type_t type,
+                           intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__SUBARRAY;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "ndims %d", &attr->u.subarray.ndims);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_sizes, attr->u.subarray.ndims * sizeof(intptr_t),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_sizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_subsizes,
+                       attr->u.subarray.ndims * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_subsizes[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.subarray.array_of_starts, attr->u.subarray.ndims * sizeof(intptr_t),
+                       rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.subarray.array_of_starts[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    SKIP_UNTIL('o');
+    if (strncmp(s, "order C", 7) == 0) {
+        attr->u.subarray.order = YAKSA_SUBARRAY_ORDER__C;
+    } else if (strncmp(s, "order FORTRAN", 13) == 0) {
+        attr->u.subarray.order = YAKSA_SUBARRAY_ORDER__FORTRAN;
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    rc = yaksa_type_create_subarray(attr->u.subarray.ndims, attr->u.subarray.array_of_sizes,
+                                    attr->u.subarray.array_of_subsizes,
+                                    attr->u.subarray.array_of_starts, attr->u.subarray.order, type,
+                                    NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+
+    int total_blklen = 1;
+    for (int i = 0; i < attr->u.subarray.ndims; i++) {
+        total_blklen *= attr->u.subarray.array_of_subsizes[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+static int custom_struct(DTP_pool_s dtp, DTPI_Attr_s * attr, yaksa_type_t * newtype,
+                         intptr_t * new_count, const char *desc, yaksa_type_t type, intptr_t count)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    attr->kind = DTPI_DATATYPE_KIND__STRUCT;
+    intptr_t tmp_lb;
+    rc = yaksa_type_get_extent(type, &tmp_lb, &attr->child_type_extent);
+    DTPI_ERR_CHK_RC(rc);
+    const char *s = desc;
+    EXPECT_CHAR('[');
+    s++;
+
+    int n;
+    n = sscanf(s, "numblks %d", &attr->u.structure.numblks);
+    DTPI_ERR_ASSERT(n == 1, rc);
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_blklens,
+                       attr->u.structure.numblks * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_blklens[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    DTPI_ALLOC_OR_FAIL(attr->u.structure.array_of_displs,
+                       attr->u.structure.numblks * sizeof(intptr_t), rc);
+    SKIP_UNTIL('(');
+    s++;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        if (i > 0) {
+            EXPECT_CHAR(',');
+            s++;
+        }
+        EXPECT_DIGIT;
+        attr->u.structure.array_of_displs[i] = atoi(s);
+        SKIP_DIGIT;
+    }
+    yaksa_type_t *array_of_types;
+    DTPI_ALLOC_OR_FAIL(array_of_types, attr->u.structure.numblks * sizeof(yaksa_type_t), rc);
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        array_of_types[i] = type;
+    }
+    rc = yaksa_type_create_struct(attr->u.structure.numblks, attr->u.structure.array_of_blklens,
+                                  attr->u.structure.array_of_displs, array_of_types, NULL, newtype);
+    DTPI_ERR_CHK_RC(rc);
+    DTPI_FREE(array_of_types);
+
+    int total_blklen = 0;
+    for (int i = 0; i < attr->u.structure.numblks; i++) {
+        total_blklen += attr->u.structure.array_of_blklens[i];
+    }
+    DTPI_ERR_ASSERT(count % total_blklen == 0, rc);
+    count /= total_blklen;
+
+    *new_count = count;
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}
+
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, yaksa_type_t * newtype,
+                         uintptr_t * new_count, const char **desc_list, int depth)
+{
+    int rc = DTP_SUCCESS;
+    DTPI_FUNC_ENTER();
+
+    if (depth == 0) {
+        DTPI_pool_s *dtpi = dtp.priv;
+        *attr_tree = NULL;
+        *newtype = dtp.DTP_base_type;
+        *new_count = dtpi->base_type_count;
+        goto fn_exit;
+    }
+
+    DTPI_Attr_s *attr;
+    DTPI_ALLOC_OR_FAIL(attr, sizeof(DTPI_Attr_s), rc);
+    *attr_tree = attr;
+
+    yaksa_type_t type;
+    intptr_t count = 0;
+    rc = DTPI_custom_datatype(dtp, &attr->child, &type, &count, desc_list + 1, depth - 1);
+    DTPI_ERR_CHK_RC(rc);
+
+    const char *s = desc_list[0];
+    if (strncmp(s, "contig", 6) == 0) {
+        rc = custom_contig(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "dup", 3) == 0) {
+        rc = custom_dup(dtp, attr, newtype, new_count, s + 3, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "resized", 7) == 0) {
+        rc = custom_resized(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "vector", 6) == 0) {
+        rc = custom_vector(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hvector", 7) == 0) {
+        rc = custom_hvector(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkindx", 7) == 0) {
+        rc = custom_blkindx(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "blkhindx", 8) == 0) {
+        rc = custom_blkhindx(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "indexed", 7) == 0) {
+        rc = custom_indexed(dtp, attr, newtype, new_count, s + 7, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "hindexed", 8) == 0) {
+        rc = custom_hindexed(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "subarray", 8) == 0) {
+        rc = custom_subarray(dtp, attr, newtype, new_count, s + 8, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "structure", 9) == 0) {
+        rc = custom_struct(dtp, attr, newtype, new_count, s + 9, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else if (strncmp(s, "struct", 6) == 0) {
+        rc = custom_struct(dtp, attr, newtype, new_count, s + 6, type, count);
+        DTPI_ERR_CHK_RC(rc);
+    } else {
+        DTPI_ERR_ASSERT(0, rc);
+    }
+
+    if (depth > 1) {
+        rc = yaksa_type_free(type);
+        DTPI_ERR_CHK_RC(rc);
+    }
+
+  fn_exit:
+    DTPI_FUNC_EXIT();
+    return rc;
+
+  fn_fail:
+    goto fn_exit;
+}

--- a/test/dtpools/src/dtpools_internal.h
+++ b/test/dtpools/src/dtpools_internal.h
@@ -438,10 +438,13 @@ typedef struct {
 
 int DTPI_obj_free(DTPI_obj_s * obj_priv);
 int DTPI_parse_base_type_str(DTP_pool_s * dtp, const char *str);
+int DTPI_parse_desc(const char *desc, const char **desc_list, int *depth, int max_depth);
 unsigned int DTPI_low_count(unsigned int count);
 unsigned int DTPI_high_count(unsigned int count);
 int DTPI_construct_datatype(DTP_pool_s dtp, int attr_tree_depth, DTPI_Attr_s ** attr_tree,
                             yaksa_type_t * newtype, uintptr_t * new_count);
+int DTPI_custom_datatype(DTP_pool_s dtp, DTPI_Attr_s ** attr_tree, yaksa_type_t * newtype,
+                         uintptr_t * new_count, const char **desc_list, int depth);
 int DTPI_populate_dtp_desc(DTPI_obj_s * obj_priv, DTPI_pool_s * dtpi, char **desc);
 int DTPI_rand(DTPI_pool_s * dtpi);
 int DTPI_init_verify(DTP_pool_s dtp, DTP_obj_s obj, void *buf, DTPI_Attr_s * attr_tree,

--- a/test/pack/Makefile.mk
+++ b/test/pack/Makefile.mk
@@ -7,8 +7,9 @@ pack_testlists = $(top_srcdir)/test/pack/testlist.gen \
 	$(top_srcdir)/test/pack/testlist.threads.gen
 
 EXTRA_DIST += $(top_srcdir)/test/pack/testlist.gen \
-	$(top_srcdir)/test/pack/testlist.threads.gen     \
-	$(top_srcdir)/test/pack/testlist.blocking.gen
+	$(top_srcdir)/test/pack/testlist.threads.gen \
+	$(top_srcdir)/test/pack/testlist.blocking.gen \
+	$(top_srcdir)/test/pack/testlist.stream.gen
 
 EXTRA_PROGRAMS += \
 	test/pack/pack

--- a/test/pack/Makefile.mk
+++ b/test/pack/Makefile.mk
@@ -4,7 +4,12 @@
 ##
 
 pack_testlists = $(top_srcdir)/test/pack/testlist.gen \
-	$(top_srcdir)/test/pack/testlist.threads.gen
+	$(top_srcdir)/test/pack/testlist.threads.gen \
+	$(top_srcdir)/test/pack/testlist.blocking.gen
+
+if BUILD_CUDA_BACKEND
+pack_testlists += $(top_srcdir)/test/pack/testlist.stream.gen
+endif
 
 EXTRA_DIST += $(top_srcdir)/test/pack/testlist.gen \
 	$(top_srcdir)/test/pack/testlist.threads.gen \

--- a/test/pack/pack-common.c
+++ b/test/pack/pack-common.c
@@ -97,3 +97,36 @@ void pack_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, mem_t
     pack_ze_copy_content(tid, sbuf, dbuf, size, type);
 #endif
 }
+
+void *pack_create_stream(void)
+{
+#ifdef HAVE_CUDA
+    return pack_cuda_create_stream();
+#elif defined(HAVE_ZE)
+    return pack_ze_create_stream();
+#else
+    assert(0 && "yaksa_pack_stream/yaksa_unpack_stream not supported");
+#endif
+}
+
+void pack_destroy_stream(void *stream)
+{
+#ifdef HAVE_CUDA
+    pack_cuda_destroy_stream(stream);
+#elif defined(HAVE_ZE)
+    pack_ze_destroy_stream(stream);
+#else
+    assert(0 && "yaksa_pack_stream/yaksa_unpack_stream not supported");
+#endif
+}
+
+void pack_stream_synchronize(void *stream)
+{
+#ifdef HAVE_CUDA
+    pack_cuda_stream_synchronize(stream);
+#elif defined(HAVE_ZE)
+    pack_ze_stream_synchronize(stream);
+#else
+    assert(0 && "yaksa_pack_stream/yaksa_unpack_stream not supported");
+#endif
+}

--- a/test/pack/pack-common.h
+++ b/test/pack/pack-common.h
@@ -36,6 +36,9 @@ void pack_alloc_mem(int device_id, size_t size, mem_type_e type, void **hostbuf,
 void pack_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
 void pack_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, mem_type_e type);
+void *pack_create_stream(void);
+void pack_destroy_stream(void *stream);
+void pack_stream_synchronize(void *stream);
 
 #ifdef HAVE_CUDA
 int pack_cuda_get_ndevices(void);
@@ -46,6 +49,9 @@ void pack_cuda_alloc_mem(int device_id, size_t size, mem_type_e type, void **hos
 void pack_cuda_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
 void pack_cuda_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_cuda_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, mem_type_e type);
+void *pack_cuda_create_stream(void);
+void pack_cuda_destroy_stream(void *stream);
+void pack_cuda_stream_synchronize(void *stream);
 #endif
 
 #ifdef HAVE_ZE
@@ -57,6 +63,9 @@ void pack_ze_alloc_mem(int device_id, size_t size, mem_type_e type, void **hostb
 void pack_ze_free_mem(mem_type_e type, void *hostbuf, void *devicebuf);
 void pack_ze_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info, int iter);
 void pack_ze_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, mem_type_e type);
+void *pack_ze_create_stream(void);
+void pack_ze_destroy_stream(void *stream);
+void pack_ze_stream_synchronize(void *stream);
 #endif
 
 /* *INDENT-OFF* */

--- a/test/pack/pack-cuda.c
+++ b/test/pack/pack-cuda.c
@@ -101,4 +101,25 @@ void pack_cuda_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, 
     }
 }
 
+void *pack_cuda_create_stream(void)
+{
+    static cudaStream_t stream;
+    /* create stream on the 1st device */
+    cudaSetDevice(0);
+    cudaStreamCreate(&stream);
+    return &stream;
+}
+
+void pack_cuda_destroy_stream(void *stream_p)
+{
+    cudaStream_t stream = *(cudaStream_t *) stream_p;
+    cudaStreamDestroy(stream);
+}
+
+void pack_cuda_stream_synchronize(void *stream_p)
+{
+    cudaStream_t stream = *(cudaStream_t *) stream_p;
+    cudaStreamSynchronize(stream);
+}
+
 #endif /* HAVE_CUDA */

--- a/test/pack/pack-ze.c
+++ b/test/pack/pack-ze.c
@@ -333,4 +333,20 @@ void pack_ze_copy_content(int tid, const void *sbuf, void *dbuf, size_t size, me
     }
 }
 
+void *pack_ze_create_stream(void)
+{
+    assert(0 && "not supported");
+    return NULL;
+}
+
+void pack_ze_destroy_stream(void *stream_p)
+{
+    assert(0 && "not supported");
+}
+
+void pack_ze_stream_synchronize(void *stream_p)
+{
+    assert(0 && "not supported");
+}
+
 #endif /* HAVE_ZE */

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -104,14 +104,12 @@ yaksa_op_t float_ops[] =
 
 yaksa_op_t complex_ops[] = { YAKSA_OP__SUM, YAKSA_OP__PROD, YAKSA_OP__REPLACE };
 
-enum {
-    OPLIST_TYPE__UNSET,
-    OPLIST_TYPE__INT,
-    OPLIST_TYPE__FLOAT,
-    OPLIST_TYPE__COMPLEX,
-} oplist_type = OPLIST_TYPE__UNSET;
+yaksa_op_t single_op = YAKSA_OP__REPLACE;
+yaksa_op_t *op_list = &single_op;
+int op_list_len = 1;
 
 #define MAX_OP_LIST  (1024)
+
 yaksa_op_t **ops;
 
 void *runtest(void *arg);
@@ -548,11 +546,58 @@ int main(int argc, char **argv)
             --argc;
             ++argv;
             if (!strcmp(*argv, "int")) {
-                oplist_type = OPLIST_TYPE__INT;
+                op_list = int_ops;
+                op_list_len = sizeof(int_ops) / sizeof(yaksa_op_t);
             } else if (!strcmp(*argv, "float")) {
-                oplist_type = OPLIST_TYPE__FLOAT;
+                op_list = float_ops;
+                op_list_len = sizeof(float_ops) / sizeof(yaksa_op_t);
             } else if (!strcmp(*argv, "complex")) {
-                oplist_type = OPLIST_TYPE__COMPLEX;
+                op_list = complex_ops;
+                op_list_len = sizeof(complex_ops) / sizeof(yaksa_op_t);
+            } else if (!strcmp(*argv, "replace")) {
+                single_op = YAKSA_OP__REPLACE;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "sum")) {
+                single_op = YAKSA_OP__SUM;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "prod")) {
+                single_op = YAKSA_OP__PROD;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "max")) {
+                single_op = YAKSA_OP__MAX;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "min")) {
+                single_op = YAKSA_OP__MIN;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "land")) {
+                single_op = YAKSA_OP__LAND;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "lor")) {
+                single_op = YAKSA_OP__LOR;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "lxor")) {
+                single_op = YAKSA_OP__LXOR;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "band")) {
+                single_op = YAKSA_OP__BAND;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "bor")) {
+                single_op = YAKSA_OP__BOR;
+                op_list = &single_op;
+                op_list_len = 1;
+            } else if (!strcmp(*argv, "bxor")) {
+                single_op = YAKSA_OP__BXOR;
+                op_list = &single_op;
+                op_list_len = 1;
             } else {
                 fprintf(stderr, "unknown oplist type %s\n", *argv);
                 exit(1);
@@ -641,21 +686,8 @@ int main(int argc, char **argv)
             }
         }
 
-        if (oplist_type == OPLIST_TYPE__INT) {
-            int max_ops = sizeof(int_ops) / sizeof(yaksa_op_t);
-            for (int j = 0; j < MAX_OP_LIST; j++) {
-                ops[i][j] = int_ops[rand() % max_ops];
-            }
-        } else if (oplist_type == OPLIST_TYPE__FLOAT) {
-            int max_ops = sizeof(float_ops) / sizeof(yaksa_op_t);
-            for (int j = 0; j < MAX_OP_LIST; j++) {
-                ops[i][j] = float_ops[rand() % max_ops];
-            }
-        } else {
-            int max_ops = sizeof(complex_ops) / sizeof(yaksa_op_t);
-            for (int j = 0; j < MAX_OP_LIST; j++) {
-                ops[i][j] = complex_ops[rand() % max_ops];
-            }
+        for (int j = 0; j < MAX_OP_LIST; j++) {
+            ops[i][j] = op_list[rand() % op_list_len];
         }
     }
 

--- a/test/pack/pack.c
+++ b/test/pack/pack.c
@@ -29,6 +29,12 @@ enum {
     OVERLAP__IRREGULAR,
 };
 
+enum {
+    PACK_KIND__NONBLOCKING,
+    PACK_KIND__BLOCKING,
+    PACK_KIND__STREAM,
+};
+
 #define MAX_DTP_BASESTRLEN (1024)
 
 static int verbose = 0;
@@ -74,8 +80,12 @@ int max_segments = -1;
 int pack_order = PACK_ORDER__UNSET;
 int overlap = -1;
 int use_subdevices = 0;
-int blocking = 0;
+int pack_kind = PACK_KIND__NONBLOCKING;
 DTP_pool_s *dtp;
+
+/* For -stream tests */
+/* TODO: test multiple streams */
+void *stream;
 
 #define MAX_DEVID_LIST   (1024)
 int **device_ids;
@@ -246,10 +256,16 @@ void *runtest(void *arg)
          * their contents are equivalent -- this is useful for
          * correctness in the accumulate operations */
         uintptr_t actual_pack_bytes;
-        if (blocking) {
+        if (pack_kind == PACK_KIND__BLOCKING) {
             rc = yaksa_pack(dbuf_h + dobj.DTP_buf_offset, dobj.DTP_type_count, dobj.DTP_datatype,
                             0, tbuf_h, tbufsize, &actual_pack_bytes, NULL, YAKSA_OP__REPLACE);
             assert(rc == YAKSA_SUCCESS);
+        } else if (pack_kind == PACK_KIND__STREAM) {
+            rc = yaksa_pack_stream(dbuf_h + dobj.DTP_buf_offset, dobj.DTP_type_count,
+                                   dobj.DTP_datatype, 0, tbuf_h, tbufsize, &actual_pack_bytes, NULL,
+                                   YAKSA_OP__REPLACE, stream);
+            assert(rc == YAKSA_SUCCESS);
+            pack_stream_synchronize(stream);
         } else {
             rc = yaksa_ipack(dbuf_h + dobj.DTP_buf_offset, dobj.DTP_type_count, dobj.DTP_datatype,
                              0, tbuf_h, tbufsize, &actual_pack_bytes, NULL, YAKSA_OP__REPLACE,
@@ -346,12 +362,19 @@ void *runtest(void *arg)
         for (int j = 0; j < segments; j++) {
             uintptr_t actual_pack_bytes;
 
-            if (blocking) {
+            if (pack_kind == PACK_KIND__BLOCKING) {
                 rc = yaksa_pack(sbuf_d + sobj.DTP_buf_offset, sobj.DTP_type_count,
                                 sobj.DTP_datatype, segment_starts[j],
                                 (char *) tbuf_d + segment_starts[j], segment_lengths[j],
                                 &actual_pack_bytes, pack_info, pack_op);
                 assert(rc == YAKSA_SUCCESS);
+            } else if (pack_kind == PACK_KIND__STREAM) {
+                rc = yaksa_pack_stream(sbuf_d + sobj.DTP_buf_offset, sobj.DTP_type_count,
+                                       sobj.DTP_datatype, segment_starts[j],
+                                       (char *) tbuf_d + segment_starts[j], segment_lengths[j],
+                                       &actual_pack_bytes, pack_info, pack_op, stream);
+                assert(rc == YAKSA_SUCCESS);
+                pack_stream_synchronize(stream);
             } else {
                 rc = yaksa_ipack(sbuf_d + sobj.DTP_buf_offset, sobj.DTP_type_count,
                                  sobj.DTP_datatype, segment_starts[j],
@@ -369,12 +392,19 @@ void *runtest(void *arg)
             }
 
             uintptr_t actual_unpack_bytes;
-            if (blocking) {
+            if (pack_kind == PACK_KIND__BLOCKING) {
                 rc = yaksa_unpack((char *) tbuf_d + segment_starts[j], actual_pack_bytes,
                                   dbuf_d + dobj.DTP_buf_offset, dobj.DTP_type_count,
                                   dobj.DTP_datatype, segment_starts[j], &actual_unpack_bytes,
                                   unpack_info, unpack_op);
                 assert(rc == YAKSA_SUCCESS);
+            } else if (pack_kind == PACK_KIND__STREAM) {
+                rc = yaksa_unpack_stream((char *) tbuf_d + segment_starts[j], actual_pack_bytes,
+                                         dbuf_d + dobj.DTP_buf_offset, dobj.DTP_type_count,
+                                         dobj.DTP_datatype, segment_starts[j], &actual_unpack_bytes,
+                                         unpack_info, unpack_op, stream);
+                assert(rc == YAKSA_SUCCESS);
+                pack_stream_synchronize(stream);
             } else {
                 rc = yaksa_iunpack((char *) tbuf_d + segment_starts[j], actual_pack_bytes,
                                    dbuf_d + dobj.DTP_buf_offset, dobj.DTP_type_count,
@@ -541,7 +571,9 @@ int main(int argc, char **argv)
                 exit(1);
             }
         } else if (!strcmp(*argv, "-blocking")) {
-            blocking = 1;
+            pack_kind = PACK_KIND__BLOCKING;
+        } else if (!strcmp(*argv, "-stream")) {
+            pack_kind = PACK_KIND__STREAM;
         } else if (!strcmp(*argv, "-verbose")) {
             verbose = 1;
         } else if (!strcmp(*argv, "-use-tiles")) {
@@ -565,8 +597,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "   -segments    number of segments to chop the packing into\n");
         fprintf(stderr, "   -ordering  packing order of segments (normal, reverse, random)\n");
         fprintf(stderr, "   -overlap     should packing overlap (none, regular, irregular)\n");
-        fprintf(stderr,
-                "   -blocking    test blocking pack/unpack (default test nonblocking pack/unpack)\n");
+        fprintf(stderr, "   -blocking    test blocking pack/unpack \n");
+        fprintf(stderr, "   -stream      test pack_stream/unpack_stream \n");
         fprintf(stderr, "   -verbose     verbose output\n");
         fprintf(stderr, "   -num-threads number of threads to spawn\n");
         fprintf(stderr, "   -oplist      oplist type (int, float, complex)\n");
@@ -629,6 +661,17 @@ int main(int argc, char **argv)
 
     pthread_t *threads = (pthread_t *) malloc(num_threads * sizeof(pthread_t));
 
+    if (pack_kind == PACK_KIND__STREAM) {
+        stream = pack_create_stream();
+        assert(stream != NULL);
+        /* The stream was created on device 0, force to use a single device */
+        for (uintptr_t i = 0; i < num_threads; i++) {
+            for (int j = 0; j < MAX_DEVID_LIST; j++) {
+                device_ids[i][j] = 0;
+            }
+        }
+    }
+
     for (uintptr_t i = 0; i < num_threads; i++)
         pthread_create(&threads[i], NULL, runtest, (void *) i);
 
@@ -636,6 +679,10 @@ int main(int argc, char **argv)
         pthread_join(threads[i], NULL);
 
     free(threads);
+
+    if (pack_kind == PACK_KIND__STREAM) {
+        pack_destroy_stream(stream);
+    }
 
     for (uintptr_t i = 0; i < num_threads; i++) {
         int rc = DTP_pool_free(dtp[i]);

--- a/test/runtests.py
+++ b/test/runtests.py
@@ -47,7 +47,7 @@ def printout_make(line, ret, elapsed_time, output):
     global num_failures
 
     sys.stdout.write(colors.PREFIX + ">>>> " + colors.END)
-    sys.stdout.write("return status: ")
+    sys.stdout.write("make return status: ")
     if (ret == 0):
         sys.stdout.write(colors.SUCCESS + "SUCCESS\n" + colors.END)
     else:
@@ -74,7 +74,7 @@ def printout_exec(line, ret, elapsed_time, output):
 
     num_tests = num_tests + 1
     sys.stdout.write(colors.PREFIX + ">>>> " + colors.END)
-    sys.stdout.write("return status: ")
+    sys.stdout.write("exec return status: ")
     if (ret == 0):
         sys.stdout.write(colors.SUCCESS + "SUCCESS\n" + colors.END)
     else:


### PR DESCRIPTION
## Pull Request Description

Add `yaksa_pack_stream` and `yaksa_unpack_stream`.

The explicit stream version of routines will only enqueue memory operations and host routines (as stream callbacks).

![image](https://user-images.githubusercontent.com/1496702/125664919-6b6fb8ae-34fe-4990-9df5-14121542b3ad.png)

In an optimal case, where the yaksa operation is just a single kernel, we just enqueue that kernel(s). But there are fallback cases that we need enqueue CPU callbacks. For example, we may need run pre/post CPU operations.

## Notes

* The progress routines are rather messy -- duplicating ~1,600 loc. I am focusing on getting the code work, and will leave the refactoring to the future.
* The user-supplied stream has to match the yaksa internal device -- the target device.
* Cuda runtime defines the semantics of stream and stream callback. It is difficult to make an abstraction that works with all potential gpu driver, thus --
    - use `void *` for `stream`. For cuda, that is `cudaStream_t *` -- note this is one additional pointer indirection.  Internally, `cudaStream_t` is already a pointer. We can't directly use `cudaStream_t` because it could be an integer or a `struct`. *bad*: this prevents us to effectively differentiate different streams.
    - use `void (*fn)(void *data)` for host callback function prototype. -- if this is not compatible with other GPU drivers, the backend needs to employ wrapper functions.
* Ideally, we would hope there to be some standardization. For example, define `stream` to be an `integer` and host callbacks be `void (*fn)(void *data)` . Ultimately, I belive at some point an open standardization gonna come along, like `OpenGL`.
* The error recovery is fragile. Since we are queuing up the operations, how would we deal with *unexpected* errors?

## TODO
* [x] Add tests

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
