### PR TITLE
cuda: disable registered host buffer pool

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -4,6 +4,7 @@
  */
 
 #include "yaksi.h"
+#include "yaksuri.h"
 #include "yaksuri_cudai.h"
 #include <assert.h>
 #include <string.h>
@@ -14,8 +15,12 @@ static void *cuda_host_malloc(uintptr_t size)
 {
     void *ptr = NULL;
 
-    cudaError_t cerr = cudaMallocHost(&ptr, size);
-    YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);
+    if (yaksuri_global.avoid_reghost_pool) {
+        ptr = malloc(size);
+    } else {
+        cudaError_t cerr = cudaMallocHost(&ptr, size);
+        YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);
+    }
 
     return ptr;
 }
@@ -47,8 +52,12 @@ static void *cuda_gpu_malloc(uintptr_t size, int device)
 
 static void cuda_host_free(void *ptr)
 {
-    cudaError_t cerr = cudaFreeHost(ptr);
-    YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);
+    if (yaksuri_global.avoid_reghost_pool) {
+        free(ptr);
+    } else {
+        cudaError_t cerr = cudaFreeHost(ptr);
+        YAKSURI_CUDAI_CUDA_ERR_CHECK(cerr);
+    }
 }
 
 static void cuda_gpu_free(void *ptr)

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -79,6 +79,7 @@ int yaksur_init_hook(yaksi_info_s * info)
             /* gpu disabled */
             goto fn_exit;
         }
+        yaksuri_global.avoid_reghost_pool = infopriv->avoid_reghost_pool;
     }
 
     /* CUDA hooks */
@@ -253,6 +254,7 @@ int yaksur_info_create_hook(yaksi_info_s * info)
     infopriv = (yaksuri_info_s *) info->backend.priv;
     infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
     infopriv->mapped_device = -1;
+    infopriv->avoid_reghost_pool = false;
 
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -327,6 +329,15 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
         yaksuri_info_s *infopriv = info->backend.priv;
         assert(vallen == sizeof(int));
         infopriv->mapped_device = *((const int *) val);
+        goto fn_exit;
+    } else if (strcmp(key, "yaksa_avoid_reghost_pool") == 0) {
+        /* only for yaksa_init, to avoid allocating registered staging buffer pool,
+         * due to potential deadlocks with "wait" kernels. */
+        yaksuri_info_s *infopriv = info->backend.priv;
+        if (strcmp((char *) val, "true") == 0 ||
+            strcmp((char *) val, "yes") == 0 || strcmp((char *) val, "1") == 0) {
+            infopriv->avoid_reghost_pool = true;
+        }
         goto fn_exit;
     }
 

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -26,6 +26,7 @@ typedef enum yaksuri_pup_e {
 #define YAKSURI_TMPBUF_NUM_EL   (16)
 
 typedef struct {
+    bool avoid_reghost_pool;
     struct {
         yaksu_buffer_pool_s host;
         yaksu_buffer_pool_s *device;
@@ -102,6 +103,8 @@ typedef struct yaksuri_request {
 typedef struct {
     yaksuri_gpudriver_id_e gpudriver_id;
     int mapped_device;
+    bool avoid_reghost_pool;    /* in situation where allocating registered staging buffer
+                                 * may cause issues */
 } yaksuri_info_s;
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,


### PR DESCRIPTION
## Pull Request Description

Allocating registered buffers may be blocked by a gpu wait kernel. Since
CUDA is able to directly work with unregistered buffers, add an options
to use unregistered buffers for staging buffers.



<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
