### PR TITLE
backend/ze: fix warnings about unused labels

### DIFF
--- a/src/backend/ze/hooks/yaksuri_zei_type_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_zei_type_hooks.c
@@ -184,9 +184,9 @@ int yaksuri_zei_type_create_hook(yaksi_type_s * type)
         if (ze->pack[i] != YAKSURI_KERNEL_NULL) {
             pthread_mutex_lock(&yaksuri_zei_global.ze_mutex);
             zerr = yaksuri_ze_load_kernel(ze->pack[i], &ze->pack_kernels[i]);
-            YAKSURI_ZEI_ZE_ERR_CHECK(zerr);
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
             zerr = yaksuri_ze_load_kernel(ze->unpack[i], &ze->unpack_kernels[i]);
-            YAKSURI_ZEI_ZE_ERR_CHECK(zerr);
+            YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
             pthread_mutex_unlock(&yaksuri_zei_global.ze_mutex);
         }
     }

--- a/src/backend/ze/pup/yaksuri_zei_event.c
+++ b/src/backend/ze/pup/yaksuri_zei_event.c
@@ -123,8 +123,6 @@ int yaksuri_zei_event_record(int device, void **event_)
   fn_exit:
     pthread_mutex_unlock(&device_state->mutex);
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 int yaksuri_zei_event_query(void *event_, int *completed)

--- a/src/backend/ze/pup/yaksuri_zei_pup.c
+++ b/src/backend/ze/pup/yaksuri_zei_pup.c
@@ -419,10 +419,7 @@ int yaksuri_zei_synchronize(int target)
     int rc = YAKSA_SUCCESS;
     rc = yaksuri_zei_add_dependency(target, -1);
 
-  fn_exit:
     return rc;
-  fn_fail:
-    goto fn_exit;
 }
 
 int yaksuri_zei_flush_all(void)


### PR DESCRIPTION
Fixes a few unused label warnings

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
