### PR TITLE
frontend: enable use of -fvisibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,9 @@ else
     fi
 fi
 
+PAC_CHECK_VISIBILITY
+PAC_APPEND_FLAG([$YAKSA_VISIBILITY_CFLAGS],[CFLAGS])
+
 AC_HEADER_STDC
 
 # required pre-Automake-1.14

--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -11,14 +11,17 @@
 # --with-ze
 PAC_SET_HEADER_LIB_PATH([ze])
 if test "$with_ze" != "no" ; then
-    if test x"${with_ze}" != x ; then
-        PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeCommandQueueCreate],[have_ze=yes],[have_ze=no])
-        AC_MSG_CHECKING([whether ocloc is installed])
-        if ! command -v ocloc &> /dev/null; then
+    PAC_CHECK_HEADER_LIB([level_zero/ze_api.h],[ze_loader],[zeCommandQueueCreate],[have_ze=yes],[have_ze=no])
+    AC_MSG_CHECKING([whether ocloc is installed])
+    if ! command -v ocloc &> /dev/null; then
+        if test "$with_ze" = "yes" ; then
             AC_MSG_ERROR([ocloc not found; either install it or disable ze support])
         else
-            AC_MSG_RESULT([yes])
+            AC_MSG_RESULT([no])
+            have_ze=no
         fi
+    else
+        AC_MSG_RESULT([yes])
     fi
     # ze_api.h relies on support for c11
     if test "${have_ze}" = "yes" ; then

--- a/src/frontend/bounds/yaksa_bounds.c
+++ b/src/frontend/bounds/yaksa_bounds.c
@@ -8,7 +8,7 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_type_get_size(yaksa_type_t type, uintptr_t * size)
+YAKSA_API_PUBLIC int yaksa_type_get_size(yaksa_type_t type, uintptr_t * size)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
@@ -26,7 +26,7 @@ int yaksa_type_get_size(yaksa_type_t type, uintptr_t * size)
     goto fn_exit;
 }
 
-int yaksa_type_get_extent(yaksa_type_t type, intptr_t * lb, intptr_t * extent)
+YAKSA_API_PUBLIC int yaksa_type_get_extent(yaksa_type_t type, intptr_t * lb, intptr_t * extent)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;
@@ -45,7 +45,7 @@ int yaksa_type_get_extent(yaksa_type_t type, intptr_t * lb, intptr_t * extent)
     goto fn_exit;
 }
 
-int yaksa_type_get_true_extent(yaksa_type_t type, intptr_t * lb, intptr_t * extent)
+YAKSA_API_PUBLIC int yaksa_type_get_true_extent(yaksa_type_t type, intptr_t * lb, intptr_t * extent)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/flatten/yaksa_flatten.c
+++ b/src/frontend/flatten/yaksa_flatten.c
@@ -98,7 +98,7 @@ static int flatten(yaksi_type_s * type, void *flattened_type)
     goto fn_exit;
 }
 
-int yaksa_flatten(yaksa_type_t type, void *flattened_type)
+YAKSA_API_PUBLIC int yaksa_flatten(yaksa_type_t type, void *flattened_type)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;

--- a/src/frontend/flatten/yaksa_flatten_size.c
+++ b/src/frontend/flatten/yaksa_flatten_size.c
@@ -91,7 +91,7 @@ int yaksi_flatten_size(yaksi_type_s * type, uintptr_t * flattened_type_size)
     goto fn_exit;
 }
 
-int yaksa_flatten_size(yaksa_type_t type, uintptr_t * flattened_type_size)
+YAKSA_API_PUBLIC int yaksa_flatten_size(yaksa_type_t type, uintptr_t * flattened_type_size)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;

--- a/src/frontend/flatten/yaksa_unflatten.c
+++ b/src/frontend/flatten/yaksa_unflatten.c
@@ -127,7 +127,7 @@ static inline int unflatten(yaksi_type_s ** type, const void *flattened_type)
     goto fn_exit;
 }
 
-int yaksa_unflatten(yaksa_type_t * type, const void *flattened_type)
+YAKSA_API_PUBLIC int yaksa_unflatten(yaksa_type_t * type, const void *flattened_type)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_type_s *yaksi_type;

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -23,6 +23,16 @@
 #endif /* MPL_HAVE_GCC_ATTRIBUTE */
 #endif /* ATTRIBUTE */
 
+#if defined(YAKSA_C_HAVE_VISIBILITY)
+#if defined(__GNUC__) && !defined(__clang__)
+#define YAKSA_API_PUBLIC __attribute__((visibility ("default"), externally_visible))
+#else
+#define YAKSA_API_PUBLIC __attribute__((visibility ("default")))
+#endif
+#else
+#define YAKSA_API_PUBLIC
+#endif
+
 #define YAKSI_ENV_DEFAULT_NESTING_LEVEL  (3)
 
 extern yaksu_atomic_int yaksi_is_initialized;

--- a/src/frontend/info/yaksa_info.c
+++ b/src/frontend/info/yaksa_info.c
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <assert.h>
 
-int yaksa_info_create(yaksa_info_t * info)
+YAKSA_API_PUBLIC int yaksa_info_create(yaksa_info_t * info)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info;
@@ -29,7 +29,7 @@ int yaksa_info_create(yaksa_info_t * info)
     goto fn_exit;
 }
 
-int yaksa_info_free(yaksa_info_t info)
+YAKSA_API_PUBLIC int yaksa_info_free(yaksa_info_t info)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info = (yaksi_info_s *) info;
@@ -48,8 +48,8 @@ int yaksa_info_free(yaksa_info_t info)
     goto fn_exit;
 }
 
-int yaksa_info_keyval_append(yaksa_info_t info, const char *key, const void *val,
-                             unsigned int vallen)
+YAKSA_API_PUBLIC int yaksa_info_keyval_append(yaksa_info_t info, const char *key, const void *val,
+                                              unsigned int vallen)
 {
     int rc = YAKSA_SUCCESS;
     yaksi_info_s *yaksi_info = (yaksi_info_s *) info;

--- a/src/frontend/init/yaksa_init.c
+++ b/src/frontend/init/yaksa_init.c
@@ -145,7 +145,7 @@ static pthread_mutex_t init_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 #define CHUNK_SIZE (1024)
 
-int yaksa_init(yaksa_info_t info)
+YAKSA_API_PUBLIC int yaksa_init(yaksa_info_t info)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -278,7 +278,7 @@ int yaksa_init(yaksa_info_t info)
     goto fn_exit;
 }
 
-int yaksa_finalize(void)
+YAKSA_API_PUBLIC int yaksa_finalize(void)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/iov/yaksa_iov.c
+++ b/src/frontend/iov/yaksa_iov.c
@@ -366,8 +366,9 @@ int yaksi_iov(const char *buf, uintptr_t count, yaksi_type_s * type, uintptr_t i
     goto fn_exit;
 }
 
-int yaksa_iov(const char *buf, uintptr_t count, yaksa_type_t type, uintptr_t iov_offset,
-              struct iovec *iov, uintptr_t max_iov_len, uintptr_t * actual_iov_len)
+YAKSA_API_PUBLIC int yaksa_iov(const char *buf, uintptr_t count, yaksa_type_t type,
+                               uintptr_t iov_offset, struct iovec *iov, uintptr_t max_iov_len,
+                               uintptr_t * actual_iov_len)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/iov/yaksa_iov_len.c
+++ b/src/frontend/iov/yaksa_iov_len.c
@@ -20,7 +20,7 @@ int yaksi_iov_len(uintptr_t count, yaksi_type_s * type, uintptr_t * iov_len)
     return YAKSA_SUCCESS;
 }
 
-int yaksa_iov_len(uintptr_t count, yaksa_type_t type, uintptr_t * iov_len)
+YAKSA_API_PUBLIC int yaksa_iov_len(uintptr_t count, yaksa_type_t type, uintptr_t * iov_len)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/pup/yaksa_ipack.c
+++ b/src/frontend/pup/yaksa_ipack.c
@@ -7,9 +7,10 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
-                void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
-                yaksa_info_t info, yaksa_op_t op, yaksa_request_t * request)
+YAKSA_API_PUBLIC int yaksa_ipack(const void *inbuf, uintptr_t incount, yaksa_type_t type,
+                                 uintptr_t inoffset, void *outbuf, uintptr_t max_pack_bytes,
+                                 uintptr_t * actual_pack_bytes, yaksa_info_t info, yaksa_op_t op,
+                                 yaksa_request_t * request)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_iunpack.c
+++ b/src/frontend/pup/yaksa_iunpack.c
@@ -9,9 +9,10 @@
 #include <string.h>
 #include <assert.h>
 
-int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                  yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
-                  yaksa_info_t info, yaksa_op_t op, yaksa_request_t * request)
+YAKSA_API_PUBLIC int yaksa_iunpack(const void *inbuf, uintptr_t insize, void *outbuf,
+                                   uintptr_t outcount, yaksa_type_t type, uintptr_t outoffset,
+                                   uintptr_t * actual_unpack_bytes, yaksa_info_t info,
+                                   yaksa_op_t op, yaksa_request_t * request)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_pack.c
+++ b/src/frontend/pup/yaksa_pack.c
@@ -7,9 +7,9 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_pack(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
-               void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
-               yaksa_info_t info, yaksa_op_t op)
+YAKSA_API_PUBLIC int yaksa_pack(const void *inbuf, uintptr_t incount, yaksa_type_t type,
+                                uintptr_t inoffset, void *outbuf, uintptr_t max_pack_bytes,
+                                uintptr_t * actual_pack_bytes, yaksa_info_t info, yaksa_op_t op)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_pack_stream.c
+++ b/src/frontend/pup/yaksa_pack_stream.c
@@ -7,9 +7,10 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_pack_stream(const void *inbuf, uintptr_t incount, yaksa_type_t type, uintptr_t inoffset,
-                      void *outbuf, uintptr_t max_pack_bytes, uintptr_t * actual_pack_bytes,
-                      yaksa_info_t info, yaksa_op_t op, void *stream)
+YAKSA_API_PUBLIC int yaksa_pack_stream(const void *inbuf, uintptr_t incount, yaksa_type_t type,
+                                       uintptr_t inoffset, void *outbuf, uintptr_t max_pack_bytes,
+                                       uintptr_t * actual_pack_bytes, yaksa_info_t info,
+                                       yaksa_op_t op, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_request.c
+++ b/src/frontend/pup/yaksa_request.c
@@ -7,7 +7,7 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_request_test(yaksa_request_t request, int *completed)
+YAKSA_API_PUBLIC int yaksa_request_test(yaksa_request_t request, int *completed)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -40,7 +40,7 @@ int yaksa_request_test(yaksa_request_t request, int *completed)
     goto fn_exit;
 }
 
-int yaksa_request_wait(yaksa_request_t request)
+YAKSA_API_PUBLIC int yaksa_request_wait(yaksa_request_t request)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_unpack.c
+++ b/src/frontend/pup/yaksa_unpack.c
@@ -9,9 +9,9 @@
 #include <string.h>
 #include <assert.h>
 
-int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                 yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
-                 yaksa_info_t info, yaksa_op_t op)
+YAKSA_API_PUBLIC int yaksa_unpack(const void *inbuf, uintptr_t insize, void *outbuf,
+                                  uintptr_t outcount, yaksa_type_t type, uintptr_t outoffset,
+                                  uintptr_t * actual_unpack_bytes, yaksa_info_t info, yaksa_op_t op)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/pup/yaksa_unpack_stream.c
+++ b/src/frontend/pup/yaksa_unpack_stream.c
@@ -7,9 +7,10 @@
 #include "yaksu.h"
 #include <assert.h>
 
-int yaksa_unpack_stream(const void *inbuf, uintptr_t insize, void *outbuf, uintptr_t outcount,
-                        yaksa_type_t type, uintptr_t outoffset, uintptr_t * actual_unpack_bytes,
-                        yaksa_info_t info, yaksa_op_t op, void *stream)
+YAKSA_API_PUBLIC int yaksa_unpack_stream(const void *inbuf, uintptr_t insize, void *outbuf,
+                                         uintptr_t outcount, yaksa_type_t type, uintptr_t outoffset,
+                                         uintptr_t * actual_unpack_bytes, yaksa_info_t info,
+                                         yaksa_op_t op, void *stream)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_blkindx.c
+++ b/src/frontend/types/yaksa_blkindx.c
@@ -110,10 +110,10 @@ int yaksi_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
-                                     const intptr_t * array_of_displs,
-                                     yaksa_type_t oldtype, yaksa_info_t info,
-                                     yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
+                                                      const intptr_t * array_of_displs,
+                                                      yaksa_type_t oldtype, yaksa_info_t info,
+                                                      yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -141,9 +141,10 @@ int yaksa_type_create_hindexed_block(intptr_t count, intptr_t blocklength,
     goto fn_exit;
 }
 
-int yaksa_type_create_indexed_block(intptr_t count, intptr_t blocklength,
-                                    const intptr_t * array_of_displs,
-                                    yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_indexed_block(intptr_t count, intptr_t blocklength,
+                                                     const intptr_t * array_of_displs,
+                                                     yaksa_type_t oldtype, yaksa_info_t info,
+                                                     yaksa_type_t * newtype)
 {
     intptr_t *real_array_of_displs = NULL;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/types/yaksa_contig.c
+++ b/src/frontend/types/yaksa_contig.c
@@ -65,8 +65,8 @@ int yaksi_type_create_contig(intptr_t count, yaksi_type_s * intype, yaksi_type_s
     goto fn_exit;
 }
 
-int yaksa_type_create_contig(intptr_t count, yaksa_type_t oldtype, yaksa_info_t info,
-                             yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_contig(intptr_t count, yaksa_type_t oldtype,
+                                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_dup.c
+++ b/src/frontend/types/yaksa_dup.c
@@ -18,7 +18,8 @@ int yaksi_type_create_dup(yaksi_type_s * intype, yaksi_type_s ** newtype)
     return rc;
 }
 
-int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_dup(yaksa_type_t oldtype, yaksa_info_t info,
+                                           yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_free.c
+++ b/src/frontend/types/yaksa_free.c
@@ -85,7 +85,7 @@ int yaksi_type_free(yaksi_type_s * type)
     goto fn_exit;
 }
 
-int yaksa_type_free(yaksa_type_t type)
+YAKSA_API_PUBLIC int yaksa_type_free(yaksa_type_t type)
 {
     yaksi_type_s *yaksi_type;
     int rc = YAKSA_SUCCESS;

--- a/src/frontend/types/yaksa_indexed.c
+++ b/src/frontend/types/yaksa_indexed.c
@@ -130,9 +130,11 @@ int yaksi_type_create_hindexed(intptr_t count, const intptr_t * array_of_blockle
     goto fn_exit;
 }
 
-int yaksa_type_create_hindexed(intptr_t count, const intptr_t * array_of_blocklengths,
-                               const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                               yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_hindexed(intptr_t count,
+                                                const intptr_t * array_of_blocklengths,
+                                                const intptr_t * array_of_displs,
+                                                yaksa_type_t oldtype, yaksa_info_t info,
+                                                yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -166,9 +168,11 @@ int yaksa_type_create_hindexed(intptr_t count, const intptr_t * array_of_blockle
     goto fn_exit;
 }
 
-int yaksa_type_create_indexed(intptr_t count, const intptr_t * array_of_blocklengths,
-                              const intptr_t * array_of_displs, yaksa_type_t oldtype,
-                              yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_indexed(intptr_t count,
+                                               const intptr_t * array_of_blocklengths,
+                                               const intptr_t * array_of_displs,
+                                               yaksa_type_t oldtype, yaksa_info_t info,
+                                               yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
     intptr_t *real_array_of_blocklengths = (intptr_t *) malloc(count * sizeof(intptr_t));

--- a/src/frontend/types/yaksa_resized.c
+++ b/src/frontend/types/yaksa_resized.c
@@ -58,8 +58,8 @@ int yaksi_type_create_resized(yaksi_type_s * intype, intptr_t lb, intptr_t exten
     goto fn_exit;
 }
 
-int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, intptr_t extent,
-                              yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_resized(yaksa_type_t oldtype, intptr_t lb, intptr_t extent,
+                                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_struct.c
+++ b/src/frontend/types/yaksa_struct.c
@@ -150,10 +150,11 @@ int yaksi_type_create_struct(intptr_t count, const intptr_t * array_of_blockleng
     goto fn_exit;
 }
 
-int yaksa_type_create_struct(intptr_t count, const intptr_t * array_of_blocklengths,
-                             const intptr_t * array_of_displs,
-                             const yaksa_type_t * array_of_types, yaksa_info_t info,
-                             yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_struct(intptr_t count,
+                                              const intptr_t * array_of_blocklengths,
+                                              const intptr_t * array_of_displs,
+                                              const yaksa_type_t * array_of_types,
+                                              yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_subarray.c
+++ b/src/frontend/types/yaksa_subarray.c
@@ -128,10 +128,11 @@ int yaksi_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
     goto fn_exit;
 }
 
-int yaksa_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
-                               const intptr_t * array_of_subsizes,
-                               const intptr_t * array_of_starts, yaksa_subarray_order_e order,
-                               yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_subarray(int ndims, const intptr_t * array_of_sizes,
+                                                const intptr_t * array_of_subsizes,
+                                                const intptr_t * array_of_starts,
+                                                yaksa_subarray_order_e order, yaksa_type_t oldtype,
+                                                yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 

--- a/src/frontend/types/yaksa_vector.c
+++ b/src/frontend/types/yaksa_vector.c
@@ -83,8 +83,9 @@ int yaksi_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t str
     goto fn_exit;
 }
 
-int yaksa_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t stride,
-                              yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_hvector(intptr_t count, intptr_t blocklength,
+                                               intptr_t stride, yaksa_type_t oldtype,
+                                               yaksa_info_t info, yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 
@@ -112,8 +113,9 @@ int yaksa_type_create_hvector(intptr_t count, intptr_t blocklength, intptr_t str
     goto fn_exit;
 }
 
-int yaksa_type_create_vector(intptr_t count, intptr_t blocklength, intptr_t stride,
-                             yaksa_type_t oldtype, yaksa_info_t info, yaksa_type_t * newtype)
+YAKSA_API_PUBLIC int yaksa_type_create_vector(intptr_t count, intptr_t blocklength, intptr_t stride,
+                                              yaksa_type_t oldtype, yaksa_info_t info,
+                                              yaksa_type_t * newtype)
 {
     int rc = YAKSA_SUCCESS;
 


### PR DESCRIPTION
Allow --enable-visibility to be used with configure
With -fvisibility=hidden, the entries of dynamic symbol table reduced from 17137 to 35:

```
nm -D ./libyaksa.so |  grep " T " | wc -l
35
```

Hopefully this improves the library loading.
It also reduced the binary by 2.3MB, which however is still huge at 864MB (with ze enabled).



## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
