### PR TITLE
backend/cuda: Use NVCC_FLAGS with user-provided NVCC

### DIFF
--- a/src/backend/cuda/subconfigure.m4
+++ b/src/backend/cuda/subconfigure.m4
@@ -92,6 +92,7 @@ if test "$with_cuda" != "no" ; then
             # append the flags to be passed to nvcc
             NVCC="$nvcc_bin $NVCC_FLAGS"
         else
+            NVCC="$NVCC $NVCC_FLAGS"
             AC_MSG_WARN([Using user-provided nvcc: '${NVCC}'])
         fi
 


### PR DESCRIPTION
## Pull Request Description

These flags were ignored when the user specified a compiler other than the nvcc included in the CUDA installation. Make sure to include them for consistency. See pmodels/mpich#6954.

## Expected Impact

Make application of NVCC_FLAGS consistent across configurations.

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
