### PR TITLE
fix for GPU builds when GPUs available on system at runtime

### DIFF
--- a/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
+++ b/src/backend/cuda/hooks/yaksuri_cuda_init_hooks.c
@@ -170,6 +170,10 @@ int yaksuri_cuda_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     cudaError_t cerr;
 
     cerr = cudaGetDeviceCount(&yaksuri_cudai_global.ndevices);
+    if (cerr == cudaErrorNoDevice || cerr == cudaErrorInsufficientDriver) {
+        /* both codes can indicate no devices available on the system */
+        goto fn_exit;
+    }
     YAKSURI_CUDAI_CUDA_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (getenv("CUDA_VISIBLE_DEVICES") == NULL) {

--- a/src/backend/hip/hooks/yaksuri_hip_init_hooks.c
+++ b/src/backend/hip/hooks/yaksuri_hip_init_hooks.c
@@ -108,6 +108,9 @@ int yaksuri_hip_init_hook(yaksur_gpudriver_hooks_s ** hooks)
     hipError_t cerr;
 
     cerr = hipGetDeviceCount(&yaksuri_hipi_global.ndevices);
+    if (cerr == hipErrorNoDevice) {
+        goto fn_exit;
+    }
     YAKSURI_HIPI_HIP_ERR_CHKANDJUMP(cerr, rc, fn_fail);
 
     if (getenv("HIP_VISIBLE_DEVICES") == NULL) {


### PR DESCRIPTION
## Pull Request Description

If a GPU-aware build detects no GPUs then just continue. Do not crash.

## Expected Impact

Allow GPU builds to run on systems without GPUs.

## Author Checklist
* [ ] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [ ] Commits are self-contained and do not do two things at once
* [ ] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [ ] Add comments such that someone without knowledge of the code could understand
* [ ] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
