### PR TITLE
cuda: no lazy stream creation with has_wait_kernel hint

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -205,6 +205,10 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
 
     yaksuri_cudai_global.p2p = (int **) malloc(yaksuri_cudai_global.ndevices * sizeof(int *));
     for (int i = 0; i < yaksuri_cudai_global.ndevices; i++) {
+        if (yaksuri_global.has_wait_kernel) {
+            /* The stream creation will deadlock with wait kernel. Create them now. */
+            yaksuri_cudai_get_stream(i);
+        }
         yaksuri_cudai_global.p2p[i] = (int *) malloc(yaksuri_cudai_global.ndevices * sizeof(int));
         /* mark as unchecked with -1. We will check access and cache the value
          * in check_p2p_comm */

--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -15,7 +15,7 @@ static void *cuda_host_malloc(uintptr_t size)
 {
     void *ptr = NULL;
 
-    if (yaksuri_global.avoid_reghost_pool) {
+    if (yaksuri_global.has_wait_kernel) {
         ptr = malloc(size);
     } else {
         cudaError_t cerr = cudaMallocHost(&ptr, size);
@@ -52,7 +52,7 @@ static void *cuda_gpu_malloc(uintptr_t size, int device)
 
 static void cuda_host_free(void *ptr)
 {
-    if (yaksuri_global.avoid_reghost_pool) {
+    if (yaksuri_global.has_wait_kernel) {
         free(ptr);
     } else {
         cudaError_t cerr = cudaFreeHost(ptr);

--- a/src/backend/src/yaksur_hooks.c
+++ b/src/backend/src/yaksur_hooks.c
@@ -79,7 +79,7 @@ int yaksur_init_hook(yaksi_info_s * info)
             /* gpu disabled */
             goto fn_exit;
         }
-        yaksuri_global.avoid_reghost_pool = infopriv->avoid_reghost_pool;
+        yaksuri_global.has_wait_kernel = infopriv->has_wait_kernel;
     }
 
     /* CUDA hooks */
@@ -254,7 +254,7 @@ int yaksur_info_create_hook(yaksi_info_s * info)
     infopriv = (yaksuri_info_s *) info->backend.priv;
     infopriv->gpudriver_id = YAKSURI_GPUDRIVER_ID__UNSET;
     infopriv->mapped_device = -1;
-    infopriv->avoid_reghost_pool = false;
+    infopriv->has_wait_kernel = false;
 
     rc = yaksuri_seq_info_create_hook(info);
     YAKSU_ERR_CHECK(rc, fn_fail);
@@ -330,13 +330,13 @@ int yaksur_info_keyval_append(yaksi_info_s * info, const char *key, const void *
         assert(vallen == sizeof(int));
         infopriv->mapped_device = *((const int *) val);
         goto fn_exit;
-    } else if (strcmp(key, "yaksa_avoid_reghost_pool") == 0) {
+    } else if (strcmp(key, "yaksa_has_wait_kernel") == 0) {
         /* only for yaksa_init, to avoid allocating registered staging buffer pool,
          * due to potential deadlocks with "wait" kernels. */
         yaksuri_info_s *infopriv = info->backend.priv;
         if (strcmp((char *) val, "true") == 0 ||
             strcmp((char *) val, "yes") == 0 || strcmp((char *) val, "1") == 0) {
-            infopriv->avoid_reghost_pool = true;
+            infopriv->has_wait_kernel = true;
         }
         goto fn_exit;
     }

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -26,7 +26,7 @@ typedef enum yaksuri_pup_e {
 #define YAKSURI_TMPBUF_NUM_EL   (16)
 
 typedef struct {
-    bool avoid_reghost_pool;
+    bool has_wait_kernel;
     struct {
         yaksu_buffer_pool_s host;
         yaksu_buffer_pool_s *device;
@@ -103,8 +103,7 @@ typedef struct yaksuri_request {
 typedef struct {
     yaksuri_gpudriver_id_e gpudriver_id;
     int mapped_device;
-    bool avoid_reghost_pool;    /* in situation where allocating registered staging buffer
-                                 * may cause issues */
+    bool has_wait_kernel;       /* avoid gpu functions that may cause deadlocks with wait kernel */
 } yaksuri_info_s;
 
 int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,


### PR DESCRIPTION
## Pull Request Description
When a wait kernel is running, the CUDA stream creation will get blocked and resulting in deadlocks. Initialize them during init to avoid such issue.


<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
