### PR TITLE
genpup: fix code generation for pup_max_nesting < 2

### DIFF
--- a/src/backend/cuda/genpup.py
+++ b/src/backend/cuda/genpup.py
@@ -239,26 +239,27 @@ if __name__ == '__main__':
         sys.exit(1)
 
     ##### generate the core pack/unpack kernels (zero levels)
-    for b in builtin_types:
-        filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s.cu" % b.replace(" ","_")
-        yutils.copyright_c(filename)
-        OUTFILE = open(filename, "a")
-        yutils.display(OUTFILE, "#include <string.h>\n")
-        yutils.display(OUTFILE, "#include <stdint.h>\n")
-        yutils.display(OUTFILE, "#include <wchar.h>\n")
-        yutils.display(OUTFILE, "#include <assert.h>\n")
-        yutils.display(OUTFILE, "#include <cuda.h>\n")
-        yutils.display(OUTFILE, "#include <cuda_runtime.h>\n")
-        yutils.display(OUTFILE, "#include \"yaksuri_cudai_base.h\"\n")
-        yutils.display(OUTFILE, "#include \"yaksuri_cudai_pup.h\"\n")
-        yutils.display(OUTFILE, "\n")
+    if args.pup_max_nesting > 0:
+        for b in builtin_types:
+            filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s.cu" % b.replace(" ","_")
+            yutils.copyright_c(filename)
+            OUTFILE = open(filename, "a")
+            yutils.display(OUTFILE, "#include <string.h>\n")
+            yutils.display(OUTFILE, "#include <stdint.h>\n")
+            yutils.display(OUTFILE, "#include <wchar.h>\n")
+            yutils.display(OUTFILE, "#include <assert.h>\n")
+            yutils.display(OUTFILE, "#include <cuda.h>\n")
+            yutils.display(OUTFILE, "#include <cuda_runtime.h>\n")
+            yutils.display(OUTFILE, "#include \"yaksuri_cudai_base.h\"\n")
+            yutils.display(OUTFILE, "#include \"yaksuri_cudai_pup.h\"\n")
+            yutils.display(OUTFILE, "\n")
 
-        emptylist = [ ]
-        for op in gencomm.type_ops[b]:
-            generate_kernels(b, emptylist, op)
-        generate_host_function(b, emptylist)
+            emptylist = [ ]
+            for op in gencomm.type_ops[b]:
+                generate_kernels(b, emptylist, op)
+            generate_host_function(b, emptylist)
 
-        OUTFILE.close()
+            OUTFILE.close()
 
     ##### generate the core pack/unpack kernels (single level)
     for b in builtin_types:
@@ -286,34 +287,35 @@ if __name__ == '__main__':
             OUTFILE.close()
 
     ##### generate the core pack/unpack kernels (more than one level)
-    darraylist = [ ]
-    yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
-    for b in builtin_types:
-        for d1 in gencomm.derived_types:
-            for d2 in gencomm.derived_types:
-                filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s_%s_%s.cu" % (d1, d2, b.replace(" ","_"))
-                yutils.copyright_c(filename)
-                OUTFILE = open(filename, "a")
-                yutils.display(OUTFILE, "#include <string.h>\n")
-                yutils.display(OUTFILE, "#include <stdint.h>\n")
-                yutils.display(OUTFILE, "#include <wchar.h>\n")
-                yutils.display(OUTFILE, "#include <assert.h>\n")
-                yutils.display(OUTFILE, "#include <cuda.h>\n")
-                yutils.display(OUTFILE, "#include <cuda_runtime.h>\n")
-                yutils.display(OUTFILE, "#include \"yaksuri_cudai_base.h\"\n")
-                yutils.display(OUTFILE, "#include \"yaksuri_cudai_pup.h\"\n")
-                yutils.display(OUTFILE, "\n")
+    if args.pup_max_nesting > 1:
+        darraylist = [ ]
+        yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
+        for b in builtin_types:
+            for d1 in gencomm.derived_types:
+                for d2 in gencomm.derived_types:
+                    filename = "src/backend/cuda/pup/yaksuri_cudai_pup_%s_%s_%s.cu" % (d1, d2, b.replace(" ","_"))
+                    yutils.copyright_c(filename)
+                    OUTFILE = open(filename, "a")
+                    yutils.display(OUTFILE, "#include <string.h>\n")
+                    yutils.display(OUTFILE, "#include <stdint.h>\n")
+                    yutils.display(OUTFILE, "#include <wchar.h>\n")
+                    yutils.display(OUTFILE, "#include <assert.h>\n")
+                    yutils.display(OUTFILE, "#include <cuda.h>\n")
+                    yutils.display(OUTFILE, "#include <cuda_runtime.h>\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_cudai_base.h\"\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_cudai_pup.h\"\n")
+                    yutils.display(OUTFILE, "\n")
 
-                for darray in darraylist:
-                    darray.append(d1)
-                    darray.append(d2)
-                    for op in gencomm.type_ops[b]:
-                        generate_kernels(b, darray, op)
-                    generate_host_function(b, darray)
-                    darray.pop()
-                    darray.pop()
+                    for darray in darraylist:
+                        darray.append(d1)
+                        darray.append(d2)
+                        for op in gencomm.type_ops[b]:
+                            generate_kernels(b, darray, op)
+                        generate_host_function(b, darray)
+                        darray.pop()
+                        darray.pop()
 
-                OUTFILE.close()
+                    OUTFILE.close()
 
     ##### generate the core pack/unpack kernel declarations
     filename = "src/backend/cuda/pup/yaksuri_cudai_pup.h"
@@ -412,12 +414,14 @@ if __name__ == '__main__':
     yutils.display(OUTFILE, "libyaksa_la_SOURCES += \\\n")
     for b in builtin_types:
         yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup_%s.cu \\\n" % b.replace(" ","_"))
-        for d1 in gencomm.derived_types:
-            yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup_%s_%s.cu \\\n" % \
-                           (d1, b.replace(" ","_")))
-            for d2 in gencomm.derived_types:
-                yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup_%s_%s_%s.cu \\\n" % \
-                               (d1, d2, b.replace(" ","_")))
+        if args.pup_max_nesting > 0:
+            for d1 in gencomm.derived_types:
+                yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup_%s_%s.cu \\\n" % \
+                               (d1, b.replace(" ","_")))
+                if args.pup_max_nesting > 1:
+                    for d2 in gencomm.derived_types:
+                        yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup_%s_%s_%s.cu \\\n" % \
+                                       (d1, d2, b.replace(" ","_")))
     yutils.display(OUTFILE, "\tsrc/backend/cuda/pup/yaksuri_cudai_pup.c\n")
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "noinst_HEADERS += \\\n")

--- a/src/backend/gencomm.py
+++ b/src/backend/gencomm.py
@@ -161,23 +161,25 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
         yutils.display(OUTFILE, "\n")
 
     yutils.display(OUTFILE, "switch (type->kind) {\n")
-    for dtype1 in derived_types:
-        yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__%s:\n" % dtype1.upper())
-        yutils.display(OUTFILE, "switch (type->u.%s.child->kind) {\n" % dtype1)
-        for dtype2 in derived_types:
-            yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__%s:\n" % dtype2.upper())
-            yutils.display(OUTFILE, "rc = yaksuri_%si_populate_pupfns_%s_%s(type);\n" % (backend, dtype1, dtype2))
+    if pup_max_nesting > 0:
+        for dtype1 in derived_types:
+            yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__%s:\n" % dtype1.upper())
+            yutils.display(OUTFILE, "switch (type->u.%s.child->kind) {\n" % dtype1)
+            if pup_max_nesting > 1:
+                for dtype2 in derived_types:
+                    yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__%s:\n" % dtype2.upper())
+                    yutils.display(OUTFILE, "rc = yaksuri_%si_populate_pupfns_%s_%s(type);\n" % (backend, dtype1, dtype2))
+                    yutils.display(OUTFILE, "break;\n")
+                    yutils.display(OUTFILE, "\n")
+            yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__BUILTIN:\n")
+            yutils.display(OUTFILE, "rc = yaksuri_%si_populate_pupfns_%s_builtin(type);\n" % (backend, dtype1))
             yutils.display(OUTFILE, "break;\n")
             yutils.display(OUTFILE, "\n")
-        yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__BUILTIN:\n")
-        yutils.display(OUTFILE, "rc = yaksuri_%si_populate_pupfns_%s_builtin(type);\n" % (backend, dtype1))
-        yutils.display(OUTFILE, "break;\n")
-        yutils.display(OUTFILE, "\n")
-        yutils.display(OUTFILE, "default:\n")
-        yutils.display(OUTFILE, "    break;\n")
-        yutils.display(OUTFILE, "}\n")
-        yutils.display(OUTFILE, "break;\n")
-        yutils.display(OUTFILE, "\n")
+            yutils.display(OUTFILE, "default:\n")
+            yutils.display(OUTFILE, "    break;\n")
+            yutils.display(OUTFILE, "}\n")
+            yutils.display(OUTFILE, "break;\n")
+            yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "case YAKSI_TYPE_KIND__BUILTIN:\n")
     yutils.display(OUTFILE, "rc = yaksuri_%si_populate_pupfns_builtin(type);\n" % backend)
     yutils.display(OUTFILE, "break;\n")
@@ -190,9 +192,46 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
     yutils.display(OUTFILE, "}\n");
     OUTFILE.close()
 
-    for dtype1 in derived_types:
-        for dtype2 in derived_types:
-            filename = "src/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_%s.c" % (backend, backend, dtype1, dtype2)
+    if pup_max_nesting > 0:
+        for dtype1 in derived_types:
+            if pup_max_nesting > 1:
+                for dtype2 in derived_types:
+                    filename = "src/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_%s.c" % (backend, backend, dtype1, dtype2)
+                    yutils.copyright_c(filename)
+                    OUTFILE = open(filename, "a")
+                    yutils.display(OUTFILE, "#include <stdio.h>\n")
+                    yutils.display(OUTFILE, "#include <stdlib.h>\n")
+                    yutils.display(OUTFILE, "#include <wchar.h>\n")
+                    yutils.display(OUTFILE, "#include \"yaksi.h\"\n")
+                    yutils.display(OUTFILE, "#include \"yaksu.h\"\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_%si.h\"\n" % backend)
+                    yutils.display(OUTFILE, "#include \"yaksuri_%si_populate_pupfns.h\"\n" % backend)
+                    yutils.display(OUTFILE, "#include \"yaksuri_%si_pup.h\"\n" % backend)
+                    yutils.display(OUTFILE, "\n")
+                    yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_%s(yaksi_type_s * type)\n" % (backend, dtype1, dtype2))
+                    yutils.display(OUTFILE, "{\n")
+                    yutils.display(OUTFILE, "int rc = YAKSA_SUCCESS;\n")
+                    yutils.display(OUTFILE, "yaksuri_%si_type_s *%s = (yaksuri_%si_type_s *) type->backend.%s.priv;\n" \
+                                   % (backend, backend, backend, backend))
+                    yutils.display(OUTFILE, "\n")
+                    yutils.display(OUTFILE, "char *str = getenv(\"YAKSA_ENV_MAX_NESTING_LEVEL\");\n")
+                    yutils.display(OUTFILE, "int max_nesting_level;\n")
+                    yutils.display(OUTFILE, "if (str) {\n")
+                    yutils.display(OUTFILE, "max_nesting_level = atoi(str);\n")
+                    yutils.display(OUTFILE, "} else {\n")
+                    yutils.display(OUTFILE, "max_nesting_level = YAKSI_ENV_DEFAULT_NESTING_LEVEL;\n")
+                    yutils.display(OUTFILE, "}\n")
+                    yutils.display(OUTFILE, "\n")
+
+                    pupstr = "%s_%s" % (dtype1, dtype2)
+                    typelist = [ dtype1, dtype2 ]
+                    switcher(backend, OUTFILE, blklens, builtin_types, builtin_maps, typelist, pupstr, pup_max_nesting - 1)
+                    yutils.display(OUTFILE, "\n")
+                    yutils.display(OUTFILE, "return rc;\n")
+                    yutils.display(OUTFILE, "}\n")
+                    OUTFILE.close()
+
+            filename = "src/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_builtin.c" % (backend, backend, dtype1)
             yutils.copyright_c(filename)
             OUTFILE = open(filename, "a")
             yutils.display(OUTFILE, "#include <stdio.h>\n")
@@ -204,7 +243,7 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
             yutils.display(OUTFILE, "#include \"yaksuri_%si_populate_pupfns.h\"\n" % backend)
             yutils.display(OUTFILE, "#include \"yaksuri_%si_pup.h\"\n" % backend)
             yutils.display(OUTFILE, "\n")
-            yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_%s(yaksi_type_s * type)\n" % (backend, dtype1, dtype2))
+            yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_builtin(yaksi_type_s * type)\n" % (backend, dtype1))
             yutils.display(OUTFILE, "{\n")
             yutils.display(OUTFILE, "int rc = YAKSA_SUCCESS;\n")
             yutils.display(OUTFILE, "yaksuri_%si_type_s *%s = (yaksuri_%si_type_s *) type->backend.%s.priv;\n" \
@@ -219,48 +258,13 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
             yutils.display(OUTFILE, "}\n")
             yutils.display(OUTFILE, "\n")
 
-            pupstr = "%s_%s" % (dtype1, dtype2)
-            typelist = [ dtype1, dtype2 ]
-            switcher(backend, OUTFILE, blklens, builtin_types, builtin_maps, typelist, pupstr, pup_max_nesting - 1)
+            pupstr = "%s" % dtype1
+            typelist = [ dtype1 ]
+            switcher_builtin(backend, OUTFILE, blklens, builtin_types, builtin_maps, typelist, pupstr)
             yutils.display(OUTFILE, "\n")
             yutils.display(OUTFILE, "return rc;\n")
             yutils.display(OUTFILE, "}\n")
             OUTFILE.close()
-
-        filename = "src/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_builtin.c" % (backend, backend, dtype1)
-        yutils.copyright_c(filename)
-        OUTFILE = open(filename, "a")
-        yutils.display(OUTFILE, "#include <stdio.h>\n")
-        yutils.display(OUTFILE, "#include <stdlib.h>\n")
-        yutils.display(OUTFILE, "#include <wchar.h>\n")
-        yutils.display(OUTFILE, "#include \"yaksi.h\"\n")
-        yutils.display(OUTFILE, "#include \"yaksu.h\"\n")
-        yutils.display(OUTFILE, "#include \"yaksuri_%si.h\"\n" % backend)
-        yutils.display(OUTFILE, "#include \"yaksuri_%si_populate_pupfns.h\"\n" % backend)
-        yutils.display(OUTFILE, "#include \"yaksuri_%si_pup.h\"\n" % backend)
-        yutils.display(OUTFILE, "\n")
-        yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_builtin(yaksi_type_s * type)\n" % (backend, dtype1))
-        yutils.display(OUTFILE, "{\n")
-        yutils.display(OUTFILE, "int rc = YAKSA_SUCCESS;\n")
-        yutils.display(OUTFILE, "yaksuri_%si_type_s *%s = (yaksuri_%si_type_s *) type->backend.%s.priv;\n" \
-                       % (backend, backend, backend, backend))
-        yutils.display(OUTFILE, "\n")
-        yutils.display(OUTFILE, "char *str = getenv(\"YAKSA_ENV_MAX_NESTING_LEVEL\");\n")
-        yutils.display(OUTFILE, "int max_nesting_level;\n")
-        yutils.display(OUTFILE, "if (str) {\n")
-        yutils.display(OUTFILE, "max_nesting_level = atoi(str);\n")
-        yutils.display(OUTFILE, "} else {\n")
-        yutils.display(OUTFILE, "max_nesting_level = YAKSI_ENV_DEFAULT_NESTING_LEVEL;\n")
-        yutils.display(OUTFILE, "}\n")
-        yutils.display(OUTFILE, "\n")
-
-        pupstr = "%s" % dtype1
-        typelist = [ dtype1 ]
-        switcher_builtin(backend, OUTFILE, blklens, builtin_types, builtin_maps, typelist, pupstr)
-        yutils.display(OUTFILE, "\n")
-        yutils.display(OUTFILE, "return rc;\n")
-        yutils.display(OUTFILE, "}\n")
-        OUTFILE.close()
 
     ### Generate mapping for reduction kernels of contiguous datatypes
     filename = "src/backend/%s/pup/yaksuri_%si_populate_pupfns_builtin.c" % (backend, backend)
@@ -295,10 +299,12 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
     yutils.copyright_makefile(filename)
     OUTFILE = open(filename, "a")
     yutils.display(OUTFILE, "libyaksa_la_SOURCES += \\\n")
-    for dtype1 in derived_types:
-        for dtype2 in derived_types:
-            yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_%s.c \\\n" % (backend, backend, dtype1, dtype2))
-        yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_builtin.c \\\n" % (backend, backend, dtype1))
+    if pup_max_nesting > 0:
+        for dtype1 in derived_types:
+            if pup_max_nesting > 1:
+                for dtype2 in derived_types:
+                    yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_%s.c \\\n" % (backend, backend, dtype1, dtype2))
+            yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns_%s_builtin.c \\\n" % (backend, backend, dtype1))
     yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns_builtin.c \\\n" % (backend, backend))
     yutils.display(OUTFILE, "\tsrc/backend/%s/pup/yaksuri_%si_populate_pupfns.c\n" % (backend, backend))
     yutils.display(OUTFILE, "\n")
@@ -313,10 +319,12 @@ def populate_pupfns(pup_max_nesting, backend, blklens, builtin_types, builtin_ma
     yutils.display(OUTFILE, "#ifndef YAKSURI_%sI_POPULATE_PUPFNS_H_INCLUDED\n" % backend.upper())
     yutils.display(OUTFILE, "#define YAKSURI_%sI_POPULATE_PUPFNS_H_INCLUDED\n" % backend.upper())
     yutils.display(OUTFILE, "\n")
-    for dtype1 in derived_types:
-        for dtype2 in derived_types:
-            yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_%s(yaksi_type_s * type);\n" % (backend, dtype1, dtype2))
-        yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_builtin(yaksi_type_s * type);\n" % (backend, dtype1))
+    if pup_max_nesting > 0:
+        for dtype1 in derived_types:
+            if pup_max_nesting > 1:
+                for dtype2 in derived_types:
+                    yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_%s(yaksi_type_s * type);\n" % (backend, dtype1, dtype2))
+            yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_%s_builtin(yaksi_type_s * type);\n" % (backend, dtype1))
     yutils.display(OUTFILE, "int yaksuri_%si_populate_pupfns_builtin(yaksi_type_s * type);\n" % backend)
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "#endif  /* YAKSURI_%sI_POPULATE_PUPFNS_H_INCLUDED */\n" % backend.upper())

--- a/src/backend/hip/genpup.py
+++ b/src/backend/hip/genpup.py
@@ -261,37 +261,10 @@ if __name__ == '__main__':
         OUTFILE.close()
 
     ##### generate the core pack/unpack kernels (single level)
-    for b in builtin_types:
-        for d in gencomm.derived_types:
-            filename = "src/backend/hip/pup/yaksuri_hipi_pup_%s_%s.hip" % (d, b.replace(" ","_"))
-            yutils.copyright_c(filename)
-            OUTFILE = open(filename, "a")
-            yutils.display(OUTFILE, "#include <string.h>\n")
-            yutils.display(OUTFILE, "#include <stdint.h>\n")
-            yutils.display(OUTFILE, "#include <wchar.h>\n")
-            yutils.display(OUTFILE, "#include <assert.h>\n")
-            yutils.display(OUTFILE, "#include <hip/hip_runtime_api.h>\n")
-            yutils.display(OUTFILE, "#include <hip/hip_runtime.h>\n")
-            yutils.display(OUTFILE, "#include \"yaksuri_hipi_base.h\"\n")
-            yutils.display(OUTFILE, "#include \"yaksuri_hipi_pup.h\"\n")
-            yutils.display(OUTFILE, "\n")
-
-            emptylist = [ ]
-            emptylist.append(d)
-            for op in gencomm.type_ops[b]:
-                generate_kernels(b, emptylist, op)
-            generate_host_function(b, emptylist)
-            emptylist.pop()
-
-            OUTFILE.close()
-
-    ##### generate the core pack/unpack kernels (more than one level)
-    darraylist = [ ]
-    yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
-    for b in builtin_types:
-        for d1 in gencomm.derived_types:
-            for d2 in gencomm.derived_types:
-                filename = "src/backend/hip/pup/yaksuri_hipi_pup_%s_%s_%s.hip" % (d1, d2, b.replace(" ","_"))
+    if args.pup_max_nesting > 0:
+        for b in builtin_types:
+            for d in gencomm.derived_types:
+                filename = "src/backend/hip/pup/yaksuri_hipi_pup_%s_%s.hip" % (d, b.replace(" ","_"))
                 yutils.copyright_c(filename)
                 OUTFILE = open(filename, "a")
                 yutils.display(OUTFILE, "#include <string.h>\n")
@@ -304,16 +277,45 @@ if __name__ == '__main__':
                 yutils.display(OUTFILE, "#include \"yaksuri_hipi_pup.h\"\n")
                 yutils.display(OUTFILE, "\n")
 
-                for darray in darraylist:
-                    darray.append(d1)
-                    darray.append(d2)
-                    for op in gencomm.type_ops[b]:
-                        generate_kernels(b, darray, op)
-                    generate_host_function(b, darray)
-                    darray.pop()
-                    darray.pop()
+                emptylist = [ ]
+                emptylist.append(d)
+                for op in gencomm.type_ops[b]:
+                    generate_kernels(b, emptylist, op)
+                generate_host_function(b, emptylist)
+                emptylist.pop()
 
                 OUTFILE.close()
+
+    ##### generate the core pack/unpack kernels (more than one level)
+    if args.pup_max_nesting > 1:
+        darraylist = [ ]
+        yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
+        for b in builtin_types:
+            for d1 in gencomm.derived_types:
+                for d2 in gencomm.derived_types:
+                    filename = "src/backend/hip/pup/yaksuri_hipi_pup_%s_%s_%s.hip" % (d1, d2, b.replace(" ","_"))
+                    yutils.copyright_c(filename)
+                    OUTFILE = open(filename, "a")
+                    yutils.display(OUTFILE, "#include <string.h>\n")
+                    yutils.display(OUTFILE, "#include <stdint.h>\n")
+                    yutils.display(OUTFILE, "#include <wchar.h>\n")
+                    yutils.display(OUTFILE, "#include <assert.h>\n")
+                    yutils.display(OUTFILE, "#include <hip/hip_runtime_api.h>\n")
+                    yutils.display(OUTFILE, "#include <hip/hip_runtime.h>\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_hipi_base.h\"\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_hipi_pup.h\"\n")
+                    yutils.display(OUTFILE, "\n")
+
+                    for darray in darraylist:
+                        darray.append(d1)
+                        darray.append(d2)
+                        for op in gencomm.type_ops[b]:
+                            generate_kernels(b, darray, op)
+                        generate_host_function(b, darray)
+                        darray.pop()
+                        darray.pop()
+
+                    OUTFILE.close()
 
     ##### generate the core pack/unpack kernel declarations
     filename = "src/backend/hip/pup/yaksuri_hipi_pup.h"
@@ -412,12 +414,14 @@ if __name__ == '__main__':
     yutils.display(OUTFILE, "libyaksa_la_SOURCES += \\\n")
     for b in builtin_types:
         yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup_%s.hip \\\n" % b.replace(" ","_"))
-        for d1 in gencomm.derived_types:
-            yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup_%s_%s.hip \\\n" % \
-                           (d1, b.replace(" ","_")))
-            for d2 in gencomm.derived_types:
-                yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup_%s_%s_%s.hip \\\n" % \
-                               (d1, d2, b.replace(" ","_")))
+        if args.pup_max_nesting > 0:
+            for d1 in gencomm.derived_types:
+                yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup_%s_%s.hip \\\n" % \
+                               (d1, b.replace(" ","_")))
+                if args.pup_max_nesting > 1:
+                    for d2 in gencomm.derived_types:
+                        yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup_%s_%s_%s.hip \\\n" % \
+                                       (d1, d2, b.replace(" ","_")))
     yutils.display(OUTFILE, "\tsrc/backend/hip/pup/yaksuri_hipi_pup.c\n")
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "noinst_HEADERS += \\\n")

--- a/src/backend/seq/genpup.py
+++ b/src/backend/seq/genpup.py
@@ -242,32 +242,10 @@ if __name__ == '__main__':
         OUTFILE.close()
 
     ##### generate the core pack/unpack kernels (single level)
-    for b in builtin_types:
-        for d in gencomm.derived_types:
-            filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s_%s.c" % (d, b.replace(" ","_"))
-            yutils.copyright_c(filename)
-            OUTFILE = open(filename, "a")
-            yutils.display(OUTFILE, "#include <string.h>\n")
-            yutils.display(OUTFILE, "#include <stdint.h>\n")
-            yutils.display(OUTFILE, "#include <wchar.h>\n")
-            yutils.display(OUTFILE, "#include \"yaksuri_seqi_pup.h\"\n")
-            yutils.display(OUTFILE, "\n")
-
-            emptylist = [ ]
-            emptylist.append(d)
-            for blklen in blklens:
-                generate_kernels(b, emptylist, blklen)
-            emptylist.pop()
-
-            OUTFILE.close()
-
-    ##### generate the core pack/unpack kernels (more than one level)
-    darraylist = [ ]
-    yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
-    for b in builtin_types:
-        for d1 in gencomm.derived_types:
-            for d2 in gencomm.derived_types:
-                filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s_%s_%s.c" % (d1, d2, b.replace(" ","_"))
+    if args.pup_max_nesting > 0:
+        for b in builtin_types:
+            for d in gencomm.derived_types:
+                filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s_%s.c" % (d, b.replace(" ","_"))
                 yutils.copyright_c(filename)
                 OUTFILE = open(filename, "a")
                 yutils.display(OUTFILE, "#include <string.h>\n")
@@ -276,15 +254,39 @@ if __name__ == '__main__':
                 yutils.display(OUTFILE, "#include \"yaksuri_seqi_pup.h\"\n")
                 yutils.display(OUTFILE, "\n")
 
-                for darray in darraylist:
-                    darray.append(d1)
-                    darray.append(d2)
-                    for blklen in blklens:
-                        generate_kernels(b, darray, blklen)
-                    darray.pop()
-                    darray.pop()
+                emptylist = [ ]
+                emptylist.append(d)
+                for blklen in blklens:
+                    generate_kernels(b, emptylist, blklen)
+                emptylist.pop()
 
                 OUTFILE.close()
+
+    ##### generate the core pack/unpack kernels (more than one level)
+    if args.pup_max_nesting > 1:
+        darraylist = [ ]
+        yutils.generate_darrays(gencomm.derived_types, darraylist, args.pup_max_nesting - 2)
+        for b in builtin_types:
+            for d1 in gencomm.derived_types:
+                for d2 in gencomm.derived_types:
+                    filename = "src/backend/seq/pup/yaksuri_seqi_pup_%s_%s_%s.c" % (d1, d2, b.replace(" ","_"))
+                    yutils.copyright_c(filename)
+                    OUTFILE = open(filename, "a")
+                    yutils.display(OUTFILE, "#include <string.h>\n")
+                    yutils.display(OUTFILE, "#include <stdint.h>\n")
+                    yutils.display(OUTFILE, "#include <wchar.h>\n")
+                    yutils.display(OUTFILE, "#include \"yaksuri_seqi_pup.h\"\n")
+                    yutils.display(OUTFILE, "\n")
+
+                    for darray in darraylist:
+                        darray.append(d1)
+                        darray.append(d2)
+                        for blklen in blklens:
+                            generate_kernels(b, darray, blklen)
+                        darray.pop()
+                        darray.pop()
+
+                    OUTFILE.close()
 
     ##### generate the core pack/unpack kernel declarations
     filename = "src/backend/seq/pup/yaksuri_seqi_pup.h"
@@ -366,12 +368,14 @@ if __name__ == '__main__':
     for b in builtin_types:
         yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seqi_pup_%s.c \\\n" % \
                        b.replace(" ","_"))
-        for d1 in gencomm.derived_types:
-            yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seqi_pup_%s_%s.c \\\n" % \
-                           (d1, b.replace(" ","_")))
-            for d2 in gencomm.derived_types:
-                yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seqi_pup_%s_%s_%s.c \\\n" % \
-                               (d1, d2, b.replace(" ","_")))
+        if args.pup_max_nesting > 0:
+            for d1 in gencomm.derived_types:
+                yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seqi_pup_%s_%s.c \\\n" % \
+                               (d1, b.replace(" ","_")))
+                if args.pup_max_nesting > 1:
+                    for d2 in gencomm.derived_types:
+                        yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seqi_pup_%s_%s_%s.c \\\n" % \
+                                       (d1, d2, b.replace(" ","_")))
     yutils.display(OUTFILE, "\tsrc/backend/seq/pup/yaksuri_seq_pup.c\n")
     yutils.display(OUTFILE, "\n")
     yutils.display(OUTFILE, "noinst_HEADERS += \\\n")


### PR DESCRIPTION
## Pull Request Description

Current codes fail to build when `--pup-max-nesting` is set to less than 2 due to incorrect/inconsistent behavior in genpup code:
1. `gencomm.populate_pupfns` always generates as max nesting level == 2
2. `genpup.py` always generates two-level-nesting kernels
3. `Makefile.pup.mk` always generates with targets of two-level-nesting kernels
4. `yaksuri_*i_pup.h` is generated correctly

Generating code with max nesting level < 2 and building will results in
1. compilation error in pupfns code because the missing decls for two-level-nesting kernels in `yaksuri_*i_pup.h`
2. wasted compilation for two-level-nesting kernels that should never be used.

This PR fixes this by adding necessary checks to the code generation. 

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
