### PR TITLE
config: fail if CUDA was requested but cannot be used

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -91,6 +91,10 @@ EOF
         fi
         rm -f conftest.*
     fi
+
+    if test "$with_cuda" -a "${have_cuda}" = "no"; then
+        AC_MSG_ERROR([CUDA was requested but it is not functional])
+    fi
 fi
 AM_CONDITIONAL([BUILD_CUDA_BACKEND], [test x${have_cuda} = xyes])
 AM_CONDITIONAL([BUILD_CUDA_TESTS], [test x${have_cuda} = xyes])


### PR DESCRIPTION
## Pull Request Description
In case CUDA was requested explicitly via the `--with-cuda=<PATH>` option, the configure step should fail if it is not functional (i.e., cannot be found or nvcc is not working). Otherwise, third-party tools using Yaksa might run into issues as the resulting build will not include CUDA support although expected.


## Expected Impact
If a wrong path is given to the `--with-cuda` option or the `nvcc` compiler is not functional (e.g., this is currently the case if GCC 11 is used), the configure step will fail.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)

