### PR TITLE
backend/ze: initialize ze_device_properties_t before using it

### DIFF
--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -173,7 +173,10 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
 
 #if ZE_DEBUG
     /* assuming homogeneous devices */
-    ze_device_properties_t deviceProperties;
+    ze_device_properties_t deviceProperties = {
+        .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES,
+        .pNext = NULL,
+    };
     zerr = zeDeviceGetProperties(yaksuri_zei_global.device[0], &deviceProperties);
     assert(zerr == ZE_RESULT_SUCCESS);
 
@@ -194,7 +197,10 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     for (int i = 0; i < yaksuri_zei_global.ndevices; i++) {
         yaksuri_zei_device_state_s *device_state = yaksuri_zei_global.device_states + i;
         device_state->dev_id = i;
-        ze_device_properties_t deviceProperties;
+        ze_device_properties_t deviceProperties = {
+            .stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES,
+            .pNext = NULL,
+        };
         zerr = zeDeviceGetProperties(yaksuri_zei_global.device[i], &deviceProperties);
         YAKSURI_ZEI_ZE_ERR_CHKANDJUMP(zerr, rc, fn_fail);
         device_state->deviceId = deviceProperties.deviceId;


### PR DESCRIPTION
initialize ze_device_properties_t before calling zeDeviceGetProperties.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
