### PR TITLE
cuda: allow user to set NVCC explicitly

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -87,7 +87,7 @@ if test "$with_cuda" != "no" ; then
         # save language settings, customize ac_ext and ac_compile to support CUDA
         AC_LANG_PUSH([C])
         ac_ext=cu
-        ac_compile='$NVCC -c conftest.$ac_ext >&5'
+        ac_compile="$NVCC -c conftest.$ac_ext >&5"
         AC_MSG_CHECKING([whether nvcc works])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([__global__ void foo(int x) {}],[])],
         [

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -57,28 +57,38 @@ AC_ARG_WITH([cuda-sm],
 
 
 # --with-cuda
+AC_ARG_VAR([NVCC], [nvcc compiler to use])
 PAC_SET_HEADER_LIB_PATH([cuda])
 if test "$with_cuda" != "no" ; then
     PAC_CHECK_HEADER_LIB([cuda_runtime_api.h],[cudart],[cudaStreamSynchronize],[have_cuda=yes],[have_cuda=no])
     if test "${have_cuda}" = "yes" ; then
-        AC_MSG_CHECKING([whether nvcc works])
-        if test -n "$ac_save_CC" ; then
-            NVCC_FLAGS="$NVCC_FLAGS -ccbin $ac_save_CC"
-            # - pgcc/nvc doesn't work, use pgc++/nvc++ instead
-            # - Extra optins such as `gcc -std=gnu99` doesn't work, strip the option
-            NVCC_FLAGS=$(echo $NVCC_FLAGS | sed -e 's/nvc/nvc++/g' -e 's/pgcc/pgc++/g' -e's/ -std=.*//g')
-        fi
-        # try nvcc from PATH if 'with-cuda' does not contain a valid path
-        if test -d ${with_cuda} ; then
-            nvcc_bin=${with_cuda}/bin/nvcc
+        # check if NVCC has been set by the user
+        if test -z "$NVCC" ; then
+            if test -n "$ac_save_CC" ; then
+                NVCC_FLAGS="$NVCC_FLAGS -ccbin $ac_save_CC"
+                # - pgcc/nvc doesn't work, use pgc++/nvc++ instead
+                # - Extra optins such as `gcc -std=gnu99` doesn't work, strip the option
+                NVCC_FLAGS=$(echo $NVCC_FLAGS | sed -e 's/nvc/nvc++/g' -e 's/pgcc/pgc++/g' -e's/ -std=.*//g')
+            fi
+
+            # try nvcc from PATH if 'with-cuda' does not contain a valid path
+            if test -d ${with_cuda} ; then
+                nvcc_bin=${with_cuda}/bin/nvcc
+            else
+                nvcc_bin=nvcc
+            fi
+
+            # append the flags to be passed to nvcc
+            NVCC="$nvcc_bin $NVCC_FLAGS"
         else
-            nvcc_bin=nvcc
+            AC_MSG_WARN([Using user-provided nvcc: '${NVCC}'])
         fi
 
         # save language settings, customize ac_ext and ac_compile to support CUDA
         AC_LANG_PUSH([C])
         ac_ext=cu
-        ac_compile='$nvcc_bin $NVCC_FLAGS -c conftest.$ac_ext >&5'
+        ac_compile='$NVCC -c conftest.$ac_ext >&5'
+        AC_MSG_CHECKING([whether nvcc works])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([__global__ void foo(int x) {}],[])],
         [
             AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
@@ -90,6 +100,7 @@ if test "$with_cuda" != "no" ; then
             have_cuda=no
             AC_MSG_RESULT([no])
         ])
+
         # done with CUDA, back to C
         AC_LANG_POP([C])
 


### PR DESCRIPTION
## Pull Request Description
We cannot use icc as the host compiler since it conflicts with recent CUDA versions. Therefore, we rely on the default GCC as it is binary compatible with icc.

This is done by simply omitting to set the `-ccbin icc`.  The test in `subconfigure.m4` can also be successfully passed by adding a `-std=c++11`.  However, this still prevents yaksa from being build by using icc as the host compiler.


## Expected Impact
CUDA code will be compiled by using GCC as the host compiler if icc is used within the build. 

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
