### PR TITLE
config: fix checking of nvcc

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -66,8 +66,9 @@ if test "$with_cuda" != "no" ; then
 EOF
         if test -n "$ac_save_CC" ; then
             NVCC_FLAGS="-ccbin $ac_save_CC"
-            # if the host compiler is PGI, change the -ccbin to pgc++ instead of pgcc
-            NVCC_FLAGS=`echo $NVCC_FLAGS | sed 's/pgcc/pgc++/g'`
+            # - pgcc doesn't work, use pgc++ instead
+            # - Extra optins such as `gcc -std=gnu99` doesn't work, strip the option
+            NVCC_FLAGS=$(echo $NVCC_FLAGS | sed -e 's/pgcc/pgc++/g' -e's/ -std=.*//g')
         else
             NVCC_FLAGS=""
         fi


### PR DESCRIPTION
## Pull Request Description

The CC may include options, a typical example is `gcc -std=gnu99`. This
won't work with nvcc -ccbin option, which expects a filepath. Strip the
option. The kernel code used in yaksa works without gnu99 option.

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

This fixes embedded build in MPICH

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
