### PR TITLE
hip: add configure check for hipPointerAttribute_t.memoryType

### DIFF
--- a/src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c
+++ b/src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c
@@ -9,15 +9,21 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 
+#ifdef HIP_USE_MEMORYTYPE
+#define ATTRTYPE memoryType
+#else
+#define ATTRTYPE type
+#endif
+
 static void attr_convert(struct hipPointerAttribute_t cattr, yaksur_ptr_attr_s * attr)
 {
-    if (cattr.memoryType == hipMemoryTypeHost) {
+    if (cattr.ATTRTYPE == hipMemoryTypeHost) {
         attr->type = YAKSUR_PTR_TYPE__REGISTERED_HOST;
         attr->device = -1;
     } else if (cattr.isManaged) {
         attr->type = YAKSUR_PTR_TYPE__MANAGED;
         attr->device = -1;
-    } else if (cattr.memoryType == hipMemoryTypeDevice) {
+    } else if (cattr.ATTRTYPE == hipMemoryTypeDevice) {
         attr->type = YAKSUR_PTR_TYPE__GPU;
         attr->device = cattr.device;
     } else {
@@ -44,9 +50,9 @@ int yaksuri_hipi_get_ptr_attr(const void *inbuf, void *outbuf, yaksi_info_s * in
         struct hipPointerAttribute_t attr;
         hipError_t cerr = hipPointerGetAttributes(&attr, inbuf);
         if (cerr == hipErrorInvalidValue) {
-            /* attr.memoryType = hipMemoryTypeUnregistered;  */
+            /* attr.ATTRTYPE = hipMemoryTypeUnregistered;  */
             /* HIP does not seem to have something corresponding to cudaMemoryTypeUnregistered */
-            attr.memoryType = -1;
+            attr.ATTRTYPE = -1;
             attr.device = -1;
             cerr = hipSuccess;
         }
@@ -60,9 +66,9 @@ int yaksuri_hipi_get_ptr_attr(const void *inbuf, void *outbuf, yaksi_info_s * in
         struct hipPointerAttribute_t attr;
         hipError_t cerr = hipPointerGetAttributes(&attr, outbuf);
         if (cerr == hipErrorInvalidValue) {
-            /* attr.memoryType = hipMemoryTypeUnregistered; */
+            /* attr.ATTRTYPE = hipMemoryTypeUnregistered; */
             /* HIP does not seem to have something corresponding to cudaMemoryTypeUnregistered */
-            attr.memoryType = -1;
+            attr.ATTRTYPE = -1;
             attr.device = -1;
             cerr = hipSuccess;
         }

--- a/src/backend/hip/subconfigure.m4
+++ b/src/backend/hip/subconfigure.m4
@@ -25,6 +25,10 @@ if test "$with_hip" != "no" ; then
     PAC_PUSH_FLAG(CPPFLAGS)
     PAC_APPEND_FLAG([-D__HIP_PLATFORM_AMD__], [CPPFLAGS])
     PAC_CHECK_HEADER_LIB([hip/hip_runtime_api.h],[amdhip64],[hipStreamSynchronize],[have_hip=yes],[have_hip=no])
+    AC_CHECK_MEMBER([struct hipPointerAttribute_t.memoryType],
+                    [AC_DEFINE(HIP_USE_MEMORYTYPE, 1, [Define if struct hipPointerAttribute_t use memoryType (pre-v6.0)])],
+                    [],
+                    [[#include <hip/hip_runtime_api.h>]])
     PAC_POP_FLAG(CPPFLAGS)
     if test "${have_hip}" = "yes" ; then
         AC_MSG_CHECKING([whether hipcc works])

--- a/test/pack/pack-hip.c
+++ b/test/pack/pack-hip.c
@@ -84,22 +84,16 @@ void pack_hip_get_ptr_attr(const void *inbuf, void *outbuf, yaksa_info_t * info,
         struct hipPointerAttribute_t attr;
 
         hipError_t cerr = hipPointerGetAttributes(&attr, inbuf);
-        // this special handling required because HIP does not yet support hipMemoryTypeUnregistered
-        if (cerr == hipErrorInvalidValue) {
-            attr.memoryType = -1;
-            attr.device = -1;
+        if (cerr == hipSuccess) {
+            rc = yaksa_info_keyval_append(*info, "yaksa_hip_inbuf_ptr_attr", &attr, sizeof(attr));
+            assert(rc == YAKSA_SUCCESS);
         }
-        rc = yaksa_info_keyval_append(*info, "yaksa_hip_inbuf_ptr_attr", &attr, sizeof(attr));
-        assert(rc == YAKSA_SUCCESS);
 
         cerr = hipPointerGetAttributes(&attr, outbuf);
-        // this special handling required because HIP does not yet support hipMemoryTypeUnregistered
-        if (cerr == hipErrorInvalidValue) {
-            attr.memoryType = -1;
-            attr.device = -1;
+        if (cerr == hipSuccess) {
+            rc = yaksa_info_keyval_append(*info, "yaksa_hip_outbuf_ptr_attr", &attr, sizeof(attr));
+            assert(rc == YAKSA_SUCCESS);
         }
-        rc = yaksa_info_keyval_append(*info, "yaksa_hip_outbuf_ptr_attr", &attr, sizeof(attr));
-        assert(rc == YAKSA_SUCCESS);
     } else
         *info = NULL;
 }


### PR DESCRIPTION
## Pull Request Description
ROCM 6.0.0 changed the field name from `memoryType` to `type`. Thus we need configure check and adapt the code.


<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
