### PR TITLE
backend: Populate pNext field in LevelZero structs

### DIFF
--- a/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
+++ b/src/backend/ze/hooks/yaksuri_ze_init_hooks.c
@@ -186,6 +186,7 @@ int yaksuri_ze_init_hook(yaksur_gpudriver_hooks_s ** hooks)
                                               sizeof(yaksuri_zei_device_state_s));
     yaksuri_zei_global.throttle_threshold = ZE_THROTTLE_THRESHOLD;
     pool_desc.stype = ZE_STRUCTURE_TYPE_EVENT_POOL_DESC;
+    pool_desc.pNext = NULL;
     pool_desc.flags = 0;
     pool_desc.count = ZE_EVENT_POOL_CAP;
 

--- a/test/pack/pack-ze.c
+++ b/test/pack/pack-ze.c
@@ -85,7 +85,11 @@ void pack_ze_init_devices(int num_threads)
         global_devices = subdevices;
     }
 
-    ze_context_desc_t contextDesc = { };
+    ze_context_desc_t contextDesc = {
+        .stype = ZE_STRUCTURE_TYPE_CONTEXT_DESC,
+        .pNext = NULL,
+        .flags = 0,
+    };
     ret = zeContextCreate(global_ze_driver_handle, &contextDesc, &ze_context);
     assert(ret == ZE_RESULT_SUCCESS);
 


### PR DESCRIPTION
Signed-off-by: Luzynski, Sebastian Jozef <sebastian.jozef.luzynski@intel.com>

## Pull Request Description
Make code LevelZero spec compliant by setting `pNext` field to `NULL`
<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->
This fixes #236 . `pNext` field is required to be set by LevelZero specification. 
<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact
None, this change yields no functional changes. This makes code compliant with spec. 
## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
