### PR TITLE
backend/ze: simplify the use of immediate command list

### DIFF
--- a/src/backend/ze/include/yaksuri_zei.h
+++ b/src/backend/ze/include/yaksuri_zei.h
@@ -64,13 +64,7 @@ typedef struct {
     int ev_lb, ev_ub;           /* [lb,ub] defines the events being used */
     ze_event_handle_t *events;
     int last_event_idx;         /* immed. cmd lists are serialized */
-    ze_command_list_handle_t *cl;       /* immed. cmd lists being used */
-    int num_cl;                 /* number of immed. cmd lists */
-    int cl_cap;
-    ze_command_list_handle_t *cl_pool;  /* command list pool, one per device */
-    int cl_pool_size;
-    int cl_pool_cnt;
-    pthread_mutex_t cl_mutex;
+    ze_command_list_handle_t cmdlist;   /* immed. cmd lists being used */
     ze_command_queue_group_properties_t *queueProperties;
     uint32_t numQueueGroups;
     pthread_mutex_t mutex;
@@ -92,7 +86,6 @@ extern yaksuri_zei_global_s yaksuri_zei_global;
 /* Define abstraction for ze event and buffer command list with this */
 typedef struct {
     ze_event_handle_t ze_event;
-    ze_command_list_handle_t cl;
     int dev_id;
     int idx;
 } yaksuri_zei_event_s;


### PR DESCRIPTION
Append task consecutively to an immediate cmd list without having to
wait for the previous tasks to finish

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

## Pull Request Description

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
