### PR TITLE
Adding auto CUDA compute capability detection

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -49,6 +49,16 @@ AC_ARG_WITH([cuda-sm],
                 ampere - build compatibility for all Ampere GPUs
                 80     - A100, A30
                 86     - RTX Ampere, MX570, A40, A16, A10, A2
+                87     - Jetson AGX Orin and Drive AGX Orin
+
+                # Ada architecture
+                ada    - build compatibility for all Ada GPUs
+                89     - GeForce RTX 4090, RTX 4080, RTX 6000, Tesla L40
+
+                # Hopper architecture
+                hopper - build compatibility for all Hopper GPUs
+                90     - NVIDIA H100 (GH100)
+                90a    - add acceleration for features like wgmma and setmaxnreg. Required for NVIDIA CUTLASS
 
                 # Other
                 <numeric> - specific SM numeric to use
@@ -150,7 +160,7 @@ fi
 ##########################################################################
 
 if test "${have_cuda}" = "yes" ; then
-    for version in 11010 11000 10000 9000 8000 7000 6000 5000 ; do
+    for version in 12000 11080 11010 11000 10000 9000 8000 7000 6000 5000 ; do
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
                               #include <cuda.h>
                               int x[[CUDA_VERSION - $version]];
@@ -163,7 +173,13 @@ if test "${have_cuda}" = "yes" ; then
     for sm in ${with_cuda_sm} ; do
         case "$sm" in
             all)
-                if test ${cuda_version} -ge 11010 ; then
+                if test ${cuda_version} -ge 12000 ; then
+                    # maxwell (52) to hopper (90a)
+                    supported_cuda_sms="52 53 60 61 62 70 72 75 80 86 87 89 90 90a"
+                elif test ${cuda_version} -ge 11080 ; then
+                    # maxwell (52) to ada (89) and hopper (90)
+                    supported_cuda_sms="52 53 60 61 62 70 72 75 80 86 87 89 90"
+                elif test ${cuda_version} -ge 11010 ; then
                     # maxwell (52) to ampere (86)
                     supported_cuda_sms="52 53 60 61 62 70 72 75 80 86"
                 elif test ${cuda_version} -ge 11000 ; then
@@ -221,6 +237,15 @@ if test "${have_cuda}" = "yes" ; then
             ampere)
                 PAC_APPEND_FLAG([80],[CUDA_SM])
                 PAC_APPEND_FLAG([86],[CUDA_SM])
+                ;;
+
+            ada)
+                PAC_APPEND_FLAG([89],[CUDA_SM])
+                ;;
+
+            hopper)
+                PAC_APPEND_FLAG([90],[CUDA_SM])
+                PAC_APPEND_FLAG([90a],[CUDA_SM])
                 ;;
 
             none)

--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -14,7 +14,7 @@ AC_ARG_WITH([cuda-sm],
   --with-cuda-sm=<options> (https://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/)
           Comma-separated list of below options:
                 auto - automatically build compatibility for all GPUs visible, any other specified compatibilities are ignored
-                all - build compatibility for all GPUs supported by the CUDA version (can increase compilation time)
+                all-major - build compatibility for all major GPU versions (sm_*0) supported by the CUDA version
 
                 # Kepler architecture
                 kepler - build compatibility for all Kepler GPUs
@@ -206,7 +206,7 @@ if test "${have_cuda}" = "yes" ; then
                     AC_MSG_RESULT([yes])
                 ],
                 [
-                    with_cuda_sm=all
+                    with_cuda_sm=all-major
                     AC_MSG_RESULT([no])
                 ]
               )
@@ -221,34 +221,31 @@ if test "${have_cuda}" = "yes" ; then
     IFS=","
     for sm in ${with_cuda_sm} ; do
         case "$sm" in
-            all)
-                if test ${cuda_version} -ge 12000 ; then
-                    # maxwell (52) to hopper (90a)
-                    supported_cuda_sms="52 53 60 61 62 70 72 75 80 86 87 89 90 90a"
-                elif test ${cuda_version} -ge 11080 ; then
-                    # maxwell (52) to ada (89) and hopper (90)
-                    supported_cuda_sms="52 53 60 61 62 70 72 75 80 86 87 89 90"
+            all-major)
+                if test ${cuda_version} -ge 11080 ; then
+                    # maxwell (52) to hopper (90)
+                    supported_cuda_sms="52 60 70 80 90"
                 elif test ${cuda_version} -ge 11010 ; then
-                    # maxwell (52) to ampere (86)
-                    supported_cuda_sms="52 53 60 61 62 70 72 75 80 86"
+                    # maxwell (52) to ampere (80)
+                    supported_cuda_sms="52 60 70 80"
                 elif test ${cuda_version} -ge 11000 ; then
                     # maxwell (52) to ampere (80)
-                    supported_cuda_sms="52 53 60 61 62 70 72 75 80"
+                    supported_cuda_sms="52 60 70 80"
                 elif test ${cuda_version} -ge 10000 ; then
-                    # kepler (30) to turing (75)
-                    supported_cuda_sms="30 35 37 50 52 53 60 61 62 70 72 75"
+                    # kepler (30) to volta (70)
+                    supported_cuda_sms="30 50 60 70"
                 elif test ${cuda_version} -ge 9000 ; then
-                    # kepler (30) to volta (72)
-                    supported_cuda_sms="30 35 37 50 52 53 60 61 62 70 72"
+                    # kepler (30) to volta (70)
+                    supported_cuda_sms="30 50 60 70"
                 elif test ${cuda_version} -ge 8000 ; then
-                    # kepler (30) to pascal (62)
-                    supported_cuda_sms="30 35 37 50 52 53 60 61 62"
+                    # kepler (30) to pascal (60)
+                    supported_cuda_sms="30 50 60"
                 elif test ${cuda_version} -ge 6000 ; then
-                    # kepler (30) to maxwell (53)
-                    supported_cuda_sms="30 35 37 50 52 53"
+                    # kepler (30) to maxwell (50)
+                    supported_cuda_sms="30 50"
                 elif test ${cuda_version} -ge 5000 ; then
-                    # kepler (30) to kepler (37)
-                    supported_cuda_sms="30 35 37"
+                    # kepler (30)
+                    supported_cuda_sms="30"
                 fi
 
                 for supported_cuda_sm in $supported_cuda_sms ; do


### PR DESCRIPTION
## Pull Request Description

PR1 simply add options for newer CUDA devices
PR2 add the auto detection. For CUDA 11.5+, we just use the new `-arch=native` option. For older version, we need to run a program to query the device version.

`--with-cuda-sm=auto` is set as the new default. The behavior is also changed to the follow:
1. If `auto` is set, any else options are ignored. e.g. `--with-cuda-sm=70,auto,80 == --with-cuda-sm=auto`.
2. Auto detection will fail only when CUDA version < 11.5 and no GPU present in the building node. If auto detection is failed, ~~we does not revert back to `--with-cuda-sm=all`~~. Probably should revert back to build all and throw out a warning.
3. Other options kept the existing behavior

## Expected Impact

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
