### PR TITLE
Fix build with Nvidia HPC compilers

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -66,9 +66,9 @@ if test "$with_cuda" != "no" ; then
 EOF
         if test -n "$ac_save_CC" ; then
             NVCC_FLAGS="-ccbin $ac_save_CC"
-            # - pgcc doesn't work, use pgc++ instead
+            # - pgcc/nvc doesn't work, use pgc++/nvc++ instead
             # - Extra optins such as `gcc -std=gnu99` doesn't work, strip the option
-            NVCC_FLAGS=$(echo $NVCC_FLAGS | sed -e 's/pgcc/pgc++/g' -e's/ -std=.*//g')
+            NVCC_FLAGS=$(echo $NVCC_FLAGS | sed -e 's/nvc/nvc++/g' -e 's/pgcc/pgc++/g' -e's/ -std=.*//g')
         else
             NVCC_FLAGS=""
         fi

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -73,10 +73,10 @@ EOF
             NVCC_FLAGS=""
         fi
         # try nvcc from PATH if 'with-cuda' does not contain a valid path
-        if test ${with_cuda} == "yes"; then
-            nvcc_bin="nvcc"
-        else
+        if test -d ${with_cuda} ; then
             nvcc_bin=${with_cuda}/bin/nvcc
+        else
+            nvcc_bin=nvcc
         fi
         ${nvcc_bin} $NVCC_FLAGS -c conftest.cu 2> /dev/null
         if test "$?" = "0" ; then


### PR DESCRIPTION
## Pull Request Description

Apply same fix we did for building with PGI compilers, since they are the same as nvc/nvc++.

## Expected Impact

Fix CUDA-aware builds with nvc/nvc++.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
