### PR TITLE
backend/ze: add --ze-revision-id option to add rev id to ocloc compiler

### DIFF
--- a/src/backend/ze/pup/Makefile.mk
+++ b/src/backend/ze/pup/Makefile.mk
@@ -18,8 +18,8 @@ if BUILD_ZE_NATIVE
 
 .cl.c:
 	@echo "  OCLOC (native)  $<" ; \
-	ocloc compile -file $< -device $(ze_native_TARGET) -out_dir `dirname $@` -output_no_suffix -q -options "-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0" && \
-	mv $(@:.c=) $(@:.c=.bin) && /bin/rm -f $(@:.c=.gen); \
+	ocloc compile -file $< -device $(ze_native_TARGET) -out_dir `dirname $@` -output_no_suffix -q -options "-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0" @extra_ocloc_options@ && \
+	mv $(@:.c=) $(@:.c=.bin) && /bin/rm -f $(@:.c=.gen) && \
 	$(top_srcdir)/src/backend/ze/pup/inline.py $(@:.c=.bin) $@ $(top_srcdir) 1
 
 else


### PR DESCRIPTION
For native compilation of Intel GPU kernels, a revision id may be needed for the ocloc compiler.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
