### PR TITLE
cuda: Allow configure to continue after nvcc check

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -89,29 +89,32 @@ if test "$with_cuda" != "no" ; then
         ],[
             have_cuda=no
             AC_MSG_RESULT([no])
-            AC_MSG_ERROR([CUDA was not functional with provided host compiler (CC)])
         ])
         # done with CUDA, back to C
         AC_LANG_POP([C])
 
-        # nvcc compiled applications need libstdc++ to be able to link
-        # with a C compiler
-        AC_MSG_CHECKING([if $CC can link libstdc++])
-        PAC_PUSH_FLAG([LIBS])
-        PAC_APPEND_FLAG([-lstdc++],[LIBS])
-        AC_LINK_IFELSE(
-            [AC_LANG_PROGRAM([int x = 5;],[x++;])],
-            [libstdcpp_works=yes],
-            [libstdcpp_works=no])
-        PAC_POP_FLAG([LIBS])
-        if test "${libstdcpp_works}" = "yes" ; then
+        if test "${have_cuda}" != "no" ; then
+            # nvcc compiled applications need libstdc++ to be able to link
+            # with a C compiler
+            AC_MSG_CHECKING([if $CC can link libstdc++])
+            PAC_PUSH_FLAG([LIBS])
             PAC_APPEND_FLAG([-lstdc++],[LIBS])
-            AC_MSG_RESULT([yes])
-        else
-            have_cuda=no
-            AC_MSG_RESULT([no])
+            AC_LINK_IFELSE(
+                [AC_LANG_PROGRAM([int x = 5;],[x++;])],
+                [libstdcpp_works=yes],
+                [libstdcpp_works=no])
+            PAC_POP_FLAG([LIBS])
+            if test "${libstdcpp_works}" = "yes" ; then
+                PAC_APPEND_FLAG([-lstdc++],[LIBS])
+                AC_MSG_RESULT([yes])
+            else
+                have_cuda=no
+                AC_MSG_RESULT([no])
+            fi
         fi
     fi
+
+    # if the user requested CUDA and it didn't work, throw an error
     if test "${have_cuda}" = "no" -a "$with_cuda" != ""; then
         AC_MSG_ERROR([CUDA was requested but it is not functional])
     fi


### PR DESCRIPTION
## Pull Request Description

cuda: Allow configure to continue after nvcc check

If CUDA was not explicitly requested, it is possible that configure will
find the CUDA runtime library, then throw an error when it fails to find
nvcc. Remove AC_MSG_ERROR from the nvcc check, and instead let the
have_cuda/with_cuda variables determine if configure should continue
without CUDA support or throw an error. This fixes a build issue in the
Spack Gitlab CI environment.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>

## Expected Impact

Fix default builds where CUDA libraries are available but `nvcc` is not in PATH.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
