### PR TITLE
backend: Fix code generation and build reproducibility

### DIFF
--- a/src/backend/gencomm.py
+++ b/src/backend/gencomm.py
@@ -11,20 +11,20 @@ import yutils
 ## loop through the derived and basic types to generate individual
 ## pack functions
 derived_types = [ "hvector", "blkhindx", "hindexed", "contig", "resized" ]
-type_ops = {'_Bool': {'REPLACE', 'LAND', 'LOR', 'LXOR'},
-            'bool': {'REPLACE', 'LAND', 'LOR', 'LXOR'},
-            'char': {'REPLACE'},
-            'wchar_t': {'REPLACE'},
-            'int8_t': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'},
-            'int16_t': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'},
-            'int32_t': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'},
-            'int64_t': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'},
-            'float': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX'},
-            'double': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX'},
-            'c_complex': {'REPLACE', 'SUM', 'PROD'},
-            'c_double_complex': {'REPLACE', 'SUM', 'PROD'},
-            'c_long_double_complex': {'REPLACE', 'SUM', 'PROD'},
-            'long double': {'REPLACE', 'SUM', 'PROD', 'MIN', 'MAX'}}
+type_ops = {'_Bool': ['REPLACE', 'LAND', 'LOR', 'LXOR'],
+            'bool': ['REPLACE', 'LAND', 'LOR', 'LXOR'],
+            'char': ['REPLACE'],
+            'wchar_t': ['REPLACE'],
+            'int8_t': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'],
+            'int16_t': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'],
+            'int32_t': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'],
+            'int64_t': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX', 'LAND', 'LOR', 'LXOR', 'BAND', 'BOR', 'BXOR'],
+            'float': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX'],
+            'double': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX'],
+            'c_complex': ['REPLACE', 'SUM', 'PROD'],
+            'c_double_complex': ['REPLACE', 'SUM', 'PROD'],
+            'c_long_double_complex': ['REPLACE', 'SUM', 'PROD'],
+            'long double': ['REPLACE', 'SUM', 'PROD', 'MIN', 'MAX']}
 ########################################################################################
 ##### Switch statement generation for pup function selection
 ########################################################################################


### PR DESCRIPTION
Replace Python sets with lists. Sets iteration order is affected by Python's hash randomization. Therefore, code generation depending on iterating over the entries of a set is not reproducible.

## Pull Request Description

Backport pmodels/mpich#7579

<!-- AUTHOR: After creating this merge request, check off each of the following items as you complete them. -->

## Expected Impact

## Author Checklist
* [x] Reference appropriate issues (with "Fixes" or "See" as appropriate)
* [x] Commits are self-contained and do not do two things at once
* [x] Commit message is of the form: `module: short description` and follows [good practice](https://chris.beams.io/posts/git-commit/)
* [x] Add comments such that someone without knowledge of the code could understand
* [x] Have read and agree to the Yaksa CLA terms (https://github.com/pmodels/yaksa/wiki/Yaksa-Contributor-License-Agreement)
