### PR TITLE
config: update deprecated autoconf macros

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,9 @@ dnl ----------------------------------------------------------------------------
 # strict
 PAC_ARG_STRICT
 
+# Add options that suppress default warnings, especially those from PGI compilers (now nvc)
+PAC_C_DEFAULT_OPTIONS
+
 # embedded builds
 AC_ARG_ENABLE([embedded],AS_HELP_STRING([--enable-embedded],[enables embedded builds]),,[enable_embedded=no])
 AM_CONDITIONAL([EMBEDDED_BUILD], [test x${enable_embedded} = xyes])

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,6 @@ dnl ----------------------------------------------------------------------------
 dnl disable AC_PROG_CC's annoying default of adding -O2 to the CFLAGS
 PAC_PUSH_FLAG([CFLAGS])
 AC_PROG_CC
-AC_PROG_CC_C99
 PAC_POP_FLAG([CFLAGS])
 
 # see if C11 is available (for atomics)
@@ -114,8 +113,6 @@ fi
 
 PAC_CHECK_VISIBILITY
 PAC_APPEND_FLAG([$YAKSA_VISIBILITY_CFLAGS],[CFLAGS])
-
-AC_HEADER_STDC
 
 # required pre-Automake-1.14
 AM_PROG_CC_C_O

--- a/m4/aclocal_cc.m4
+++ b/m4/aclocal_cc.m4
@@ -167,7 +167,7 @@ AC_DEFUN([PAC_C_OPTIMIZATION],[
 	    break
         fi
     done
-    if test "$ac_cv_prog_gcc" = "yes" ; then
+    if test "$GCC" = "yes" ; then
 	for copt in "-fomit-frame-pointer" "-finline-functions" \
 		 "-funroll-loops" ; do
 	    PAC_C_CHECK_COMPILER_OPTION($copt,found_opt=yes,found_opt=no)
@@ -350,13 +350,13 @@ if test "$pac_cv_prog_c_weak_symbols" != "no" ; then
 fi
 AC_CACHE_CHECK([whether __attribute__ ((weak)) allowed],
 pac_cv_attr_weak,[
-AC_TRY_COMPILE([int foo(int) __attribute__ ((weak));],[int a;],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int foo(int) __attribute__ ((weak));],[int a;])],
 pac_cv_attr_weak=yes,pac_cv_attr_weak=no)])
 # Note that being able to compile with weak_import doesn't mean that
 # it works.
 AC_CACHE_CHECK([whether __attribute__ ((weak_import)) allowed],
 pac_cv_attr_weak_import,[
-AC_TRY_COMPILE([int foo(int) __attribute__ ((weak_import));],[int a;],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int foo(int) __attribute__ ((weak_import));],[int a;])],
 pac_cv_attr_weak_import=yes,pac_cv_attr_weak_import=no)])
 # Check if the alias option for weak attributes is allowed
 AC_CACHE_CHECK([whether __attribute__((weak,alias(...))) allowed],
@@ -364,7 +364,7 @@ pac_cv_attr_weak_alias,[
 PAC_PUSH_FLAG([CFLAGS])
 # force an error exit if the weak attribute isn't understood
 CFLAGS=-Werror
-AC_TRY_COMPILE([int foo(int) __attribute__((weak,alias("__foo")));],[int a;],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int foo(int) __attribute__((weak,alias("__foo")));],[int a;])],
 pac_cv_attr_weak_alias=yes,pac_cv_attr_weak_alias=no)
 # Restore original CFLAGS
 PAC_POP_FLAG([CFLAGS])])
@@ -392,7 +392,7 @@ AC_DEFUN([PAC_PROG_CC_WORKS],
 AC_MSG_CHECKING([whether the C compiler sets its return status correctly])
 AC_LANG_SAVE
 AC_LANG_C
-AC_TRY_COMPILE(,[int a = bzzzt;],notbroken=no,notbroken=yes)
+AC_COMPILE_IFELSE([AC_LANG_SOURCE(,[int a = bzzzt;])],notbroken=no,notbroken=yes)
 AC_MSG_RESULT($notbroken)
 if test "$notbroken" = "no" ; then
     AC_MSG_ERROR([installation or configuration problem: C compiler does not
@@ -666,7 +666,7 @@ dnl
 dnl D*/
 AC_DEFUN([PAC_ARG_STRICT],[
 AC_ARG_ENABLE(strict,
-	AC_HELP_STRING([--enable-strict], [Turn on strict compilation testing]))
+	AS_HELP_STRING([--enable-strict], [Turn on strict compilation testing]))
 PAC_CC_STRICT($enable_strict)
 CFLAGS="$CFLAGS $pac_cc_strict_flags"
 export CFLAGS
@@ -1244,8 +1244,8 @@ dnl D*/
 AC_DEFUN([PAC_FUNC_NEEDS_DECL],[
 AC_CACHE_CHECK([whether $2 needs a declaration],
 pac_cv_func_decl_$2,[
-AC_TRY_COMPILE([$1
-void (*fptr)(void) = (void(*)(void))$2;],[],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([$1
+void (*fptr)(void) = (void(*)(void))$2;],[])],
 pac_cv_func_decl_$2=no,pac_cv_func_decl_$2=yes)])
 if test "$pac_cv_func_decl_$2" = "yes" ; then
 changequote(<<,>>)dnl
@@ -1271,14 +1271,14 @@ dnl __attribute__((pure)) but generates warnings for __attribute__((format...))
 dnl
 AC_DEFUN([PAC_C_GNU_ATTRIBUTE],[
 AC_REQUIRE([AC_PROG_CC_GNU])
-if test "$ac_cv_prog_gcc" = "yes" ; then
+if test "$GCC" = "yes" ; then
     AC_CACHE_CHECK([whether __attribute__ allowed],
 pac_cv_gnu_attr_pure,[
-AC_TRY_COMPILE([int foo(int) __attribute__ ((pure));],[int a;],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int foo(int) __attribute__ ((pure));],[int a;])],
 pac_cv_gnu_attr_pure=yes,pac_cv_gnu_attr_pure=no)])
 AC_CACHE_CHECK([whether __attribute__((format)) allowed],
 pac_cv_gnu_attr_format,[
-AC_TRY_COMPILE([int foo(char *,...) __attribute__ ((format(printf,1,2)));],[int a;],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int foo(char *,...) __attribute__ ((format(printf,1,2)));],[int a;])],
 pac_cv_gnu_attr_format=yes,pac_cv_gnu_attr_format=no)])
     if test "$pac_cv_gnu_attr_pure" = "yes" -a "$pac_cv_gnu_attr_format" = "yes" ; then
         AC_DEFINE(HAVE_GCC_ATTRIBUTE,1,[Define if GNU __attribute__ is supported])
@@ -1497,7 +1497,7 @@ AC_DEFUN([PAC_STRUCT_ALIGNMENT],[
 	is_largest=1
 
 	# See if long double exists
-	AC_TRY_COMPILE(,[long double a;],have_long_double=yes,have_long_double=no)
+	AC_COMPILE_IFELSE([AC_LANG_SOURCE(,[long double a;])],have_long_double=yes,have_long_double=no)
 
 	# Get sizes of regular types
 	AC_CHECK_SIZEOF(char)

--- a/m4/aclocal_cc.m4
+++ b/m4/aclocal_cc.m4
@@ -672,6 +672,25 @@ CFLAGS="$CFLAGS $pac_cc_strict_flags"
 export CFLAGS
 ])
 
+AC_DEFUN([PAC_C_DEFAULT_OPTIONS],[
+    pac_cc_defaut_flags="
+        --diag_suppress=incompatible_param
+    "
+    # See if the above options work with the compiler
+    accepted_flags=""
+    for flag in $pac_cc_defaut_flags ; do
+        PAC_PUSH_FLAG([CFLAGS])
+        CFLAGS="$CFLAGS $accepted_flags"
+        PAC_C_CHECK_COMPILER_OPTION([$flag],[accepted_flags="$accepted_flags $flag"],)
+        PAC_POP_FLAG([CFLAGS])
+    done
+    if test -n "$accepted_flags" ; then
+        CFLAGS="$CFLAGS $accepted_flags"
+        export CFLAGS
+    fi
+])
+
+
 dnl Return the integer structure alignment in pac_cv_c_max_integer_align
 dnl Possible values include
 dnl	packed

--- a/m4/aclocal_check_visibility.m4
+++ b/m4/aclocal_check_visibility.m4
@@ -68,7 +68,7 @@ AC_DEFUN([PAC_CHECK_VISIBILITY],[
     # Check if the compiler has support for visibility, like some
     # versions of gcc, icc, Sun Studio cc.
     AC_ARG_ENABLE(visibility,
-        AC_HELP_STRING([--enable-visibility],
+        AS_HELP_STRING([--enable-visibility],
             [enable visibility feature of certain compilers/linkers (default: enabled on platforms that support it)]))
 
     case ${target} in

--- a/m4/aclocal_coverage.m4
+++ b/m4/aclocal_coverage.m4
@@ -17,12 +17,12 @@ AC_ARG_VAR([GCOV],[name/path for the gcov utility])
 AC_CHECK_PROGS([GCOV],[gcov])
 
 AC_ARG_ENABLE([coverage],
-              [AC_HELP_STRING([--enable-coverage],
+              [AS_HELP_STRING([--enable-coverage],
                               [Turn on coverage analysis using gcc and gcov])],
               [],[enable_coverage=no])
 
 if test "$enable_coverage" = "yes" ; then
-    if test "$ac_cv_prog_gcc" = "yes" ; then
+    if test "$GCC" = "yes" ; then
         CFLAGS="$CFLAGS -fprofile-arcs -ftest-coverage"
         LIBS="$LIBS -lgcov"
     else

--- a/m4/aclocal_libs.m4
+++ b/m4/aclocal_libs.m4
@@ -8,11 +8,11 @@ dnl characters in it.  Use AS_TR_SH (and possibly AS_VAR_* macros) to handle
 dnl this case if it ever arises.
 AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
     AC_ARG_WITH([$1],
-                [AC_HELP_STRING([--with-$1=PATH],
+                [AS_HELP_STRING([--with-$1=PATH],
                                 [specify path where $1 include directory and lib directory can be found])]
                 )
     AC_ARG_WITH([$1-include],
-                [AC_HELP_STRING([--with-$1-include=PATH],
+                [AS_HELP_STRING([--with-$1-include=PATH],
                                 [specify path where $1 include directory can be found])],
                 [AS_CASE(["$withval"],
                          [yes|no|''],
@@ -20,7 +20,7 @@ AC_DEFUN([PAC_SET_HEADER_LIB_PATH],[
                           with_$1_include=""])],
                 [])
     AC_ARG_WITH([$1-lib],
-                [AC_HELP_STRING([--with-$1-lib=PATH],
+                [AS_HELP_STRING([--with-$1-lib=PATH],
                                 [specify path where $1 lib directory can be found])],
                 [AS_CASE(["$withval"],
                          [yes|no|''],

--- a/src/backend/ze/subconfigure.m4
+++ b/src/backend/ze/subconfigure.m4
@@ -28,16 +28,16 @@ if test "$with_ze" != "no" ; then
         PAC_PUSH_FLAG([CFLAGS])
         CFLAGS="$CFLAGS -Werror"
         AC_CACHE_CHECK([for -Werror],ac_cv_werror,[
-        AC_TRY_COMPILE([],[],ac_cv_werror=yes,ac_cv_werror=no)])
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([],[])],ac_cv_werror=yes,ac_cv_werror=no)])
         if test "${ac_cv_werror}" = "yes" ; then
             AC_CACHE_CHECK([for c11 support],ac_cv_support_c11,[
-            AC_TRY_COMPILE([
+            AC_COMPILE_IFELSE([AC_LANG_SOURCE([
     typedef struct _ze_ipc_mem_handle_t
     {
         int data;
     } ze_ipc_mem_handle_t;
     typedef struct _ze_ipc_mem_handle_t ze_ipc_mem_handle_t;
-            ],[],ac_cv_support_c11=yes,ac_cv_support_c11=no)])
+            ],[])],ac_cv_support_c11=yes,ac_cv_support_c11=no)])
             if test "${ac_cv_support_c11}" = "no" ; then
                 have_ze=no
             fi


### PR DESCRIPTION
## Pull Request Description
To suppress warnings from autoconf 2.70 and later.

Fix/suppress warnings from pgcc/nvc.



<!--
By submitting a PR, you are confirming that you have read and agree to
the terms in the Yaksa contributor license agreement
(https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement).
-->

<!--
Insert description of the work in this merge request (above this comment),
particularly focused on _why_ the work is necessary, not _what_ you did.
-->

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
