### PR TITLE
config: add --enable-fast=all

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,13 @@ for option in ${enable_fast} ; do
         ndebug)
             PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
             ;;
+        all|yes)
+            PAC_APPEND_FLAG([-O2],[CFLAGS])
+            PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
+            ;;
+        none|no)
+            PAC_APPEND_FLAG([-O0],[CFLAGS])
+            ;;
         *)
             # ignore unknown options
             ;;

--- a/configure.ac
+++ b/configure.ac
@@ -47,16 +47,16 @@ else
     if test "$V3" = "" ; then V3="0"; fi
     if test "$V3" -le 9 ; then V3="0$V3" ; fi
     if test "$V4" = "a" ; then
-	V4=0
+        V4=0
     elif test "$V4" = "b" ; then
-	V4=1
+        V4=1
     elif test "$V4" = "rc" ; then
-	V4=2
+        V4=2
     elif test "$V4" = "" ; then
-	V4=3
-	V5=0
+        V4=3
+        V5=0
     elif test "$V4" = "p" ; then
-	V4=3
+        V4=3
     fi
     if test "$V5" -le 9 ; then V5="0$V5" ; fi
 
@@ -142,13 +142,13 @@ for option in ${enable_fast} ; do
     case "$option" in
         O*)
             PAC_APPEND_FLAG([-${option}],[CFLAGS])
-	    ;;
-	ndebug)
-	    PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
-	    ;;
-	*)
-	    # ignore unknown options
-	    ;;
+            ;;
+        ndebug)
+            PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
+            ;;
+        *)
+            # ignore unknown options
+            ;;
     esac
 done
 PAC_POP_FLAG(IFS)
@@ -256,7 +256,7 @@ AH_BOTTOM([
 AC_CONFIG_FILES([Makefile
                  Doxyfile
                  maint/yaksa.pc
-		 src/frontend/include/yaksa.h
+                 src/frontend/include/yaksa.h
 ])
 AC_OUTPUT
 


### PR DESCRIPTION
## Pull Request Description
MPICH uses option --enable-fast=all to enable most common fast options.
However, yaksa ignores it, resulting from worse performance than the default
-O2. Add the option to avoid surprises when building mpich.

Once merged, this should fix the current mpich nightly enable fast test (TIMEOUT in `./rma/large_acc_flush_local`).

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
