### PR TITLE
Fix incompatibilities with CUDA 13 runtime API

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -178,12 +178,11 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
          * incorrect device sharing */
         bool excl = false;
         for (int i = 0; i < yaksuri_cudai_global.ndevices; i++) {
-            struct cudaDeviceProp prop;
-
-            cerr = cudaGetDeviceProperties(&prop, i);
+            int mode;
+            cerr = cudaDeviceGetAttribute(&mode, cudaDevAttrComputeMode, i);
             YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
-            if (prop.computeMode != cudaComputeModeDefault) {
+            if (mode != cudaComputeModeDefault) {
                 excl = true;
                 break;
             }


### PR DESCRIPTION
Addresses changes in the CUDA 13 runtime API. In particular, I was getting the following error when compiling MPICH 4.3.1:
`error: ‘struct cudaDeviceProp’ has no member named ‘computeMode’`

Cheers,
-Nuno
