### PR TITLE
cuda: Delay stream creation

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -65,17 +65,17 @@ static int finalize_hook(void)
     cudaError_t cerr;
 
     for (int i = 0; i < yaksuri_cudai_global.ndevices; i++) {
-        if (yaksuri_cudai_global.stream[i] != 0) {
+        if (yaksuri_cudai_global.streams[i].created) {
             cerr = cudaSetDevice(i);
             YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-            cerr = cudaStreamDestroy(yaksuri_cudai_global.stream[i]);
+            cerr = cudaStreamDestroy(yaksuri_cudai_global.streams[i].stream);
             YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
         }
 
         free(yaksuri_cudai_global.p2p[i]);
     }
-    free(yaksuri_cudai_global.stream);
+    free(yaksuri_cudai_global.streams);
     free(yaksuri_cudai_global.p2p);
 
   fn_exit:
@@ -141,8 +141,7 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
         }
     }
 
-    yaksuri_cudai_global.stream = (cudaStream_t *)
-        calloc(yaksuri_cudai_global.ndevices, sizeof(cudaStream_t));
+    yaksuri_cudai_global.streams = calloc(yaksuri_cudai_global.ndevices, sizeof(cudai_stream));
 
     yaksuri_cudai_global.p2p = (bool **) malloc(yaksuri_cudai_global.ndevices * sizeof(bool *));
     for (int i = 0; i < yaksuri_cudai_global.ndevices; i++) {

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -97,6 +97,20 @@ int yaksuri_cudai_pup_is_supported(yaksi_type_s * type, yaksa_op_t op, bool * is
 uintptr_t yaksuri_cudai_get_iov_pack_threshold(yaksi_info_s * info);
 uintptr_t yaksuri_cudai_get_iov_unpack_threshold(yaksi_info_s * info);
 
+static inline cudaStream_t *yaksuri_cudai_get_stream(int device)
+{
+    if (yaksuri_cudai_global.stream[device] == 0) {
+        int cur_device;
+        cudaGetDevice(&cur_device);
+
+        cudaSetDevice(device);
+        cudaStreamCreateWithFlags(&yaksuri_cudai_global.stream[device], cudaStreamNonBlocking);
+
+        cudaSetDevice(cur_device);
+    }
+    return &yaksuri_cudai_global.stream[device];
+}
+
 /* *INDENT-OFF* */
 #ifdef __cplusplus
 }

--- a/src/backend/cuda/include/yaksuri_cudai.h
+++ b/src/backend/cuda/include/yaksuri_cudai.h
@@ -99,16 +99,18 @@ uintptr_t yaksuri_cudai_get_iov_unpack_threshold(yaksi_info_s * info);
 
 static inline cudaStream_t *yaksuri_cudai_get_stream(int device)
 {
-    if (yaksuri_cudai_global.stream[device] == 0) {
+    if (!yaksuri_cudai_global.streams[device].created) {
         int cur_device;
         cudaGetDevice(&cur_device);
 
         cudaSetDevice(device);
-        cudaStreamCreateWithFlags(&yaksuri_cudai_global.stream[device], cudaStreamNonBlocking);
+        cudaStreamCreateWithFlags(&yaksuri_cudai_global.streams[device].stream,
+                                  cudaStreamNonBlocking);
+        yaksuri_cudai_global.streams[device].created = true;
 
         cudaSetDevice(cur_device);
     }
-    return &yaksuri_cudai_global.stream[device];
+    return &yaksuri_cudai_global.streams[device].stream;
 }
 
 /* *INDENT-OFF* */

--- a/src/backend/cuda/include/yaksuri_cudai_base.h
+++ b/src/backend/cuda/include/yaksuri_cudai_base.h
@@ -18,10 +18,15 @@
         }                                                               \
     } while (0)
 
+typedef struct cudai_stream_s {
+    bool created;
+    cudaStream_t stream;
+} cudai_stream;
+
 typedef struct {
     int ndevices;
-    cudaStream_t *stream;
-    bool **p2p;
+    cudai_stream *streams;      /* array of lazily created streams, one for each device */
+    bool **p2p;                 /* p2p[sdev][ddev] */
 } yaksuri_cudai_global_s;
 extern yaksuri_cudai_global_s yaksuri_cudai_global;
 

--- a/src/backend/cuda/pup/yaksuri_cudai_event.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_event.c
@@ -30,7 +30,7 @@ int yaksuri_cudai_event_record(int device, void **event_)
     cerr = cudaEventCreate(&event->event);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaEventRecord(event->event, yaksuri_cudai_global.stream[device]);
+    cerr = cudaEventRecord(event->event, *yaksuri_cudai_get_stream(device));
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (cur_device != device) {
@@ -90,7 +90,7 @@ int yaksuri_cudai_add_dependency(int device1, int device2)
     cerr = cudaEventCreate(&event);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-    cerr = cudaEventRecord(event, yaksuri_cudai_global.stream[device1]);
+    cerr = cudaEventRecord(event, *yaksuri_cudai_get_stream(device1));
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (cur_device != device1) {
@@ -99,7 +99,7 @@ int yaksuri_cudai_add_dependency(int device1, int device2)
     }
 
     /* add a dependency on that event for the second device */
-    cerr = cudaStreamWaitEvent(yaksuri_cudai_global.stream[device2], event, 0);
+    cerr = cudaStreamWaitEvent(*yaksuri_cudai_get_stream(device2), event, 0);
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     /* destroy the temporary event */

--- a/src/backend/cuda/pup/yaksuri_cudai_pup.c
+++ b/src/backend/cuda/pup/yaksuri_cudai_pup.c
@@ -216,14 +216,14 @@ int yaksuri_cudai_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
                         yaksi_info_s * info, yaksa_op_t op, int target)
 {
     return yaksuri_cudai_ipack_with_stream(inbuf, outbuf, count, type, info, op, target,
-                                           &yaksuri_cudai_global.stream[target]);
+                                           yaksuri_cudai_get_stream(target));
 }
 
 int yaksuri_cudai_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
                           yaksi_info_s * info, yaksa_op_t op, int target)
 {
     return yaksuri_cudai_iunpack_with_stream(inbuf, outbuf, count, type, info, op, target,
-                                             &yaksuri_cudai_global.stream[target]);
+                                             yaksuri_cudai_get_stream(target));
 }
 
 int yaksuri_cudai_synchronize(int target)
@@ -231,7 +231,7 @@ int yaksuri_cudai_synchronize(int target)
     int rc = YAKSA_SUCCESS;
     cudaError_t cerr;
 
-    cerr = cudaStreamSynchronize(yaksuri_cudai_global.stream[target]);
+    cerr = cudaStreamSynchronize(*yaksuri_cudai_get_stream(target));
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
   fn_exit:


### PR DESCRIPTION
## Pull Request Description

Some applications may seutp GPU affinity after MPI initialization. Delay
CUDA stream creation during yaksa init to avoid allocating resources on
GPUs a process may never use. See #212.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>

## Expected Impact

Avoid allocating resources on devices that will not be used.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
