### PR TITLE
backend/ze: fix checking ze-native option

### DIFF
--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -95,12 +95,12 @@ EOF
         fi
     else
         AC_MSG_RESULT([no])
-        enable_ze_native=
+        enable_ze_native=no
         AC_MSG_ERROR([ocloc compiler is not compatible with ze_native])
     fi
     rm -f conftest.*
 fi
-if test x"${enable_ze_native}" != x; then
+if test x"${enable_ze_native}" != xno; then
     AC_DEFINE(ZE_NATIVE, 1, [Compile kernels to binary])
 else
     AC_DEFINE(ZE_NATIVE, 0, [No native format])


### PR DESCRIPTION
set ze-native to "no" instead of empty string

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
