### PR TITLE
build: do not install yaksa.pc in embedded mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,11 @@ EXTRA_PROGRAMS =
 .PHONY: doxygen
 
 pkgconfigdir = $(libdir)/pkgconfig
+if EMBEDDED_BUILD
+pkgconfig_DATA =
+else
 pkgconfig_DATA = maint/yaksa.pc
+endif !EMBEDDED_BUILD
 
 noinst_HEADERS =
 include_HEADERS =


### PR DESCRIPTION
## Pull Request Description

We should not install `yaksa.pc` in embedded mode.

When merged, will fix https://github.com/hzhou/yaksa/pull/new/2109_no_pc


<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
