### PR TITLE
frontend: work around for a clang bug

### DIFF
--- a/src/frontend/pup/yaksi_ipack_backend.c
+++ b/src/frontend/pup/yaksi_ipack_backend.c
@@ -7,6 +7,10 @@
 #include "yaksu.h"
 #include <assert.h>
 
+static int yaksi_ipack_internal(const void *inbuf, void *outbuf, uintptr_t count,
+                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                yaksi_request_s * request);
+
 #define BUILTIN_PAIRTYPE_PACK(type, TYPE1, TYPE2, inbuf, count, outbuf, info, op, request) \
     do {                                                                \
         type z;                                                         \
@@ -23,11 +27,11 @@
         YAKSU_ERR_CHECK(rc, fn_fail);                                   \
                                                                         \
         for (int i = 0; i < count; i++) {                               \
-            rc = yaksi_ipack_backend(sbuf, dbuf, 1, type1, info, op, request); \
+            rc = yaksi_ipack_internal(sbuf, dbuf, 1, type1, info, op, request); \
             YAKSU_ERR_CHECK(rc, fn_fail);                               \
             dbuf += type1->size;                                        \
                                                                         \
-            rc = yaksi_ipack_backend(sbuf + offset, dbuf, 1, type2, info, op, request); \
+            rc = yaksi_ipack_internal(sbuf + offset, dbuf, 1, type2, info, op, request); \
             YAKSU_ERR_CHECK(rc, fn_fail);                               \
             dbuf += type2->size;                                        \
                                                                         \
@@ -90,8 +94,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
 
                 for (int i = 0; i < count; i++) {
                     for (int j = 0; j < type->u.hvector.count; j++) {
-                        rc = yaksi_ipack_backend(sbuf, dbuf, type->u.hvector.blocklength,
-                                                 type->u.hvector.child, info, op, request);
+                        rc = yaksi_ipack_internal(sbuf, dbuf, type->u.hvector.blocklength,
+                                                  type->u.hvector.child, info, op, request);
                         YAKSU_ERR_CHECK(rc, fn_fail);
                         sbuf += type->u.hvector.stride;
                         dbuf += size;
@@ -114,8 +118,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
                         sbuf =
                             (const char *) inbuf + i * type->extent +
                             type->u.blkhindx.array_of_displs[j];
-                        rc = yaksi_ipack_backend(sbuf, dbuf, type->u.blkhindx.blocklength,
-                                                 type->u.blkhindx.child, info, op, request);
+                        rc = yaksi_ipack_internal(sbuf, dbuf, type->u.blkhindx.blocklength,
+                                                  type->u.blkhindx.child, info, op, request);
                         YAKSU_ERR_CHECK(rc, fn_fail);
                         dbuf += size;
                     }
@@ -136,9 +140,9 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
                         sbuf =
                             (const char *) inbuf + i * type->extent +
                             type->u.hindexed.array_of_displs[j];
-                        rc = yaksi_ipack_backend(sbuf, dbuf,
-                                                 type->u.hindexed.array_of_blocklengths[j],
-                                                 type->u.hindexed.child, info, op, request);
+                        rc = yaksi_ipack_internal(sbuf, dbuf,
+                                                  type->u.hindexed.array_of_blocklengths[j],
+                                                  type->u.hindexed.child, info, op, request);
                         YAKSU_ERR_CHECK(rc, fn_fail);
                         dbuf +=
                             type->u.hindexed.array_of_blocklengths[j] *
@@ -161,8 +165,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
                         sbuf =
                             (const char *) inbuf + i * type->extent +
                             type->u.str.array_of_displs[j];
-                        rc = yaksi_ipack_backend(sbuf, dbuf, type->u.str.array_of_blocklengths[j],
-                                                 type->u.str.array_of_types[j], info, op, request);
+                        rc = yaksi_ipack_internal(sbuf, dbuf, type->u.str.array_of_blocklengths[j],
+                                                  type->u.str.array_of_types[j], info, op, request);
                         YAKSU_ERR_CHECK(rc, fn_fail);
                         dbuf +=
                             type->u.str.array_of_blocklengths[j] *
@@ -177,8 +181,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
                 const char *sbuf = (const char *) inbuf;
                 char *dbuf = (char *) outbuf;
                 for (int i = 0; i < count; i++) {
-                    rc = yaksi_ipack_backend(sbuf, dbuf, 1, type->u.resized.child, info, op,
-                                             request);
+                    rc = yaksi_ipack_internal(sbuf, dbuf, 1, type->u.resized.child, info, op,
+                                              request);
                     YAKSU_ERR_CHECK(rc, fn_fail);
 
                     sbuf += type->extent;
@@ -189,8 +193,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
 
         case YAKSI_TYPE_KIND__CONTIG:
             {
-                rc = yaksi_ipack_backend(inbuf, outbuf, count * type->u.contig.count,
-                                         type->u.contig.child, info, op, request);
+                rc = yaksi_ipack_internal(inbuf, outbuf, count * type->u.contig.count,
+                                          type->u.contig.child, info, op, request);
                 YAKSU_ERR_CHECK(rc, fn_fail);
             }
             break;
@@ -199,8 +203,8 @@ static inline int pack_backend(const void *inbuf, void *outbuf, uintptr_t count,
             {
                 const char *sbuf =
                     (const char *) inbuf + type->true_lb - type->u.subarray.primary->true_lb;
-                rc = yaksi_ipack_backend(sbuf, outbuf, count, type->u.subarray.primary, info,
-                                         op, request);
+                rc = yaksi_ipack_internal(sbuf, outbuf, count, type->u.subarray.primary, info,
+                                          op, request);
                 YAKSU_ERR_CHECK(rc, fn_fail);
             }
             break;
@@ -233,4 +237,23 @@ int yaksi_ipack_backend(const void *inbuf, void *outbuf, uintptr_t count, yaksi_
     return rc;
   fn_fail:
     goto fn_exit;
+}
+
+/* Essentially the same as yaksi_ipack_backend.
+ * This is to work-around a clang (v10 and v11) compiler bug that confuses the branches
+ * in yaksi_ipack_backend when the initial inbuf is NULL (MPI_BOTTOM).
+ */
+static int yaksi_ipack_internal(const void *inbuf, void *outbuf, uintptr_t count,
+                                yaksi_type_s * type, yaksi_info_s * info, yaksa_op_t op,
+                                yaksi_request_s * request)
+{
+    int rc = YAKSA_SUCCESS;
+
+    /* The compiler bug will trigger the assertion even though inbuf != NULL */
+    /* assert(inbuf); */
+    rc = yaksur_ipack(inbuf, outbuf, count, type, info, op, request);
+    if (rc == YAKSA_ERR__NOT_SUPPORTED) {
+        rc = pack_backend(inbuf, outbuf, count, type, info, op, request);
+    }
+    return rc;
 }


### PR DESCRIPTION
## Pull Request Description
In this recursive call, clang, verified in v10 and v11 with at least -O2, will use an outdated value of inbuf for branch switching but passing the correct inbuf value to actual function calls. Add an internal function to work around this bug. This bug was triggered by commit 2f5443c.

## Background
It currently shows up as failure on osx with many tests that uses a struct datatype with buffer=MPI_BOTTOM. For example:
```
not ok 1558 - ./datatype/struct_pack_mpi_bottom 1
  ---
  Directory: ./datatype
  File: struct_pack_mpi_bottom
  Num-procs: 1
  Timeout: 180
  Date: "Sat Nov 19 01:42:45 2022"
  ...
## Test output (expected 'No Errors'):
## Assertion failed: (!type->is_contig), function pack_backend, file yaksi_ipack_backend.c, line 52.
## 
## ===================================================================================
## =   BAD TERMINATION OF ONE OF YOUR APPLICATION PROCESSES
## =   PID 37314 RUNNING AT pmrs-macos-240-01.cels.anl.gov
## =   EXIT CODE: 6
## =   CLEANING UP REMAINING PROCESSES
## =   YOU CAN IGNORE THE BELOW CLEANUP MESSAGES
## ===================================================================================
## YOUR APPLICATION TERMINATED WITH THE EXIT STRING: Abort trap: 6 (signal 6)
## This typically refers to a problem with your application.
## Please see the FAQ page for debugging suggestions
```


<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
