### PR TITLE
backend/hip: Fix compilation for ROCm < 6

### DIFF
--- a/src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c
+++ b/src/backend/hip/pup/yaksuri_hipi_get_ptr_attr.c
@@ -17,8 +17,8 @@ static hipError_t attr_convert(hipError_t cerr, struct hipPointerAttribute_t cat
     if (cerr == hipErrorInvalidValue) {
         /* attr.ATTRTYPE = hipMemoryTypeUnregistered;  */
         /* HIP does not seem to have something corresponding to cudaMemoryTypeUnregistered */
-        attr.ATTRTYPE = YAKSUR_PTR_TYPE__UNREGISTERED_HOST;
-        attr.device = -1;
+        attr->type = YAKSUR_PTR_TYPE__UNREGISTERED_HOST;
+        attr->device = -1;
         return hipSuccess;
     }
 


### PR DESCRIPTION
## Pull Request Description

[6a1c2611a] broke compilation for older ROCm versions. I forgot to test with an older ROCm module before merge.

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
