### PR TITLE
cuda: delay query p2p accessibility

### DIFF
--- a/src/backend/cuda/include/yaksuri_cudai_base.h
+++ b/src/backend/cuda/include/yaksuri_cudai_base.h
@@ -26,7 +26,7 @@ typedef struct cudai_stream_s {
 typedef struct {
     int ndevices;
     cudai_stream *streams;      /* array of lazily created streams, one for each device */
-    bool **p2p;                 /* p2p[sdev][ddev] */
+    int **p2p;                  /* p2p[sdev][ddev] */
 } yaksuri_cudai_global_s;
 extern yaksuri_cudai_global_s yaksuri_cudai_global;
 


### PR DESCRIPTION
## Pull Request Description

Calling cudaDeviceEnablePeerAccess may have the side effects of marking
off resource. Delay that to when we acutally need it.


<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
