### PR TITLE
util: Do not warn on leaked handles by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,7 @@ AC_ARG_ENABLE([g],AS_HELP_STRING([--enable-g],[alias for --enable-debug]),,[enab
 AC_ARG_ENABLE([debug],AS_HELP_STRING([--enable-debug],[adds -g to CFLAGS]),,[enable_debug=${enable_g}])
 if test "${enable_debug}" != "no" ; then
     PAC_APPEND_FLAG([-g],[CFLAGS])
+    AC_DEFINE(YAKSA_DEBUG, [1], [Define if debugging is enabled])
 fi
 
 # --enable-fast

--- a/src/util/yaksu_buffer_pool.c
+++ b/src/util/yaksu_buffer_pool.c
@@ -115,11 +115,13 @@ int yaksu_buffer_pool_free(yaksu_buffer_pool_s pool)
     pthread_mutex_lock(&global_mutex);
 
     /* throw a warning if the used hashmap is not empty */
+#ifdef YAKSA_DEBUG
     int count = HASH_COUNT(pool_head->used_elems);
     if (count) {
         fprintf(stderr, "[WARNING] yaksa: %d leaked buffer pool objects\n", count);
         fflush(stderr);
     }
+#endif
 
     /* free the freelist elements */
     elem_s *el, *el_tmp;


### PR DESCRIPTION
## Pull Request Description

Only warn if handles are leaked in debug mode. MPICH users have noticed
yaksa warnings in default builds, which traditionally have not warned on
leaked MPI handles. This aligns the behavior between the two packages.

## Expected Impact

Silence leak warnings in default builds.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
