### PR TITLE
Optimize backend for contiguous datatype

### DIFF
--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -797,31 +797,51 @@ static int pack_d2urh_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * su
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    yaksa_op_t op = subreq->u.multiple.op;
+    yaksi_type_s *type = subreq->u.multiple.type;
 
     *chunk = NULL;
 
-    int devices[] = { reqpriv->request->backend.inattr.device, -1 };
-    rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    void *d_buf = NULL, *rh_buf;
+    /* no need to bounce to device buffer if type is contig and copy only */
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        int devices[] = { -1 };
+        rc = alloc_chunk(id, reqpriv, subreq, 1, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    if (*chunk == NULL)
-        goto fn_exit;
+        if (*chunk == NULL)
+            goto fn_exit;
 
-    void *d_buf, *rh_buf;
-    d_buf = (*chunk)->tmpbufs[0].buf;
-    rh_buf = (*chunk)->tmpbufs[1].buf;
+        rh_buf = (*chunk)->tmpbufs[0].buf;
+    } else {
+        int devices[] = { -1, reqpriv->request->backend.inattr.device };
+        rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+
+        if (*chunk == NULL)
+            goto fn_exit;
+
+        rh_buf = (*chunk)->tmpbufs[0].buf;
+        d_buf = (*chunk)->tmpbufs[1].buf;
+    }
 
     const char *sbuf;
     sbuf = (const char *) subreq->u.multiple.inbuf +
         (*chunk)->count_offset * subreq->u.multiple.type->extent;
 
-    rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (d_buf) {
+        rc = ipack(id, sbuf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = icopy(id, d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        rc = icopy(id, d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        rc = ipack(id, sbuf, rh_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     rc = event_record(id, reqpriv->request->backend.inattr.device, &(*chunk)->event);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -841,7 +861,7 @@ static int pack_d2urh_release(yaksuri_request_s * reqpriv, yaksuri_subreq_s * su
     yaksi_type_s *type = subreq->u.multiple.type;
     yaksi_type_s *base_type = get_base_type(type);
 
-    rc = yaksuri_seq_ipack(chunk->tmpbufs[1].buf, dbuf,
+    rc = yaksuri_seq_ipack(chunk->tmpbufs[0].buf, dbuf,
                            chunk->count * type->size / base_type->size, base_type,
                            reqpriv->info, subreq->u.multiple.op);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -1140,19 +1160,27 @@ static int unpack_urh2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    yaksa_op_t op = subreq->u.multiple.op;
+    yaksi_type_s *type = subreq->u.multiple.type;
 
     *chunk = NULL;
 
-    int devices[] = { reqpriv->request->backend.outattr.device, -1 };
-    rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
-    YAKSU_ERR_CHECK(rc, fn_fail);
-
+    /* no need to bounce to device buffer if type is contig and copy only */
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        int devices[] = { -1 };
+        rc = alloc_chunk(id, reqpriv, subreq, 1, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        int devices[] = { -1, reqpriv->request->backend.outattr.device };
+        rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
     if (*chunk == NULL)
         goto fn_exit;
 
     void *d_buf, *rh_buf;
-    d_buf = (*chunk)->tmpbufs[0].buf;
-    rh_buf = (*chunk)->tmpbufs[1].buf;
+    rh_buf = (*chunk)->tmpbufs[0].buf;
+    d_buf = (*chunk)->tmpbufs[1].buf;
 
     const char *sbuf;
     char *dbuf;
@@ -1169,13 +1197,19 @@ static int unpack_urh2d_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s * 
                            byte_type, reqpriv->info, YAKSA_OP__REPLACE);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        rc = iunpack(id, rh_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                     op, reqpriv->request->backend.outattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-                 subreq->u.multiple.op, reqpriv->request->backend.outattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                     subreq->u.multiple.op, reqpriv->request->backend.outattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
     YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -565,6 +565,7 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
     yaksa_op_t op = subreq->u.multiple.op;
+    yaksi_type_s *type = subreq->u.multiple.type;
 
     assert(reqpriv->request->backend.inattr.device != reqpriv->request->backend.outattr.device);
 
@@ -572,18 +573,22 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
 
     void *base_addr = (char *) subreq->u.multiple.outbuf + subreq->u.multiple.type->true_lb;
 
-    if (op == YAKSA_OP__REPLACE) {
-        int devices[] = { reqpriv->request->backend.inattr.device, -1 };
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        int devices[] = { -1 };
+        rc = alloc_chunk(id, reqpriv, subreq, 1, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else if (op == YAKSA_OP__REPLACE) {
+        int devices[] = { -1, reqpriv->request->backend.inattr.device };
         rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else if (buf_is_aligned(base_addr, subreq->u.multiple.type)) {
-        int devices[] = { reqpriv->request->backend.inattr.device, -1,
+        int devices[] = { -1, reqpriv->request->backend.inattr.device,
             reqpriv->request->backend.outattr.device
         };
         rc = alloc_chunk(id, reqpriv, subreq, 3, devices, chunk);
         YAKSU_ERR_CHECK(rc, fn_fail);
     } else {
-        int devices[] = { reqpriv->request->backend.inattr.device, -1,
+        int devices[] = { -1, reqpriv->request->backend.inattr.device,
             reqpriv->request->backend.outattr.device,
             reqpriv->request->backend.outattr.device
         };
@@ -595,8 +600,8 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
         goto fn_exit;
 
     void *src_d_buf, *rh_buf, *dst_d_buf, *dst_d_buf2;
-    src_d_buf = (*chunk)->tmpbufs[0].buf;
-    rh_buf = (*chunk)->tmpbufs[1].buf;
+    rh_buf = (*chunk)->tmpbufs[0].buf;
+    src_d_buf = (*chunk)->tmpbufs[1].buf;
     dst_d_buf = (*chunk)->tmpbufs[2].buf;
     dst_d_buf2 = (*chunk)->tmpbufs[3].buf;
 
@@ -607,13 +612,19 @@ static int pack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_s 
     dbuf =
         (char *) subreq->u.multiple.outbuf + (*chunk)->count_offset * subreq->u.multiple.type->size;
 
-    rc = ipack(id, sbuf, src_d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
-               YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        rc = ipack(id, sbuf, rh_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        rc = ipack(id, sbuf, src_d_buf, (*chunk)->count, subreq->u.multiple.type, reqpriv->info,
+                   YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = icopy(id, src_d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        rc = icopy(id, src_d_buf, rh_buf, (*chunk)->count, subreq->u.multiple.type,
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.inattr.device, NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     rc = add_dependency(id, reqpriv->request->backend.inattr.device,
                         reqpriv->request->backend.outattr.device);
@@ -1022,21 +1033,29 @@ static int unpack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_gpudriver_id_e id = reqpriv->gpudriver_id;
+    yaksa_op_t op = subreq->u.multiple.op;
+    yaksi_type_s *type = subreq->u.multiple.type;
 
     assert(reqpriv->request->backend.inattr.device != reqpriv->request->backend.outattr.device);
 
     *chunk = NULL;
 
-    int devices[] = { reqpriv->request->backend.outattr.device, -1 };
-    rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        int devices[] = { -1 };
+        rc = alloc_chunk(id, reqpriv, subreq, 1, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        int devices[] = { -1, reqpriv->request->backend.outattr.device };
+        rc = alloc_chunk(id, reqpriv, subreq, 2, devices, chunk);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     if (*chunk == NULL)
         goto fn_exit;
 
     void *d_buf, *rh_buf;
-    d_buf = (*chunk)->tmpbufs[0].buf;
-    rh_buf = (*chunk)->tmpbufs[1].buf;
+    rh_buf = (*chunk)->tmpbufs[0].buf;
+    d_buf = (*chunk)->tmpbufs[1].buf;
 
     const char *sbuf;
     char *dbuf;
@@ -1053,14 +1072,22 @@ static int unpack_d2d_nop2p_acquire(yaksuri_request_s * reqpriv, yaksuri_subreq_
                         reqpriv->request->backend.outattr.device);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type,
-               reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device, NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+    if (op == YAKSA_OP__REPLACE && type->is_contig) {
+        rc = iunpack(id, rh_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
+                     reqpriv->info, subreq->u.multiple.op, reqpriv->request->backend.outattr.device,
+                     NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    } else {
+        rc = icopy(id, rh_buf, d_buf, (*chunk)->count, subreq->u.multiple.type,
+                   reqpriv->info, YAKSA_OP__REPLACE, reqpriv->request->backend.outattr.device,
+                   NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
 
-    rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
-                 reqpriv->info, subreq->u.multiple.op, reqpriv->request->backend.outattr.device,
-                 NULL);
-    YAKSU_ERR_CHECK(rc, fn_fail);
+        rc = iunpack(id, d_buf, dbuf, (*chunk)->count, subreq->u.multiple.type,
+                     reqpriv->info, subreq->u.multiple.op, reqpriv->request->backend.outattr.device,
+                     NULL);
+        YAKSU_ERR_CHECK(rc, fn_fail);
+    }
 
     rc = event_record(id, reqpriv->request->backend.outattr.device, &(*chunk)->event);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -2323,6 +2350,7 @@ static int set_subreq_pack_d2d(const void *inbuf, void *outbuf, uintptr_t count,
     else if (request->backend.inattr.device == request->backend.outattr.device && aligned) {
         rc = singlechunk_pack(id, request->backend.inattr.device, inbuf, outbuf, count,
                               type, info, op, request, subreq_ptr, stream);
+        YAKSU_ERR_CHECK(rc, fn_fail);
     }
     /* Slow paths */
     else if (request->backend.inattr.device == request->backend.outattr.device) {

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -264,7 +264,8 @@ static int simple_release(yaksuri_request_s * reqpriv, yaksuri_subreq_s * subreq
     DL_DELETE(subreq->u.multiple.chunks, chunk);
     free(chunk);
 
-    if (subreq->u.multiple.chunks == NULL) {
+    if (subreq->u.multiple.chunks == NULL &&
+        subreq->u.multiple.issued_count == subreq->u.multiple.count) {
         DL_DELETE(reqpriv->subreqs, subreq);
         yaksi_type_free(subreq->u.multiple.type);
         free(subreq);


### PR DESCRIPTION
In case of REPLACE operation and contiguous datatype, remove the unnecessary device bounce buffer used for packing or unpacking (which is only needed if it is non-contiguous type). This saves one extra copying for performance.


This PR optimizes for copy between device and unregistered host buffer, and between device to device (w/o p2p).

The third commit fixed a (long standing) bug in backend progress when a packing/unpacking of more than 16MB buffer may exit prematurely (i.e. when the device buffer pool runs out). We have seen validation errors on very large message in various OSU benchmarks due to this bug.

The fourth commit fixed a bug in ze for event_record.


## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
