### PR TITLE
fix libtool scripts for gpu backends

### DIFF
--- a/src/backend/cuda/cudalt.sh
+++ b/src/backend/cuda/cudalt.sh
@@ -41,7 +41,7 @@ CMD="${@} -o $NPIC_FILEPATH"
 if test "$verbose" ; then echo "$CMD" ; fi
 eval "$CMD"
 
-LIBTOOL_VERSION=$(libtool --version | head -n 1)
+LIBTOOL_VERSION=$(./libtool --version | head -n 1)
 
 cat > $LO_FILEPATH <<EOF
 # $LO_FILEPATH - a libtool object file

--- a/src/backend/hip/hiplt.sh
+++ b/src/backend/hip/hiplt.sh
@@ -41,7 +41,7 @@ CMD="${@} -o $NPIC_FILEPATH"
 if test "$verbose" ; then echo "$CMD" ; fi
 eval "$CMD"
 
-LIBTOOL_VERSION=$(libtool --version | head -n 1)
+LIBTOOL_VERSION=$(./libtool --version | head -n 1)
 
 cat > $LO_FILEPATH <<EOF
 # $LO_FILEPATH - a libtool object file


### PR DESCRIPTION
## Pull Request Description

Do not assume libtool is in PATH. This may not be the case, for instance
with preconfigured tarballs. Use the local copy.

## Expected Impact

Fix tarball builds when no `libtool` is available on the system.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
