### PR TITLE
backend/ze: support compiling multiple devices with --ze-native

### DIFF
--- a/src/backend/ze/pup/Makefile.mk
+++ b/src/backend/ze/pup/Makefile.mk
@@ -24,10 +24,22 @@ if BUILD_ZE_NATIVE
 
 else
 
+if BUILD_ZE_NATIVE_MULTIPLE
+
+.cl.c:
+	@echo "  OCLOC (multiple native)  $<" ; \
+	ocloc compile -file $< -device $(ze_native_TARGET) -q -options "-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0" @extra_ocloc_options@ && \
+	mv `basename $(@:.c=.ar)` `dirname $@` && \
+	$(top_srcdir)/src/backend/ze/pup/inline.py $(@:.c=.ar) $@ $(top_srcdir) 2
+
+else
+
 .cl.c:
 	@echo " OCLOC (spirv)  $<"; \
 	ocloc compile -file $< -device skl -spv_only -out_dir `dirname $@` -output_no_suffix -q -options "-I $(top_srcdir)/src/backend/ze/include -cl-std=CL2.0" && \
-	/bin/rm -f $(@:.c=.gen); \
+	/bin/rm -f $(@:.c=.gen) &&  \
 	$(top_srcdir)/src/backend/ze/pup/inline.py $(@:.c=.spv) $@ $(top_srcdir) 0
+
+endif
 
 endif

--- a/src/backend/ze/pup/inline.py
+++ b/src/backend/ze/pup/inline.py
@@ -6,7 +6,7 @@
 
 import sys, os
 
-# inline.py [infile] [outfile] [topdir] [native: 0|1]
+# inline.py [infile] [outfile] [topdir] [native: 0|1|2]
 
 infile = sys.argv[1]
 outfile = sys.argv[2]
@@ -22,7 +22,9 @@ import yutils
 yutils.copyright_c(outfile)
 OUTFILE = open(outfile, 'a')
 
-if native == "1":
+if native == "2":
+    OUTFILE.write("/* native format with multiple devices */\n\n")
+elif native == "1":
     OUTFILE.write("/* native format */\n\n")
 else:
     OUTFILE.write("/* SPIR-V format */\n\n")

--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -78,6 +78,7 @@ if test $enable_ze_revision_id != -1; then
 fi
 
 # --ze-native=[skl|dg1|ats|pvc]
+enable_multi_native=no
 AC_ARG_ENABLE([ze-native],AS_HELP_STRING([--enable-ze-native=device],[compile GPU kernel to native binary]),,
               [enable_ze_native=no])
 if test "${have_ze}" = "yes" -a x"${enable_ze_native}" != xno; then
@@ -85,9 +86,13 @@ if test "${have_ze}" = "yes" -a x"${enable_ze_native}" != xno; then
     cat>conftest.cl<<EOF
     __kernel void foo(int x) {}
 EOF
+    rm -f conftest.ar
     ocloc compile -file conftest.cl -device ${enable_ze_native} ${extra_ocloc_options} -options "-cl-std=CL2.0" > /dev/null 2>&1
     if test "$?" = "0" ; then
         AC_MSG_RESULT([yes])
+        if test -f conftest.ar; then
+            enable_multi_native=yes
+        fi
     else
         AC_MSG_RESULT([no])
         enable_ze_native=
@@ -102,7 +107,8 @@ else
 fi
 AC_SUBST(enable_ze_native)
 AC_SUBST(extra_ocloc_options)
-AM_CONDITIONAL([BUILD_ZE_NATIVE],[test x"$enable_ze_native" != xno])
+AM_CONDITIONAL([BUILD_ZE_NATIVE],[test x"$enable_ze_native" != xno -a x"$enable_multi_native" != xyes])
+AM_CONDITIONAL([BUILD_ZE_NATIVE_MULTIPLE],[test x"$enable_multi_native" != xno])
 
 
 ##########################################################################


### PR DESCRIPTION
This change allows yaksa to build one copy of kernel native binaries to include multiple devices.
For example, one kernel binary contains binary for both ATS and PVC.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
