### PR TITLE
Use Streaming Store For Cross-Socket Memory Copies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -216,6 +216,13 @@ if test "${have_c11_atomics}" = "yes"; then
 fi
 AM_CONDITIONAL([HAVE_C11_ATOMICS], [test x${have_c11_atomics} = xyes])
 
+# look for x86 intrinsics
+AC_CHECK_HEADERS([immintrin.h],[have_immintrin=yes],[have_immintrin=no])
+if test "${have_immintrin}" = "yes"; then
+    AC_DEFINE([HAVE_IMMINTRIN_H],[1],[Define if x86 intrinsics are available])
+fi
+AM_CONDITIONAL([HAVE_IMMINTRIN_H], [test x${have_immintrin} = xyes])
+
 # look for pthreads
 AC_CHECK_HEADERS(pthread.h)
 AC_CHECK_LIB([pthread],[pthread_key_create],have_pthreads=yes)

--- a/configure.ac
+++ b/configure.ac
@@ -152,12 +152,16 @@ for option in ${enable_fast} ; do
         ndebug)
             PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
             ;;
+        avx)
+            enable_fast_avx_instr=yes
+            ;;
         all|yes)
             PAC_APPEND_FLAG([-O2],[CFLAGS])
             PAC_APPEND_FLAG([-DNDEBUG],[CFLAGS])
             ;;
         none|no)
             PAC_APPEND_FLAG([-O0],[CFLAGS])
+            enable_fast_avx_instr=no
             ;;
         *)
             # ignore unknown options
@@ -166,6 +170,39 @@ for option in ${enable_fast} ; do
 done
 PAC_POP_FLAG(IFS)
 
+if test "$enable_fast_avx_instr" = "yes" ; then
+    AC_CACHE_CHECK([whether -mavx is supported], pac_cv_found_avx,
+                   [PAC_C_CHECK_COMPILER_OPTION([-mavx],pac_cv_found_avx=yes,pac_cv_found_avx=no)],
+                   pac_cv_found_avx=no,pac_cv_found_avx=yes)
+    if test "$pac_cv_found_avx" = "yes" ; then
+        PAC_APPEND_FLAG([-mavx],[CFLAGS])
+        PAC_APPEND_FLAG([-mavx],[CXXFLAGS])
+        PAC_APPEND_FLAG([-mavx],[FFLAGS])
+        PAC_APPEND_FLAG([-mavx],[FCFLAGS])
+
+        AC_CACHE_CHECK([whether _mm256_stream_si256 is supported], pac_cv_found__mm256_stream_si256,[
+                        AC_RUN_IFELSE([AC_LANG_SOURCE([[
+                                       #include <immintrin.h>
+
+                                       int main(int argc, char **argv) {
+                                           char source[1024], dest[1024];
+                                           for (int i = 0; i < 1024; i++) source[i] = 'a';
+
+                                           __m256i ymm0 = _mm256_loadu_si256((__m256i const *) source);
+                                           _mm256_stream_si256((__m256i *) dest, ymm0);
+
+                                           if (dest[0] == source[0]) return 0;
+                                           else return 1;
+                                       }
+                                       ]])], pac_cv_found__mm256_stream_si256="yes",
+                                       pac_cv_found__mm256_stream_si256="no",
+                                       pac_cv_found__mm256_stream_si256="unknown")
+                        ])
+    fi
+    if test "$pac_cv_found__mm256_stream_si256" = "yes" ; then
+        AC_DEFINE(HAVE_MM256_STREAM_SI256,1,[Define if 256 bit streaming memcpy is available])
+    fi
+fi
 
 dnl ----------------------------------------------------------------------------
 dnl check the environment and the availability of functions

--- a/src/backend/seq/hooks/yaksuri_seq_hooks.c
+++ b/src/backend/seq/hooks/yaksuri_seq_hooks.c
@@ -83,6 +83,9 @@ int yaksuri_seq_info_keyval_append(yaksi_info_s * info, const char *key, const v
     } else if (!strncmp(key, "yaksa_seq_iov_unpack_threshold", YAKSA_INFO_MAX_KEYLEN)) {
         assert(vallen == sizeof(uintptr_t));
         seq->iov_unpack_threshold = (uintptr_t) val;
+    } else if (!strncmp(key, "yaksa_seq_stream_copy", YAKSA_INFO_MAX_KEYLEN)) {
+        assert(vallen == sizeof(int));
+        seq->stream_cpy = *((int *) val);
     }
 
     return YAKSA_SUCCESS;

--- a/src/backend/seq/include/yaksuri_seqi.h
+++ b/src/backend/seq/include/yaksuri_seqi.h
@@ -23,6 +23,8 @@ typedef struct yaksuri_seqi_type_s {
 typedef struct {
     uintptr_t iov_pack_threshold;
     uintptr_t iov_unpack_threshold;
+    int stream_cpy; /* If this is true, then the copy can be done with a streaming copy
+                     * (non-temporal write that doesn't make memory resident in writer's cache). */
 } yaksuri_seqi_info_s;
 
 int yaksuri_seqi_populate_pupfns(yaksi_type_s * type);

--- a/src/util/yaksu.h
+++ b/src/util/yaksu.h
@@ -10,5 +10,6 @@
 #include "yaksu_atomics.h"
 #include "yaksu_buffer_pool.h"
 #include "yaksu_handle_pool.h"
+#include "yaksu_mem.h"
 
 #endif /* YAKSU_H_INCLUDED */

--- a/src/util/yaksu_mem.h
+++ b/src/util/yaksu_mem.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) by Argonne National Laboratory
+ *     See COPYRIGHT in top-level directory
+ */
+
+#ifndef YAKSU_MEM_H_INCLUDED
+#define YAKSU_MEM_H_INCLUDED
+
+#define YAKSU_MEMCPY__SYSTEM        0
+
+static inline void *yaksu_memcpy(void *dest, const void *src, size_t n, int memcpy_type)
+{
+    switch(memcpy_type) {
+        case YAKSU_MEMCPY__SYSTEM:
+            return memcpy(dest, src, n);
+        default:
+            /* Using an invalid memcpy type */
+            assert(0);
+    }
+}
+
+#endif /* YAKSU_MEM_H_INCLUDED */

--- a/src/util/yaksu_mem.h
+++ b/src/util/yaksu_mem.h
@@ -6,16 +6,103 @@
 #ifndef YAKSU_MEM_H_INCLUDED
 #define YAKSU_MEM_H_INCLUDED
 
+#ifdef HAVE_MM256_STREAM_SI256
+#include <immintrin.h>
+#endif
+#include "string.h"
+
 #define YAKSU_MEMCPY__SYSTEM        0
+#define YAKSU_MEMCPY__STREAM        1
+
+static inline void *yaksu_stream_memcpy(void *dest, const void *src, size_t n)
+{
+#ifdef HAVE_MM256_STREAM_SI256
+    if (n <= 256) {
+        return memcpy(dest, src, n);
+    }
+
+    char *d = (char *) dest;
+    const char *s = (const char *) src;
+
+    /* Copy the first 63 bits or less (if the address isn't 64-bit aligned) using a regular memcpy to
+     * make the rest faster */
+    if (((uintptr_t)d) & 63) {
+        const uintptr_t t = 64 - (((uintptr_t)d) & 63);
+        memcpy(d, s, t);
+        d += t;
+        s += t;
+        n -= t;
+    }
+
+    /* Copy 256, 128, and then 64 bit chunks using the non-temporal store to pipeline as much as
+     * possible. */
+    while (n >= 256) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *)(s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *)(s + (32 * 1)));
+        __m256i ymm2 = _mm256_loadu_si256((__m256i const *)(s + (32 * 2)));
+        __m256i ymm3 = _mm256_loadu_si256((__m256i const *)(s + (32 * 3)));
+        __m256i ymm4 = _mm256_loadu_si256((__m256i const *)(s + (32 * 4)));
+        __m256i ymm5 = _mm256_loadu_si256((__m256i const *)(s + (32 * 5)));
+        __m256i ymm6 = _mm256_loadu_si256((__m256i const *)(s + (32 * 6)));
+        __m256i ymm7 = _mm256_loadu_si256((__m256i const *)(s + (32 * 7)));
+        _mm256_stream_si256((__m256i *)(d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *)(d + (32 * 1)), ymm1);
+        _mm256_stream_si256((__m256i *)(d + (32 * 2)), ymm2);
+        _mm256_stream_si256((__m256i *)(d + (32 * 3)), ymm3);
+        _mm256_stream_si256((__m256i *)(d + (32 * 4)), ymm4);
+        _mm256_stream_si256((__m256i *)(d + (32 * 5)), ymm5);
+        _mm256_stream_si256((__m256i *)(d + (32 * 6)), ymm6);
+        _mm256_stream_si256((__m256i *)(d + (32 * 7)), ymm7);
+        d += 256;
+        s += 256;
+        n -= 256;
+    }
+
+    if (n & 128) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *)(s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *)(s + (32 * 1)));
+        __m256i ymm2 = _mm256_loadu_si256((__m256i const *)(s + (32 * 2)));
+        __m256i ymm3 = _mm256_loadu_si256((__m256i const *)(s + (32 * 3)));
+        _mm256_stream_si256((__m256i *)(d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *)(d + (32 * 1)), ymm1);
+        _mm256_stream_si256((__m256i *)(d + (32 * 2)), ymm2);
+        _mm256_stream_si256((__m256i *)(d + (32 * 3)), ymm3);
+        d += 128;
+        s += 128;
+    }
+
+    if (n & 64) {
+        __m256i ymm0 = _mm256_loadu_si256((__m256i const *)(s + (32 * 0)));
+        __m256i ymm1 = _mm256_loadu_si256((__m256i const *)(s + (32 * 1)));
+        _mm256_stream_si256((__m256i *)(d + (32 * 0)), ymm0);
+        _mm256_stream_si256((__m256i *)(d + (32 * 1)), ymm1);
+        d += 64;
+        s += 64;
+    }
+
+    /* If there is any data left, copy it using a regular memcpy */
+    if (n & 63) {
+        memcpy(d, s, (n & 63));
+    }
+
+    _mm_sfence();
+
+    return d;
+#else
+    return memcpy(dest, src, n);
+#endif
+}
 
 static inline void *yaksu_memcpy(void *dest, const void *src, size_t n, int memcpy_type)
 {
     switch(memcpy_type) {
+        case YAKSU_MEMCPY__STREAM:
+            return yaksu_stream_memcpy(dest, src, n);
         case YAKSU_MEMCPY__SYSTEM:
             return memcpy(dest, src, n);
         default:
-            /* Using an invalid memcpy type */
-            assert(0);
+            /* Using an invalid memcpy type so fall back to the default memcpy implementation. */
+    return memcpy(dest, src, n);
     }
 }
 


### PR DESCRIPTION
## Pull Request Description

This PR is essentially a duplicate of https://github.com/pmodels/mpich/pull/5758, but for data copies in Yaksa rather than in MPICH. I'll copy the description from that PR:

Adds a new type of `memcpy` that uses the AVX instruction `_mm256_stream_si256` to perform a streaming copy that writes data without bringing it into the cache of the writing process. This is used with the iqueue send code to avoid extra latency, especially when writing data from a process located on one socket to a process located on another socket.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
