### PR TITLE
config/cuda: do not reset NVCC

### DIFF
--- a/src/backend/cuda/Makefile.mk
+++ b/src/backend/cuda/Makefile.mk
@@ -17,8 +17,8 @@ endif !BUILD_CUDA_BACKEND
 .cu.lo:
 	@if $(AM_V_P) ; then \
 		$(top_srcdir)/src/backend/cuda/cudalt.sh --verbose $@ \
-			$(NVCC) $(NVCC_FLAGS) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
+			$(NVCC) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
 	else \
 		echo "  NVCC     $@" ; \
-		$(top_srcdir)/src/backend/cuda/cudalt.sh $@ $(NVCC) $(NVCC_FLAGS) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
+		$(top_srcdir)/src/backend/cuda/cudalt.sh $@ $(NVCC) $(AM_CPPFLAGS) $(CUDA_GENCODE) -c $< ; \
 	fi

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -84,6 +84,8 @@ if test "$with_cuda" != "no" ; then
             AC_MSG_WARN([Using user-provided nvcc: '${NVCC}'])
         fi
 
+        AC_SUBST(NVCC)
+
         # save language settings, customize ac_ext and ac_compile to support CUDA
         AC_LANG_PUSH([C])
         ac_ext=cu
@@ -92,9 +94,6 @@ if test "$with_cuda" != "no" ; then
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([__global__ void foo(int x) {}],[])],
         [
             AC_DEFINE([HAVE_CUDA],[1],[Define is CUDA is available])
-            AS_IF([test -d "${with_cuda}"],[NVCC=${with_cuda}/bin/nvcc],[NVCC=nvcc])
-            AC_SUBST(NVCC)
-            AC_SUBST(NVCC_FLAGS)
             AC_MSG_RESULT([yes])
         ],[
             have_cuda=no


### PR DESCRIPTION
## Pull Request Description
An extra check that resets NVCC.

Remove NVCC_FLAGS from makefile since it is already in the NVCC variable.

Also, move AC_SUBST to the outside as it does not depend on the branch.

Ref: https://github.com/pmodels/mpich/issues/6447

<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
