### PR TITLE
Support mixed memory types

### DIFF
--- a/src/backend/src/yaksur_pup.c
+++ b/src/backend/src/yaksur_pup.c
@@ -10,12 +10,13 @@
 #include "yaksuri.h"
 
 static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s * type,
-                yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request)
+                yaksi_info_s * info, yaksa_op_t op, yaksi_request_s * request,
+                bool always_query_ptr_attr)
 {
     int rc = YAKSA_SUCCESS;
     yaksuri_request_s *reqpriv = (yaksuri_request_s *) request->backend.priv;
 
-    if (reqpriv->gpudriver_id != YAKSURI_GPUDRIVER_ID__UNSET)
+    if (!always_query_ptr_attr && reqpriv->gpudriver_id != YAKSURI_GPUDRIVER_ID__UNSET)
         goto query_done;
 
     yaksuri_info_s *infopriv;
@@ -27,7 +28,7 @@ static int ipup(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s *
     }
 
     yaksuri_gpudriver_id_e id;
-    id = reqpriv->gpudriver_id;
+    id = always_query_ptr_attr ? YAKSURI_GPUDRIVER_ID__UNSET : reqpriv->gpudriver_id;
     if (id == YAKSURI_GPUDRIVER_ID__UNSET) {
         for (id = YAKSURI_GPUDRIVER_ID__UNSET; id < YAKSURI_GPUDRIVER_ID__LAST; id++) {
             if (id == YAKSURI_GPUDRIVER_ID__UNSET || yaksuri_global.gpudriver[id].hooks == NULL)
@@ -96,7 +97,7 @@ int yaksur_ipack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_s 
     yaksuri_request_s *reqpriv = (yaksuri_request_s *) request->backend.priv;
 
     reqpriv->optype = YAKSURI_OPTYPE__PACK;
-    rc = ipup(inbuf, outbuf, count, type, info, op, request);
+    rc = ipup(inbuf, outbuf, count, type, info, op, request, request->always_query_ptr_attr);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:
@@ -112,7 +113,7 @@ int yaksur_iunpack(const void *inbuf, void *outbuf, uintptr_t count, yaksi_type_
     yaksuri_request_s *reqpriv = (yaksuri_request_s *) request->backend.priv;
 
     reqpriv->optype = YAKSURI_OPTYPE__UNPACK;
-    rc = ipup(inbuf, outbuf, count, type, info, op, request);
+    rc = ipup(inbuf, outbuf, count, type, info, op, request, request->always_query_ptr_attr);
     YAKSU_ERR_CHECK(rc, fn_fail);
 
   fn_exit:

--- a/src/backend/src/yaksuri.h
+++ b/src/backend/src/yaksuri.h
@@ -83,6 +83,8 @@ typedef struct yaksuri_subreq {
         } multiple;
     } u;
 
+    yaksuri_gpudriver_id_e gpudriver_id;
+
     struct yaksuri_subreq *next;
     struct yaksuri_subreq *prev;
 } yaksuri_subreq_s;

--- a/src/backend/src/yaksuri_progress.c
+++ b/src/backend/src/yaksuri_progress.c
@@ -2964,6 +2964,9 @@ int yaksuri_progress_enqueue(const void *inbuf, void *outbuf, uintptr_t count, y
         goto fn_exit;
     }
 
+    /* id (i.e., reqpriv->gpudriver_id) may differ between differen calls to yaksuri_progress_enqueue() */
+    subreq->gpudriver_id = id;
+
     pthread_mutex_lock(&progress_mutex);
     DL_APPEND(reqpriv->subreqs, subreq);
 
@@ -3007,11 +3010,11 @@ int yaksuri_progress_poke(void)
     /**********************************************************************/
     yaksuri_request_s *reqpriv, *tmp;
     HASH_ITER(hh, pending_reqs, reqpriv, tmp) {
-        id = reqpriv->gpudriver_id;
         assert(reqpriv->subreqs);
 
         yaksuri_subreq_s *subreq, *tmp2;
         DL_FOREACH_SAFE(reqpriv->subreqs, subreq, tmp2) {
+            id = subreq->gpudriver_id;
             if (subreq->kind == YAKSURI_SUBREQ_KIND__SINGLE_CHUNK) {
                 int completed;
                 rc = event_query(id, subreq->u.single.event, &completed);
@@ -3047,11 +3050,11 @@ int yaksuri_progress_poke(void)
     /* Step 2: Issue new operations */
     /**********************************************************************/
     HASH_ITER(hh, pending_reqs, reqpriv, tmp) {
-        id = reqpriv->gpudriver_id;
         assert(reqpriv->subreqs);
 
         yaksuri_subreq_s *subreq, *tmp2;
         DL_FOREACH_SAFE(reqpriv->subreqs, subreq, tmp2) {
+            id = subreq->gpudriver_id;
             if (subreq->kind == YAKSURI_SUBREQ_KIND__SINGLE_CHUNK)
                 continue;
 

--- a/src/frontend/include/yaksi.h
+++ b/src/frontend/include/yaksi.h
@@ -166,6 +166,7 @@ typedef struct yaksi_request_s {
      * ipack/iunpack are nonblocking; pack/unpack are blocking;
      * pack_stream/unpack_stream sets stream */
     int kind;
+    bool always_query_ptr_attr;
     void *stream;               /* for CUDA, it's pointer to cudaStream_t
                                  * for HIP, it's pointer to hipStream_t */
     /* give some private space for the backend to store content */

--- a/src/frontend/pup/yaksi_ipack_backend.c
+++ b/src/frontend/pup/yaksi_ipack_backend.c
@@ -214,7 +214,8 @@ int yaksi_ipack_backend(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = yaksur_ipack(inbuf, outbuf, count, type, info, op, request);
+    rc = (inbuf) ? yaksur_ipack(inbuf, outbuf, count, type, info, op,
+                                request) : YAKSA_ERR__NOT_SUPPORTED;
     if (rc == YAKSA_ERR__NOT_SUPPORTED) {
         rc = pack_backend(inbuf, outbuf, count, type, info, op, request);
         YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksi_ipack_backend.c
+++ b/src/frontend/pup/yaksi_ipack_backend.c
@@ -41,6 +41,12 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
 {
     int rc = YAKSA_SUCCESS;
 
+
+    /* always query the ptr attributes for datatypes with absolue addresses */
+    if (!inbuf) {
+        request->always_query_ptr_attr = true;
+    }
+
     switch (type->kind) {
         case YAKSI_TYPE_KIND__BUILTIN:
             assert(!type->is_contig);

--- a/src/frontend/pup/yaksi_iunpack_backend.c
+++ b/src/frontend/pup/yaksi_iunpack_backend.c
@@ -212,7 +212,8 @@ int yaksi_iunpack_backend(const void *inbuf, void *outbuf, uintptr_t count, yaks
 {
     int rc = YAKSA_SUCCESS;
 
-    rc = yaksur_iunpack(inbuf, outbuf, count, type, info, op, request);
+    rc = (outbuf) ? yaksur_iunpack(inbuf, outbuf, count, type, info, op,
+                                   request) : YAKSA_ERR__NOT_SUPPORTED;
     if (rc == YAKSA_ERR__NOT_SUPPORTED) {
         rc = unpack_backend(inbuf, outbuf, count, type, info, op, request);
         YAKSU_ERR_CHECK(rc, fn_fail);

--- a/src/frontend/pup/yaksi_iunpack_backend.c
+++ b/src/frontend/pup/yaksi_iunpack_backend.c
@@ -41,6 +41,11 @@ static inline int unpack_backend(const void *inbuf, void *outbuf, uintptr_t coun
 {
     int rc = YAKSA_SUCCESS;
 
+    /* always query the ptr attributes for datatypes with absolue addresses */
+    if (!outbuf) {
+        request->always_query_ptr_attr = true;
+    }
+
     switch (type->kind) {
         case YAKSI_TYPE_KIND__BUILTIN:
             switch (type->u.builtin.handle) {

--- a/src/frontend/pup/yaksi_request.c
+++ b/src/frontend/pup/yaksi_request.c
@@ -22,6 +22,7 @@ int yaksi_request_create(yaksi_request_s ** request)
 
     yaksu_atomic_store(&req->cc, 0);
     req->kind = YAKSI_REQUEST_KIND__NONBLOCKING;
+    req->always_query_ptr_attr = false;
 
     rc = yaksur_request_create_hook(req);
     YAKSU_ERR_CHECK(rc, fn_fail);


### PR DESCRIPTION
## Pull Request Description

Currently, yaksa assumes all memory regions of derived datatypes to have the same memory type. However, in cases with absolute addressing, this is not necessarily true and therefore the caching of the memory type should be disabled. These patches avoid the caching of memory type information in such cases. Additionally, to support different memory types when subrequests are used, the `gpudriver_id` is stored on this level.

See also: https://github.com/pmodels/mpich/pull/6226

## Expected Impact
In case of absolute addressing, these patches will result in an increased amount of memory type queries.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
