### PR TITLE
info: add info hint mapped_device

### DIFF
--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -247,6 +247,7 @@ int yaksur_info_create_hook(yaksi_info_s * info)
     yaksuri_info_s *infopriv;
     infopriv = (yaksuri_info_s *) info->backend.priv;
     infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
+    infopriv->mapped_device = -1;
 
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -314,6 +315,11 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
         } else {
             assert(0);
         }
+        goto fn_exit;
+    } else if (!strncmp(key, "yaksa_mapped_device", YAKSA_INFO_MAX_KEYLEN)) {
+        yaksuri_info_s *infopriv = info->backend.priv;
+        assert(vallen == sizeof(int));
+        infopriv->mapped_device = *((const int *) val);
         goto fn_exit;
     }
 

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -100,6 +100,7 @@ typedef struct yaksuri_request {
 
 typedef struct {
     yaksuri_gpudriver_id_e gpudriver_id;
+    int mapped_device;
 } yaksuri_info_s;
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -2274,7 +2274,14 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
         (request->backend.inattr.device == request->backend.outattr.device ||
          check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                         reqpriv->request->backend.outattr.device)) && aligned) {
-        rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count,
+        int use_device = reqpriv->request->backend.inattr.device;
+        if (info) {
+            yaksuri_info_s *infopriv = (yaksuri_info_s *) info->backend.priv;
+            if (infopriv->mapped_device >= 0) {
+                use_device = infopriv->mapped_device;
+            }
+        }
+        rc = singlechunk_pack(id, use_device, inbuf, outbuf, count,
                               type, info, op, request, subreq_ptr, stream);
     }
     /* Fast path for other reduce operations with aligned buffer on the same device */
@@ -2537,7 +2544,14 @@ static int set_subreq_unpack_d2d(const void *inbuf, void *outbuf, uintptr_t coun
         (request->backend.inattr.device == request->backend.outattr.device ||
          check_p2p_comm(id, reqpriv->request->backend.inattr.device,
                         reqpriv->request->backend.outattr.device)) && aligned) {
-        rc = singlechunk_unpack(id, request->backend.inattr.device, inbuf, outbuf, count,
+        int use_device = reqpriv->request->backend.inattr.device;
+        if (info) {
+            yaksuri_info_s *infopriv = (yaksuri_info_s *) info->backend.priv;
+            if (infopriv->mapped_device >= 0) {
+                use_device = infopriv->mapped_device;
+            }
+        }
+        rc = singlechunk_unpack(id, use_device, inbuf, outbuf, count,
                                 type, info, op, request, subreq_ptr, stream);
     }
     /* Fast path for other reduce operations with aligned buffer on the same device */


### PR DESCRIPTION
## Pull Request Description
For device-to-device operations, the mapped_device hint can be used to
influence which device context (stream) to use.


If the buffer is mapped with ipc, using the stream of mapped_device has
better performance. And in the case of launching kernel, it has to be
launched on the mapped device.

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
