### PR TITLE
backend/ze: nullify pNext in ze_module_desc_t before loading kernels

### DIFF
--- a/src/backend/ze/hooks/yaksuri_zei_type_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_zei_type_hooks.c
@@ -28,6 +28,7 @@ static ze_result_t yaksuri_ze_load_module(int module, ze_module_handle_t ** hand
 
         for (d = 0; d < yaksuri_zei_global.ndevices; d++) {
             ze_module_desc_t desc = { ZE_STRUCTURE_TYPE_MODULE_DESC };
+            desc.pNext = NULL;
 #if ZE_NATIVE
             desc.format = ZE_MODULE_FORMAT_NATIVE;
             desc.pBuildFlags = NULL;


### PR DESCRIPTION
bug fix for an uninitialized field in ze_module_desc_t

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
